### PR TITLE
Use X-Forwarded-For and X-Forwarded-Proto headers to know the protoco…

### DIFF
--- a/src/Eventuras.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Eventuras.Web/Extensions/ServiceCollectionExtensions.cs
@@ -33,6 +33,8 @@ using System.Net.Http.Headers;
 using Losol.Communication.HealthCheck.Abstractions;
 using Losol.Communication.HealthCheck.Email;
 using Losol.Communication.HealthCheck.Sms;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using DefaultAuthenticationService = Eventuras.Web.Services.DefaultAuthenticationService;
 
 namespace Eventuras.Web.Extensions
@@ -104,6 +106,11 @@ namespace Eventuras.Web.Extensions
                 })
                 .AddViewLocalization(LanguageViewLocationExpanderFormat.Suffix)
                 .AddRazorRuntimeCompilation();
+
+            services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+            });
         }
 
         public static void ConfigureLocalization(this IServiceCollection services, CultureInfo defaultCultureInfo)


### PR DESCRIPTION
…l used.

This may help in constructing the right link in OpenIdConnect middleware (and everywhere else actually).

Another fix may be needed in Reverse proxy setup. See the details here:

https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-3.1

Sample conig for Nginx:

https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/linux-nginx?view=aspnetcore-3.1#configure-nginx