### PR TITLE
Issues/348 adding products to event fails

### DIFF
--- a/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
@@ -111,9 +111,12 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 				var existingRegistration = await _registrationService.GetAsync(user.Id, Registration.EventInfoId);
 				if (existingRegistration != null)
 				{
-					// The user has already registered for the event.
-					await _registrationEmailSender.SendRegistrationAsync(user.Email, "Du var allerede påmeldt!", "<p>Vi hadde allerede en registrering for deg.</p>", existingRegistration.RegistrationId);
-					return RedirectToPage("/Info/EmailSent");
+                    // The user has already registered for the event.
+                    await _registrationEmailSender.SendRegistrationAsync(user.Email,
+                        this._stringLocalizer["You were already signed up!"],
+                        this._stringLocalizer["<p>We already had a registration for you.</p>"],
+                        existingRegistration.RegistrationId);
+                    return RedirectToPage("/Info/EmailSent");
 				}
 			}
 			else

--- a/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
+++ b/src/EventManagement.Web/Pages/Events/Register/Index.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -17,6 +17,7 @@ using losol.EventManagement.Services.Extensions;
 using System.Text;
 using static losol.EventManagement.Domain.PaymentMethod;
 using System.Text.RegularExpressions;
+using Microsoft.Extensions.Localization;
 
 namespace losol.EventManagement.Web.Pages.Events.Register
 {
@@ -28,22 +29,24 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 		private readonly IPaymentMethodService _paymentMethodService;
 		private readonly IRegistrationService _registrationService;
 		private readonly RegistrationEmailSender _registrationEmailSender;
+        private readonly IStringLocalizer<EventRegistrationModel> _stringLocalizer;
 
-		public EventRegistrationModel(
+        public EventRegistrationModel(
 			UserManager<ApplicationUser> userManager,
 			RegistrationEmailSender registrationEmailSender,
 			ILogger<EventRegistrationModel> logger,
 			IEventInfoService eventsService,
 			IPaymentMethodService paymentMethodService,
-			IRegistrationService registrationService
-		)
+			IRegistrationService registrationService,
+            IStringLocalizer<EventRegistrationModel> stringLocalizer)
 		{
 			_userManager = userManager;
 			_logger = logger;
 			_eventsService = eventsService;
 			_paymentMethodService = paymentMethodService;
 			_registrationService = registrationService;
-			_registrationEmailSender = registrationEmailSender;
+            _stringLocalizer = stringLocalizer;
+            _registrationEmailSender = registrationEmailSender;
 		}
 
 		[BindProperty]
@@ -143,10 +146,13 @@ namespace losol.EventManagement.Web.Pages.Events.Register
 			var newRegistration = Registration.Adapt<Registration>();
 			newRegistration.VerificationCode = PasswordHelper.GeneratePassword(6);
 			await _registrationService.CreateRegistration(newRegistration, Registration.SelectedProducts);
-            await _registrationEmailSender.SendRegistrationAsync(user.Email, "Velkommen på kurs!", "<p>Vi fikk registreringen din</p>", newRegistration.RegistrationId);
+            await _registrationEmailSender.SendRegistrationAsync(user.Email,
+                this._stringLocalizer["Welcome to the course!"],
+                this._stringLocalizer["<p>We received your registration</p>"],
+                newRegistration.RegistrationId);
 
 
-			return RedirectToPage("/Info/EmailSent");
+            return RedirectToPage("/Info/EmailSent");
 		}
 	}
 }

--- a/src/EventManagement.Web/Resources/Pages.Events.Register.EventRegistrationModel.nb-NO.resx
+++ b/src/EventManagement.Web/Resources/Pages.Events.Register.EventRegistrationModel.nb-NO.resx
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="&lt;p&gt;We received your registration&lt;/p&gt;" xml:space="preserve">
+    <value>&lt;p&gt;Vi fikk registreringen din&lt;/p&gt;</value>
+  </data>
+  <data name="Welcome to the course!" xml:space="preserve">
+    <value>Velkommen på kurs!</value>
+  </data>
+</root>

