### PR TITLE
Fixing issue with "Invalid URI: The Uri string is too long."

### DIFF
--- a/src/EventManagement.Services.Converto/ConvertoPdfRenderService.cs
+++ b/src/EventManagement.Services.Converto/ConvertoPdfRenderService.cs
@@ -8,31 +8,31 @@ namespace EventManagement.Services.Converto
 {
     public class ConvertoPdfRenderService : IPdfRenderService
     {
-        private readonly IConvertoClient client;
-        private readonly IOptions<ConvertoConfig> options;
-        private readonly ILogger<ConvertoPdfRenderService> logger;
+        private readonly IConvertoClient _client;
+        private readonly IOptions<ConvertoConfig> _options;
+        private readonly ILogger<ConvertoPdfRenderService> _logger;
 
         public ConvertoPdfRenderService(
             IConvertoClient client,
             IOptions<ConvertoConfig> options,
             ILogger<ConvertoPdfRenderService> logger)
         {
-            this.client = client;
-            this.options = options;
-            this.logger = logger;
+            _client = client;
+            _options = options;
+            _logger = logger;
         }
 
         public async Task<Stream> RenderHtmlAsync(string html, PdfRenderOptions pdfRenderOptions)
         {
             try
             {
-                return await this.client.Html2PdfAsync(html,
-                    pdfRenderOptions.Scale ?? this.options.Value.DefaultScale ?? 1,
-                    pdfRenderOptions.Format ?? this.options.Value.DefaultFormat ?? "A4");
+                return await _client.Html2PdfAsync(html,
+                    pdfRenderOptions.Scale ?? _options.Value.DefaultScale ?? 1,
+                    pdfRenderOptions.Format ?? _options.Value.DefaultFormat ?? "A4");
             }
             catch (ConvertoClientException e)
             {
-                this.logger.LogError(e.Message, e);
+                _logger.LogError(e.Message, e);
                 return new MemoryStream();
             }
         }

--- a/tests/EventManagement.Services.Converto.Tests/ConvertoPdfRenderServiceTest.cs
+++ b/tests/EventManagement.Services.Converto.Tests/ConvertoPdfRenderServiceTest.cs
@@ -101,6 +101,18 @@ namespace EventManagement.Services.Converto.Tests
             }
         }
 
+        [Fact(Skip = "Provide URL for converto service")]
+        public async Task ShouldRenderLargePdf()
+        {
+            // Initially caused "Invalid URI: The Uri string is too long."
+            var html = $"<html>{new String('A', 200000)}</html>";
+            using (var stream = await this.NewService().RenderHtmlAsync(html,
+                new PdfRenderOptions()))
+            {
+                await CheckNotEmptyAsync(stream);
+            }
+        }
+
         private static async Task CheckEmptyAsync(Stream stream)
         {
             var buffer = new byte[1024];


### PR DESCRIPTION
POST'ing application/json instead of form encoded string.

+ test
+ following common code conversion with _ prefixes for private members and not using this. as a suffix.

TODO: point tests (ConvertoPdfRenderServiceTest) to some exising converto service public URL and remove Skip="..."