### PR TITLE
Fixing issues like 'A second operation started on this context before…

### DIFF
--- a/src/EventManagement.Services/IOrderVmConversionService.cs
+++ b/src/EventManagement.Services/IOrderVmConversionService.cs
@@ -1,0 +1,11 @@
+using losol.EventManagement.Domain;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace losol.EventManagement.Services
+{
+    public interface IOrderVmConversionService
+    {
+        Task<IEnumerable<OrderDTO>> OrderVmsToOrderDtos(ICollection<OrderVM> orders);
+    }
+}

--- a/src/EventManagement.Services/IRegistrationService.cs
+++ b/src/EventManagement.Services/IRegistrationService.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using losol.EventManagement.Domain;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using losol.EventManagement.Domain;
 using static losol.EventManagement.Domain.PaymentMethod;
 
 namespace losol.EventManagement.Services

--- a/src/EventManagement.Services/OrderVmConversionService.cs
+++ b/src/EventManagement.Services/OrderVmConversionService.cs
@@ -1,0 +1,41 @@
+using losol.EventManagement.Domain;
+using losol.EventManagement.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace losol.EventManagement.Services
+{
+    public class OrderVmConversionService : IOrderVmConversionService
+    {
+        private readonly ApplicationDbContext context;
+
+        public OrderVmConversionService(ApplicationDbContext context)
+        {
+            this.context = context;
+        }
+
+        public async Task<IEnumerable<OrderDTO>> OrderVmsToOrderDtos(ICollection<OrderVM> orders)
+        {
+            var productIds = orders.Select(o => o.ProductId).ToArray();
+            var variantIds = orders.Select(o => o.VariantId).ToArray();
+
+            var productMap = await this.context.Products
+                .Where(p => productIds.Contains(p.ProductId))
+                .ToDictionaryAsync(p => p.ProductId);
+
+            var variantMap = await this.context.ProductVariants
+                .Where(v => variantIds.Contains(v.ProductVariantId))
+                .ToDictionaryAsync(v => v.ProductVariantId);
+
+            return orders.Select(o => new OrderDTO
+            {
+                Product = productMap[o.ProductId],
+                Variant = o.VariantId.HasValue ? variantMap[o.VariantId.Value] : null,
+                Quantity = o.Quantity
+            });
+        }
+    }
+}

--- a/src/EventManagement.Services/ProductsService.cs
+++ b/src/EventManagement.Services/ProductsService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -104,14 +104,14 @@ namespace losol.EventManagement.Services
 				}
 			}
 
-			/* 
+            /* 
             foreach(var id in registrationIds)
             {
                 var registration = await _db.Registrations.FindAsync(id);
                 var task1 = _db.Entry(registration).Reference(r => r.User).LoadAsync();
                 var task2 = _db.Entry(registration).Collection(r => r.Orders).LoadAsync();
                 var task3 = _db.OrderLines.Where(l => l.Order.RegistrationId == id).LoadAsync();
-                await Task.WhenAll(task1, task2, task3);
+                await Task.WhenAll(task1, task2, task3); // DON'T DO THIS, it will cause 'A second operation started on this context before a previous operation completed.'
 
                 registrations.Add(registration);
             }

--- a/src/EventManagement.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EventManagement.Web/Extensions/ServiceCollectionExtensions.cs
@@ -213,6 +213,7 @@ namespace EventManagement.Web.Extensions
             services.AddScoped<IOrderService, OrderService>();
             services.AddScoped<ICertificatesService, CertificatesService>();
             services.AddScoped<IMessageLogService, MessageLogService>();
+            services.AddTransient<IOrderVmConversionService, OrderVmConversionService>();
 
             // Add Page render Service
             services.AddScoped<IRenderService, ViewRenderService>();


### PR DESCRIPTION
… a previous operation completed.'