--- a/src/EventManagement.Web/Resources/Pages.Events.Register.EventRegistrationModel.nb-NO.resx
+++ b/src/EventManagement.Web/Resources/Pages.Events.Register.EventRegistrationModel.nb-NO.resx
@@ -117,10 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="&lt;p&gt;We already had a registration for you.&lt;/p&gt;" xml:space="preserve">
+    <value>&lt;p&gt;Vi hadde allerede en registrering for deg.&lt;/p&gt;</value>
+  </data>
   <data name="&lt;p&gt;We received your registration&lt;/p&gt;" xml:space="preserve">
     <value>&lt;p&gt;Vi fikk registreringen din&lt;/p&gt;</value>
   </data>
   <data name="Welcome to the course!" xml:space="preserve">
     <value>Velkommen på kurs!</value>
+  </data>
+  <data name="You were already signed up!" xml:space="preserve">
+    <value>Du var allerede påmeldt!</value>
   </data>
 </root>

--- a/tests/EventManagement.IntegrationTests/Controllers/Api/MessagingControllerTest.cs
+++ b/tests/EventManagement.IntegrationTests/Controllers/Api/MessagingControllerTest.cs
@@ -1,3 +1,4 @@
+using System;
 using losol.EventManagement.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -10,13 +11,18 @@ using Xunit;
 
 namespace losol.EventManagement.IntegrationTests.Controllers.Api
 {
-    public class MessagingControllerTest : IClassFixture<CustomWebApplicationFactory<Startup>>
+    public class MessagingControllerTest : IClassFixture<CustomWebApplicationFactory<Startup>>, IDisposable
     {
         private readonly CustomWebApplicationFactory<Startup> factory;
 
         public MessagingControllerTest(CustomWebApplicationFactory<Startup> factory)
         {
             this.factory = factory;
+        }
+
+        public void Dispose()
+        {
+            this.factory.EmailSenderMock.Reset();
         }
 
         [Theory]

--- a/tests/EventManagement.IntegrationTests/Controllers/Api/ParticipantsControllerTest.cs
+++ b/tests/EventManagement.IntegrationTests/Controllers/Api/ParticipantsControllerTest.cs
@@ -1,25 +1,28 @@
+using losol.EventManagement.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using losol.EventManagement.Infrastructure;
-using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.Extensions.DependencyInjection;
-using Moq;
-using Newtonsoft.Json;
 using Xunit;
 
 namespace losol.EventManagement.IntegrationTests.Controllers.Api
 {
-    public class ParticipantsControllerTest : IClassFixture<CustomWebApplicationFactory<Startup>>
+    public class ParticipantsControllerTest : IClassFixture<CustomWebApplicationFactory<Startup>>, IDisposable
     {
         private readonly CustomWebApplicationFactory<Startup> factory;
 
         public ParticipantsControllerTest(CustomWebApplicationFactory<Startup> factory)
         {
             this.factory = factory;
+        }
+
+        public void Dispose()
+        {
+            this.factory.EmailSenderMock.Reset();
         }
 
         [Theory]

--- a/tests/EventManagement.IntegrationTests/EmailExpectation.cs
+++ b/tests/EventManagement.IntegrationTests/EmailExpectation.cs
@@ -1,0 +1,110 @@
+using System.Collections.Generic;
+using Losol.Communication.Email;
+using Moq;
+using Xunit;
+
+namespace losol.EventManagement.IntegrationTests
+{
+    public class EmailExpectation
+    {
+        private const string Placeholder = "___Placeholder___";
+
+        private readonly Mock<IEmailSender> mock;
+
+        private string email = Placeholder;
+        private string subject = Placeholder;
+        private string message = Placeholder;
+        private readonly List<string> textContained = new List<string>();
+        private bool shouldNotHaveAttachment;
+        private bool shouldHaveAttachment;
+        private EmailMessageType type = EmailMessageType.Html;
+
+        public EmailExpectation(Mock<IEmailSender> mock)
+        {
+            this.mock = mock;
+        }
+
+        public EmailExpectation SentTo(string email)
+        {
+            this.email = email;
+            return this;
+        }
+
+        public EmailExpectation WithSubject(string subject)
+        {
+            this.subject = subject;
+            return this;
+        }
+
+        public EmailExpectation WithMessage(string message)
+        {
+            this.message = message;
+            return this;
+        }
+
+        public EmailExpectation WithType(EmailMessageType type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        public EmailExpectation HavingAttachment(bool hasAttachment = true)
+        {
+            this.shouldHaveAttachment = hasAttachment;
+            this.shouldNotHaveAttachment = !hasAttachment;
+            return this;
+        }
+
+        public EmailExpectation ContainingText(string text)
+        {
+            this.textContained.Add(text);
+            return this;
+        }
+
+        public EmailExpectation Setup()
+        {
+            this.mock.Setup(s => s.SendEmailAsync(
+                    this.EmailToCheck,
+                    this.SubjectToCheck,
+                    this.MessageToCheck,
+                    this.AttachmentToCheck,
+                    this.type))
+                .Callback((string email, string subject, string html, Attachment attachment, EmailMessageType emailType) =>
+                {
+                    foreach (var text in this.textContained)
+                    {
+                        Assert.Contains(text, html);
+                    }
+                });
+
+            return this;
+        }
+        public void VerifyEmailSent(Times? times = null)
+        {
+            if (times == null)
+            {
+                times = Times.Once();
+            }
+
+            this.mock.Verify(s => s.SendEmailAsync(
+                this.EmailToCheck,
+                this.SubjectToCheck,
+                this.MessageToCheck,
+                this.AttachmentToCheck,
+                this.type), times.Value);
+        }
+
+        private Attachment AttachmentToCheck =>
+            this.shouldHaveAttachment
+                ? It.IsNotNull<Attachment>()
+                : this.shouldNotHaveAttachment
+                    ? null
+                    : It.IsAny<Attachment>();
+
+        private string MessageToCheck => this.message != Placeholder ? this.message : It.IsAny<string>();
+
+        private string SubjectToCheck => this.subject != Placeholder ? this.subject : It.IsAny<string>();
+
+        private string EmailToCheck => this.email != Placeholder ? this.email : It.IsAny<string>();
+    }
+}

--- a/tests/EventManagement.IntegrationTests/EmailExpectation.cs
+++ b/tests/EventManagement.IntegrationTests/EmailExpectation.cs
@@ -14,6 +14,7 @@ namespace losol.EventManagement.IntegrationTests
         private string email = Placeholder;
         private string subject = Placeholder;
         private string message = Placeholder;
+        private readonly List<string> subjectContains = new List<string>();
         private readonly List<string> textContained = new List<string>();
         private bool shouldNotHaveAttachment;
         private bool shouldHaveAttachment;
@@ -55,6 +56,12 @@ namespace losol.EventManagement.IntegrationTests
             return this;
         }
 
+        public EmailExpectation SubjectContains(string text)
+        {
+            this.subjectContains.Add(text);
+            return this;
+        }
+
         public EmailExpectation ContainingText(string text)
         {
             this.textContained.Add(text);
@@ -69,11 +76,16 @@ namespace losol.EventManagement.IntegrationTests
                     this.MessageToCheck,
                     this.AttachmentToCheck,
                     this.type))
-                .Callback((string email, string subject, string html, Attachment attachment, EmailMessageType emailType) =>
+                .Callback((string email, string subject, string body, Attachment attachment, EmailMessageType emailType) =>
                 {
+                    foreach (var text in this.subjectContains)
+                    {
+                        Assert.Contains(text, subject);
+                    }
+
                     foreach (var text in this.textContained)
                     {
-                        Assert.Contains(text, html);
+                        Assert.Contains(text, body);
                     }
                 });
 

--- a/tests/EventManagement.IntegrationTests/JTokenExtensions.cs
+++ b/tests/EventManagement.IntegrationTests/JTokenExtensions.cs
@@ -4,7 +4,7 @@ using losol.EventManagement.Domain;
 using Newtonsoft.Json.Linq;
 using Xunit;
 
-namespace losol.EventManagement.IntegrationTests.Pages.Admin.Events
+namespace losol.EventManagement.IntegrationTests
 {
     public static class JTokenExtensions
     {

--- a/tests/EventManagement.IntegrationTests/MockExtensions.cs
+++ b/tests/EventManagement.IntegrationTests/MockExtensions.cs
@@ -1,118 +1,13 @@
 using Losol.Communication.Email;
 using Moq;
-using System.Collections.Generic;
-using Xunit;
 
 namespace losol.EventManagement.IntegrationTests
 {
     public static class MockExtensions
     {
-        public static EmailMockSetup ExpectEmail(this Mock<IEmailSender> sender)
+        public static EmailExpectation ExpectEmail(this Mock<IEmailSender> sender)
         {
-            return new EmailMockSetup(sender);
+            return new EmailExpectation(sender);
         }
-    }
-
-    public class EmailMockSetup
-    {
-        private const string Placeholder = "___Placeholder___";
-
-        private readonly Mock<IEmailSender> mock;
-
-        private string email = Placeholder;
-        private string subject = Placeholder;
-        private string message = Placeholder;
-        private readonly List<string> textContained = new List<string>();
-        private bool shouldNotHaveAttachment;
-        private bool shouldHaveAttachment;
-        private EmailMessageType type = EmailMessageType.Html;
-
-        public EmailMockSetup(Mock<IEmailSender> mock)
-        {
-            this.mock = mock;
-        }
-
-        public EmailMockSetup SentTo(string email)
-        {
-            this.email = email;
-            return this;
-        }
-
-        public EmailMockSetup WithSubject(string subject)
-        {
-            this.subject = subject;
-            return this;
-        }
-
-        public EmailMockSetup WithMessage(string message)
-        {
-            this.message = message;
-            return this;
-        }
-
-        public EmailMockSetup WithType(EmailMessageType type)
-        {
-            this.type = type;
-            return this;
-        }
-
-        public EmailMockSetup HavingAttachment(bool hasAttachment = true)
-        {
-            this.shouldHaveAttachment = hasAttachment;
-            this.shouldNotHaveAttachment = !hasAttachment;
-            return this;
-        }
-
-        public EmailMockSetup ContainingText(string text)
-        {
-            this.textContained.Add(text);
-            return this;
-        }
-
-        public EmailMockSetup Setup()
-        {
-            this.mock.Setup(s => s.SendEmailAsync(
-                    this.EmailToCheck,
-                    this.SubjectToCheck,
-                    this.MessageToCheck,
-                    this.AttachmentToCheck,
-                    this.type))
-                .Callback((string email, string subject, string html, Attachment attachment, EmailMessageType emailType) =>
-                {
-                    foreach (var text in this.textContained)
-                    {
-                        Assert.Contains(text, html);
-                    }
-                });
-
-            return this;
-        }
-        public void VerifyEmailSent(Times? times = null)
-        {
-            if (times == null)
-            {
-                times = Times.Once();
-            }
-
-            this.mock.Verify(s => s.SendEmailAsync(
-                this.EmailToCheck,
-                this.SubjectToCheck,
-                this.MessageToCheck,
-                this.AttachmentToCheck,
-                this.type), times.Value);
-        }
-
-        private Attachment AttachmentToCheck =>
-            this.shouldHaveAttachment
-                ? It.IsNotNull<Attachment>()
-                : this.shouldNotHaveAttachment
-                    ? null
-                    : It.IsAny<Attachment>();
-
-        private string MessageToCheck => this.message != Placeholder ? this.message : It.IsAny<string>();
-
-        private string SubjectToCheck => this.subject != Placeholder ? this.subject : It.IsAny<string>();
-
-        private string EmailToCheck => this.email != Placeholder ? this.email : It.IsAny<string>();
     }
 }

--- a/tests/EventManagement.IntegrationTests/Pages/Account/LoginPageTests.cs
+++ b/tests/EventManagement.IntegrationTests/Pages/Account/LoginPageTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Moq;
 using System.Collections.Generic;
 using System.Net;
@@ -6,13 +7,18 @@ using Xunit;
 
 namespace losol.EventManagement.IntegrationTests.Pages.Account
 {
-    public class LoginPageTests : IClassFixture<CustomWebApplicationFactory<Startup>>
+    public class LoginPageTests : IClassFixture<CustomWebApplicationFactory<Startup>>, IDisposable
     {
         private readonly CustomWebApplicationFactory<Startup> factory;
 
         public LoginPageTests(CustomWebApplicationFactory<Startup> factory)
         {
             this.factory = factory;
+        }
+
+        public void Dispose()
+        {
+            this.factory.EmailSenderMock.Reset();
         }
 
         [Theory]

--- a/tests/EventManagement.IntegrationTests/Pages/Admin/Events/ProductsPageTests.cs
+++ b/tests/EventManagement.IntegrationTests/Pages/Admin/Events/ProductsPageTests.cs
@@ -1,0 +1,66 @@
+using losol.EventManagement.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace losol.EventManagement.IntegrationTests.Pages.Admin.Events
+{
+    public class ProductsPageTests : IClassFixture<CustomWebApplicationFactory<Startup>>
+    {
+        private readonly CustomWebApplicationFactory<Startup> factory;
+
+        public ProductsPageTests(CustomWebApplicationFactory<Startup> factory)
+        {
+            this.factory = factory;
+        }
+
+        [Fact]
+        public async Task Should_Add_Products_To_Event()
+        {
+            var client = this.factory.CreateClient();
+            await client.LogInAsSuperAdminAsync();
+
+            using var scope = this.factory.Services.NewScope();
+            using var user = await scope.ServiceProvider.CreateUserAsync();
+
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            using var eventInfo = await context.CreateEventAsync();
+
+            var response = await client.PostAsync($"/Admin/Events/Products/{eventInfo.Entity.EventInfoId}",
+                new Dictionary<string, string>
+                {
+                    { "Vm.EventInfoId", eventInfo.Entity.EventInfoId.ToString() },
+                    { "Vm.Products[0].Name", "Test Product 1 With No Variants" },
+                    { "Vm.Products[1].Name", "Test Product 2 With 2 Variants" },
+                    { "Vm.Products[1].ProductVariants[0].Name", "Variant 1" },
+                    { "Vm.Products[1].ProductVariants[1].Name", "Variant 2" }
+                });
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+            var updatedEvent = await context.EventInfos.AsNoTracking()
+                .Include(e => e.Products)
+                .ThenInclude(p => p.ProductVariants)
+                .FirstOrDefaultAsync(e => e.EventInfoId == eventInfo.Entity.EventInfoId);
+
+            Assert.NotNull(updatedEvent);
+
+            var products = updatedEvent.Products
+                .OrderBy(p => p.Name)
+                .ToArray();
+
+            Assert.Equal(2, products.Length);
+            Assert.Equal("Test Product 1 With No Variants", products[0].Name);
+            Assert.Empty(products[0].ProductVariants);
+
+            Assert.Equal("Test Product 2 With 2 Variants", products[1].Name);
+            Assert.Equal(new[] { "Variant 1", "Variant 2" }, products[1].ProductVariants
+                .OrderBy(v => v.Name)
+                .Select(v => v.Name)
+                .ToArray());
+        }
+    }
+}

--- a/tests/EventManagement.IntegrationTests/Pages/Events/Register/IndexPageTests.cs
+++ b/tests/EventManagement.IntegrationTests/Pages/Events/Register/IndexPageTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using losol.EventManagement.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
+{
+    public class IndexPageTests : IClassFixture<CustomWebApplicationFactory<Startup>>, IDisposable
+    {
+        private const string Email = "some-test@email.com";
+
+        private readonly CustomWebApplicationFactory<Startup> factory;
+
+        public IndexPageTests(CustomWebApplicationFactory<Startup> factory)
+        {
+            this.factory = factory;
+        }
+
+        public void Dispose()
+        {
+            this.factory.EmailSenderMock.Reset();
+
+            using var scope = this.factory.Services.NewScope();
+
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var user = context.Users.FirstOrDefault(u => u.Email == Email);
+            if (user != null)
+            {
+                context.Remove(user);
+                context.SaveChanges();
+            }
+        }
+
+        [Theory]
+        [InlineData("nb-NO", "Velkommen på kurs!", "Vi fikk registreringen din")]
+        [InlineData("en-US", "Welcome to the course!", "We received your registration")]
+        public async Task ShouldCreateNewUserAndRegistration(string language, string subject, string body)
+        {
+            var client = this.factory.CreateClient();
+            client.AcceptLanguage(language);
+
+            using var scope = this.factory.Services.NewScope();
+
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            using var eventInfo = await context.CreateEventAsync();
+
+            var emailExpectation = this.factory.EmailSenderMock
+                .ExpectEmail()
+                .SentTo(Email)
+                .WithSubject(subject)
+                .ContainingText(body)
+                .Setup();
+
+            var response = await client.PostAsync($"/events/{eventInfo.Entity.EventInfoId}/{eventInfo.Entity.Code}/register",
+                new Dictionary<string, string>
+            {
+                { "Email", Email },
+                { "PhoneCountryCode", "+1" },
+                { "Phone", "1111111111" },
+                { "ParticipantName", "John Doe" },
+                { "ParticipantJobTitle", "Head" },
+                { "ParticipantCity", "Oslo" },
+                { "Notes", "Testing" }
+            });
+
+            Assert.True(response.IsSuccessStatusCode, await response.Content.ReadAsStringAsync());
+
+            var user = await context.Users.FirstOrDefaultAsync(u => u.Email == Email);
+            Assert.NotNull(user);
+            Assert.Equal("John Doe", user.Name);
+            Assert.Equal(Email, user.UserName);
+            Assert.Equal("+11111111111", user.PhoneNumber);
+
+            var registration =
+                await context.Registrations.FirstOrDefaultAsync(r =>
+                    r.UserId == user.Id && r.EventInfoId == eventInfo.Entity.EventInfoId);
+
+            Assert.NotNull(registration);
+            Assert.Equal("John Doe", registration.ParticipantName);
+            Assert.Equal("Head", registration.ParticipantJobTitle);
+            Assert.Equal("Oslo", registration.ParticipantCity);
+            Assert.Equal("Testing", registration.Notes);
+
+            emailExpectation.VerifyEmailSent();
+        }
+    }
+}

--- a/tests/EventManagement.IntegrationTests/Pages/Events/Register/IndexPageTests.cs
+++ b/tests/EventManagement.IntegrationTests/Pages/Events/Register/IndexPageTests.cs
@@ -39,7 +39,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
         [Theory]
         [InlineData("nb-NO", "Du var allerede påmeldt!", "Vi hadde allerede en registrering for deg.")]
         [InlineData("en-US", "You were already signed up!", "We already had a registration for you.")]
-        public async Task ShouldSendEmailWhenAlreadyRegistered(string language, string subject, string body)
+        public async Task Should_Send_Email_When_Already_Registered(string language, string subject, string body)
         {
             var client = this.factory.CreateClient();
             client.AcceptLanguage(language);
@@ -78,7 +78,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
         [Theory]
         [InlineData("nb-NO", "Velkommen på kurs!", "Vi fikk registreringen din")]
         [InlineData("en-US", "Welcome to the course!", "We received your registration")]
-        public async Task ShouldCreateNewRegistrationForExistingUser(string language, string subject, string body)
+        public async Task Should_Create_New_Registration_For_Existing_User(string language, string subject, string body)
         {
             var client = this.factory.CreateClient();
             client.AcceptLanguage(language);
@@ -126,7 +126,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
         [Theory]
         [InlineData("nb-NO", "Velkommen på kurs!", "Vi fikk registreringen din")]
         [InlineData("en-US", "Welcome to the course!", "We received your registration")]
-        public async Task ShouldCreateNewUserAndRegistration(string language, string subject, string body)
+        public async Task Should_Create_New_User_And_Registration(string language, string subject, string body)
         {
             var client = this.factory.CreateClient();
             client.AcceptLanguage(language);

--- a/tests/EventManagement.IntegrationTests/Pages/Events/Register/IndexPageTests.cs
+++ b/tests/EventManagement.IntegrationTests/Pages/Events/Register/IndexPageTests.cs
@@ -58,6 +58,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
                 .ContainingText(body)
                 .Setup();
 
+            var token = await client.GetAntiForgeryTokenAsync("/Account/Login");
             var response = await client.PostAsync($"/events/{eventInfo.Entity.EventInfoId}/{eventInfo.Entity.Code}/register",
                 new Dictionary<string, string>
             {
@@ -68,7 +69,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
                 { "ParticipantJobTitle", "Head" },
                 { "ParticipantCity", "Oslo" },
                 { "Notes", "Testing" }
-            });
+            }, token);
 
             Assert.True(response.IsSuccessStatusCode, await response.Content.ReadAsStringAsync());
 
@@ -96,6 +97,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
                 .ContainingText(body)
                 .Setup();
 
+            var token = await client.GetAntiForgeryTokenAsync("/Account/Login");
             var response = await client.PostAsync($"/events/{eventInfo.Entity.EventInfoId}/{eventInfo.Entity.Code}/register",
                 new Dictionary<string, string>
             {
@@ -106,7 +108,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
                 { "ParticipantJobTitle", "Head" },
                 { "ParticipantCity", "Oslo" },
                 { "Notes", "Testing" }
-            });
+            }, token);
 
             Assert.True(response.IsSuccessStatusCode, await response.Content.ReadAsStringAsync());
 
@@ -143,6 +145,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
                 .ContainingText(body)
                 .Setup();
 
+            var token = await client.GetAntiForgeryTokenAsync("/Account/Login");
             var response = await client.PostAsync($"/events/{eventInfo.Entity.EventInfoId}/{eventInfo.Entity.Code}/register",
                 new Dictionary<string, string>
             {
@@ -153,7 +156,7 @@ namespace losol.EventManagement.IntegrationTests.Pages.Events.Register
                 { "ParticipantJobTitle", "Head" },
                 { "ParticipantCity", "Oslo" },
                 { "Notes", "Testing" }
-            });
+            }, token);
 
             Assert.True(response.IsSuccessStatusCode, await response.Content.ReadAsStringAsync());
 

--- a/tests/EventManagement.IntegrationTests/ServiceProviderExtensions.cs
+++ b/tests/EventManagement.IntegrationTests/ServiceProviderExtensions.cs
@@ -9,6 +9,7 @@ namespace losol.EventManagement.IntegrationTests
     public static class ServiceProviderExtensions
     {
         public const string Placeholder = "___Placeholder___";
+        public const string DefaultPassword = "MySuperSecretPassword1!";
 
         public static IServiceScope NewScope(this IServiceProvider serviceProvider)
         {
@@ -30,7 +31,7 @@ namespace losol.EventManagement.IntegrationTests
 
             if (password == Placeholder)
             {
-                password = "MySuperSecretPassword1!";
+                password = DefaultPassword;
             }
 
             var user = new ApplicationUser


### PR DESCRIPTION
Bug fixed.

The cause was improper usage of Linq expressions. Once entities are loaded into memory using ToArrayAsync there is no need to call AsNoTracking on them, or their chidl collections, as well as use their To***Async() methods - they are for data loading only, not for in-memory data manipulation.

First need to merge https://github.com/losol/eventuras/pull/350