### PR TITLE
Multi-tenancy, Part 2. User management.

### DIFF
--- a/src/Eventuras.Domain/OrganizationMember.cs
+++ b/src/Eventuras.Domain/OrganizationMember.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 
 namespace Eventuras.Domain
 {
@@ -18,5 +20,9 @@ namespace Eventuras.Domain
 
         [ForeignKey(nameof(OrganizationId))]
         public Organization Organization { get; set; }
+
+        public List<OrganizationMemberRole> Roles { get; set; }
+
+        public bool HasRole(string role) => Roles?.Any(r => r.Role == role) == true;
     }
 }

--- a/src/Eventuras.Domain/OrganizationMemberRole.cs
+++ b/src/Eventuras.Domain/OrganizationMemberRole.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Eventuras.Domain
+{
+    public class OrganizationMemberRole
+    {
+        public int OrganizationMemberId { get; set; }
+
+        [Required]
+        public string Role { get; set; }
+
+        [ForeignKey(nameof(OrganizationMemberId))]
+        public OrganizationMember OrganizationMember { get; set; }
+    }
+}

--- a/src/Eventuras.Infrastructure/ApplicationDbContext.cs
+++ b/src/Eventuras.Infrastructure/ApplicationDbContext.cs
@@ -19,6 +19,7 @@ namespace Eventuras.Infrastructure
         public DbSet<OrderLine> OrderLines { get; set; }
         public DbSet<Organization> Organizations { get; set; }
         public DbSet<OrganizationMember> OrganizationMembers { get; set; }
+        public DbSet<OrganizationMemberRole> OrganizationMemberRoles { get; set; }
         public DbSet<OrganizationHostname> OrganizationHostnames { get; set; }
         public DbSet<Certificate> Certificates { get; set; }
         public DbSet<MessageLog> MessageLogs { get; set; }
@@ -53,6 +54,9 @@ namespace Eventuras.Infrastructure
             builder.Entity<OrganizationMember>()
                 .HasIndex(m => new { m.OrganizationId, m.UserId })
                 .IsUnique();
+
+            builder.Entity<OrganizationMemberRole>()
+                .HasKey(o => new { o.OrganizationMemberId, o.Role });
         }
 
         public void DetachAllEntities()

--- a/src/Eventuras.Infrastructure/Migrations/20200930061949_OrgMembershipRoles.Designer.cs
+++ b/src/Eventuras.Infrastructure/Migrations/20200930061949_OrgMembershipRoles.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Eventuras.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace Eventuras.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20200930061949_OrgMembershipRoles")]
+    partial class OrgMembershipRoles
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eventuras.Infrastructure/Migrations/20200930061949_OrgMembershipRoles.cs
+++ b/src/Eventuras.Infrastructure/Migrations/20200930061949_OrgMembershipRoles.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Eventuras.Infrastructure.Migrations
+{
+    public partial class OrgMembershipRoles : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "OrganizationMemberRoles",
+                columns: table => new
+                {
+                    OrganizationMemberId = table.Column<int>(nullable: false),
+                    Role = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrganizationMemberRoles", x => new { x.OrganizationMemberId, x.Role });
+                    table.ForeignKey(
+                        name: "FK_OrganizationMemberRoles_OrganizationMembers_OrganizationMem~",
+                        column: x => x.OrganizationMemberId,
+                        principalTable: "OrganizationMembers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrganizationMemberRoles");
+        }
+    }
+}

--- a/src/Eventuras.Services/Auth/ApplicationClaimsIdentityFactory.cs
+++ b/src/Eventuras.Services/Auth/ApplicationClaimsIdentityFactory.cs
@@ -1,0 +1,84 @@
+using Eventuras.Domain;
+using Eventuras.Services.Organizations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Eventuras.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Eventuras.Services.Auth
+{
+    internal class ApplicationClaimsIdentityFactory : UserClaimsPrincipalFactory<ApplicationUser, IdentityRole>
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ICurrentOrganizationAccessorService _currentOrganizationAccessorService;
+
+        public ApplicationClaimsIdentityFactory(
+            UserManager<ApplicationUser> userManager,
+            RoleManager<IdentityRole> roleManager,
+            IOptions<IdentityOptions> optionsAccessor,
+            ApplicationDbContext context,
+            ICurrentOrganizationAccessorService currentOrganizationAccessorService) : base(userManager, roleManager, optionsAccessor)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _currentOrganizationAccessorService = currentOrganizationAccessorService ?? throw
+                new ArgumentNullException(nameof(currentOrganizationAccessorService));
+        }
+
+        protected override async Task<ClaimsIdentity> GenerateClaimsAsync(ApplicationUser user)
+        {
+            var identity = await base.GenerateClaimsAsync(user);
+
+            var defaultRoleClaims = identity.Claims
+                .Where(c => c.Type == identity.RoleClaimType)
+                .ToArray();
+
+            if (defaultRoleClaims.Any(c => c.Value == Roles.SuperAdmin))
+            {
+                return identity;
+            }
+
+            // For all users except super admin replace
+            // default roles assigned by AspNetIdentity with
+            // org-specific roles.
+
+            foreach (var roleClaim in defaultRoleClaims)
+            {
+                identity.RemoveClaim(roleClaim);
+            }
+
+            var organization = await _currentOrganizationAccessorService.GetCurrentOrganizationAsync();
+            if (organization == null)
+            {
+                return identity;
+            }
+
+            var member = await _context.OrganizationMembers
+                .AsNoTracking()
+                .Include(m => m.Roles)
+                .SingleOrDefaultAsync(m =>
+                    m.OrganizationId == organization.OrganizationId &&
+                    m.UserId == user.Id);
+
+            if (member == null)
+            {
+                return identity;
+            }
+
+            var orgSpecificRoles = member.Roles
+                .Select(r => r.Role)
+                .ToHashSet() ?? new HashSet<string>();
+
+            foreach (var role in orgSpecificRoles)
+            {
+                identity.AddClaim(new Claim(identity.RoleClaimType, role));
+            }
+
+            return identity;
+        }
+    }
+}

--- a/src/Eventuras.Services/Auth/AuthServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services/Auth/AuthServiceCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using Eventuras.Domain;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Eventuras.Services.Auth
+{
+    internal static class AuthServiceCollectionExtensions
+    {
+        public static void AddAuthServices(this IServiceCollection services)
+        {
+            services.AddScoped<IUserClaimsPrincipalFactory<ApplicationUser>, ApplicationClaimsIdentityFactory>();
+        }
+    }
+}

--- a/src/Eventuras.Services/Organizations/IOrganizationMemberManagementService.cs
+++ b/src/Eventuras.Services/Organizations/IOrganizationMemberManagementService.cs
@@ -5,10 +5,40 @@ namespace Eventuras.Services.Organizations
 {
     public interface IOrganizationMemberManagementService
     {
-        Task<OrganizationMember> FindOrganizationMemberAsync(ApplicationUser user, Organization organization = null);
+        /// <summary>
+        /// Find org member record for the given app user. If no <c>organization</c> is passed,
+        /// then returns member record for the current organization (see <see cref="ICurrentOrganizationAccessorService"/>).
+        /// </summary>
+        /// <param name="user">User to find membership for.</param>
+        /// <param name="organization">Organization to find membership for, or <c>null</c> for current org.</param>
+        /// <param name="options">Optional load params.</param>
+        /// <returns>Org membership record or <c>null</c> if not found.</returns>
+        Task<OrganizationMember> FindOrganizationMemberAsync(
+            ApplicationUser user,
+            Organization organization = null,
+            OrganizationMemberRetrievalOptions options = null);
 
-        Task<OrganizationMember> AddToOrganizationAsync(ApplicationUser user, Organization organization = null);
+        /// <summary>
+        /// Ensures org member record for the given app user. If no <c>organization</c> is passed,
+        /// then returns member record for the current organization (see <see cref="ICurrentOrganizationAccessorService"/>).
+        /// </summary>
+        /// <param name="user">User to create/retrieve membership for.</param>
+        /// <param name="organization">Organization to find membership for, or <c>null</c> for current org.</param>
+        /// <param name="options">Optional load params.</param>
+        /// <returns>Org membership record or <c>null</c> if not found.</returns>
+        Task<OrganizationMember> AddToOrganizationAsync(
+            ApplicationUser user,
+            Organization organization = null,
+            OrganizationMemberRetrievalOptions options = null);
 
-        Task RemoveFromOrganizationAsync(ApplicationUser user, Organization organization = null);
+        /// <summary>
+        /// Removes membership for the given user, if any. If no org is passed,
+        /// then removes from the current org.
+        /// </summary>
+        /// <param name="user">User to which membership is to be removed.</param>
+        /// <param name="organization">Organization to find membership for, or <c>null</c> for current org.</param>
+        Task RemoveFromOrganizationAsync(
+            ApplicationUser user,
+            Organization organization = null);
     }
 }

--- a/src/Eventuras.Services/Organizations/IOrganizationMemberRolesManagementService.cs
+++ b/src/Eventuras.Services/Organizations/IOrganizationMemberRolesManagementService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Eventuras.Services.Organizations
+{
+    public interface IOrganizationMemberRolesManagementService
+    {
+        Task UpdateOrganizationMemberRolesAsync(int memberId, string[] roles);
+    }
+}

--- a/src/Eventuras.Services/Organizations/OrganizationMemberQueryableExtensions.cs
+++ b/src/Eventuras.Services/Organizations/OrganizationMemberQueryableExtensions.cs
@@ -1,0 +1,27 @@
+using Eventuras.Domain;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace Eventuras.Services.Organizations
+{
+    internal static class OrganizationMemberQueryableExtensions
+    {
+        public static IQueryable<OrganizationMember> UseOptions(
+            this IQueryable<OrganizationMember> query,
+            OrganizationMemberRetrievalOptions options)
+        {
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            if (options.LoadRoles)
+            {
+                query = query.Include(m => m.Roles);
+            }
+
+            return query;
+        }
+    }
+}

--- a/src/Eventuras.Services/Organizations/OrganizationMemberRetrievalOptions.cs
+++ b/src/Eventuras.Services/Organizations/OrganizationMemberRetrievalOptions.cs
@@ -1,0 +1,7 @@
+namespace Eventuras.Services.Organizations
+{
+    public class OrganizationMemberRetrievalOptions
+    {
+        public bool LoadRoles { get; set; }
+    }
+}

--- a/src/Eventuras.Services/Organizations/OrganizationMemberRolesManagementService.cs
+++ b/src/Eventuras.Services/Organizations/OrganizationMemberRolesManagementService.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Eventuras.Domain;
+using Eventuras.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Eventuras.Services.Organizations
+{
+    internal class OrganizationMemberRolesManagementService : IOrganizationMemberRolesManagementService
+    {
+        private readonly ApplicationDbContext _context;
+
+        public OrganizationMemberRolesManagementService(ApplicationDbContext context)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+        }
+
+        public async Task UpdateOrganizationMemberRolesAsync(int memberId, string[] roles)
+        {
+            if (roles == null)
+            {
+                throw new ArgumentNullException(nameof(roles));
+            }
+
+            var member = await _context.OrganizationMembers
+                .Include(m => m.Roles)
+                .SingleAsync(m => m.Id == memberId);
+
+            var oldRoles = member.Roles
+                .ToDictionary(r => r.Role);
+
+            foreach (var role in roles)
+            {
+                if (oldRoles.ContainsKey(role))
+                {
+                    oldRoles.Remove(role);
+                }
+                else
+                {
+                    member.Roles.Add(new OrganizationMemberRole
+                    {
+                        Role = role
+                    });
+                }
+            }
+
+            foreach (var role in oldRoles.Values)
+            {
+                member.Roles.Remove(role);
+            }
+
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/src/Eventuras.Services/Organizations/OrganizationServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services/Organizations/OrganizationServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ namespace Eventuras.Services.Organizations
             services.AddTransient<IOrganizationRetrievalService, OrganizationRetrievalService>();
             services.AddTransient<IOrganizationManagementService, OrganizationManagementService>();
             services.AddTransient<IOrganizationMemberManagementService, OrganizationMemberManagementService>();
+            services.AddTransient<IOrganizationMemberRolesManagementService, OrganizationMemberRolesManagementService>();
             return services;
         }
     }

--- a/src/Eventuras.Services/ServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services/ServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
+using Eventuras.Services.Auth;
 using Eventuras.Services.Invoicing;
 using Eventuras.Services.ExternalSync;
 using Eventuras.Services.Organizations;
 using Eventuras.Services.Registrations;
+using Eventuras.Services.Users;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Eventuras.Services
@@ -22,6 +24,8 @@ namespace Eventuras.Services
             services.AddRegistrationServices();
             services.AddLmsServices();
             services.AddOrganizationServices();
+            services.AddUserServices();
+            services.AddAuthServices();
             return services;
         }
     }

--- a/src/Eventuras.Services/Users/IUserRetrievalService.cs
+++ b/src/Eventuras.Services/Users/IUserRetrievalService.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Eventuras.Domain;
+
+namespace Eventuras.Services.Users
+{
+    public interface IUserRetrievalService
+    {
+        Task<ApplicationUser> GetUserByIdAsync(string userId);
+
+        Task<List<ApplicationUser>> ListAccessibleUsers(UserRetrievalOptions options = null);
+    }
+}

--- a/src/Eventuras.Services/Users/UserQueryableExtensions.cs
+++ b/src/Eventuras.Services/Users/UserQueryableExtensions.cs
@@ -1,0 +1,37 @@
+using Eventuras.Domain;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+
+namespace Eventuras.Services.Users
+{
+    internal static class UserQueryableExtensions
+    {
+        public static IQueryable<ApplicationUser> UseOptions(this IQueryable<ApplicationUser> query, UserRetrievalOptions options)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            if (options.IncludeOrgMembership)
+            {
+                query = query.Include(o => o.OrganizationMembership);
+            }
+
+            return query;
+        }
+
+        public static IQueryable<ApplicationUser> HavingNoOrganizationOnly(this IQueryable<ApplicationUser> query)
+        {
+            return query.Where(u => !u.OrganizationMembership.Any());
+        }
+
+        public static IQueryable<ApplicationUser> HavingOrganization(this IQueryable<ApplicationUser> query, Organization organization)
+        {
+            if (organization == null)
+                throw new ArgumentNullException(nameof(organization));
+
+            return query.Where(u => u.OrganizationMembership
+                .Any(m => m.OrganizationId == organization.OrganizationId));
+        }
+    }
+}

--- a/src/Eventuras.Services/Users/UserRetrievalOptions.cs
+++ b/src/Eventuras.Services/Users/UserRetrievalOptions.cs
@@ -1,0 +1,7 @@
+namespace Eventuras.Services.Users
+{
+    public class UserRetrievalOptions
+    {
+        public bool IncludeOrgMembership { get; set; }
+    }
+}

--- a/src/Eventuras.Services/Users/UserRetrievalService.cs
+++ b/src/Eventuras.Services/Users/UserRetrievalService.cs
@@ -1,0 +1,68 @@
+using Eventuras.Domain;
+using Eventuras.Infrastructure;
+using Eventuras.Services.Organizations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Eventuras.Services.Users
+{
+    internal class UserRetrievalService : IUserRetrievalService
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly ICurrentOrganizationAccessorService _currentOrganizationAccessorService;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public UserRetrievalService(
+            ApplicationDbContext context,
+            ICurrentOrganizationAccessorService currentOrganizationAccessorService,
+            IHttpContextAccessor httpContextAccessor)
+        {
+            _context = context ?? throw new ArgumentNullException(nameof(context));
+            _currentOrganizationAccessorService = currentOrganizationAccessorService ?? throw new ArgumentNullException(nameof(currentOrganizationAccessorService));
+            _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
+        }
+
+        public async Task<ApplicationUser> GetUserByIdAsync(string userId)
+        {
+            if (string.IsNullOrWhiteSpace(userId))
+            {
+                throw new ArgumentException(nameof(userId));
+            }
+
+            return await _context.ApplicationUsers
+                .AsNoTracking()
+                .SingleAsync(u => u.Id == userId);
+        }
+        public async Task<List<ApplicationUser>> ListAccessibleUsers(UserRetrievalOptions options)
+        {
+            options ??= new UserRetrievalOptions();
+
+            var user = _httpContextAccessor.HttpContext.User;
+            if (!user.IsInRole(Roles.Admin) &&
+                !user.IsInRole(Roles.SuperAdmin))
+            {
+                throw new AccessViolationException($"Should have {Roles.Admin} role to access other users.");
+            }
+
+            var query = _context.Users.AsNoTracking()
+                .UseOptions(options);
+
+            if (!user.IsInRole(Roles.SuperAdmin))
+            {
+                if (!user.IsInRole(Roles.Admin))
+                {
+                    // Not an admin of the current org => can't see org member list.
+                    return new List<ApplicationUser>();
+                }
+
+                var organization = await _currentOrganizationAccessorService.RequireCurrentOrganizationAsync();
+                query = query.HavingOrganization(organization);
+            }
+
+            return await query.ToListAsync();
+        }
+    }
+}

--- a/src/Eventuras.Services/Users/UserServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services/Users/UserServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Eventuras.Services.Users
+{
+    public static class UserServiceCollectionExtensions
+    {
+        public static IServiceCollection AddUserServices(this IServiceCollection services)
+        {
+            services.AddTransient<IUserRetrievalService, UserRetrievalService>();
+            return services;
+        }
+    }
+}

--- a/src/Eventuras.Web/Controllers/Api/V0/UsersController.cs
+++ b/src/Eventuras.Web/Controllers/Api/V0/UsersController.cs
@@ -1,7 +1,7 @@
-using Eventuras.Infrastructure;
+using Eventuras.Services.Users;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -12,18 +12,18 @@ namespace Eventuras.Web.Controllers.Api.V0
     [Authorize(Policy = AuthPolicies.AdministratorRole)]
     public class UsersController : Controller
     {
-        private readonly ApplicationDbContext _db; // TODO: Get rid of this
-        public UsersController(ApplicationDbContext db)
+        private readonly IUserRetrievalService _userRetrievalService;
+        public UsersController(IUserRetrievalService userRetrievalService)
         {
-            _db = db;
+            _userRetrievalService = userRetrievalService ?? throw new ArgumentNullException(nameof(userRetrievalService));
         }
 
         [HttpGet("")]
         public async Task<IActionResult> GetUsers()
         {
-            var users = await _db.Users
-                                 .Select(u => new { Id = u.Id, Name = u.Name, Email = u.Email, Phone = u.PhoneNumber })
-                                 .ToListAsync();
+            var users = (await _userRetrievalService.ListAccessibleUsers())
+                                 .Select(u => new { u.Id, u.Name, u.Email, Phone = u.PhoneNumber })
+                                 .ToList();
             return Ok(users);
         }
     }

--- a/src/Eventuras.Web/Pages/Admin/Users/Create.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Users/Create.cshtml
@@ -1,5 +1,5 @@
 @page
-@model Eventuras.Pages.Admin.Users.CreateModel
+@model Eventuras.Web.Pages.Admin.Users.CreateModel
 
 @{
     ViewData["Title"] = "Ny bruker";
@@ -36,6 +36,18 @@
                         <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
                     </div>
                 </div>
+                @if (Model.Organization != null && User.IsInRole(Roles.SuperAdmin))
+                {
+                    <div class="row">
+                        <div class="form-check">
+                            @Html.CheckBoxFor(model => model.Input.IsOrgMember, new { @class = "form-check-input", onchange = "javascript:enableRoleInputs(this.checked)" })
+                            <label asp-for="Input.IsOrgMember" class="form-check-label">Assosiert med @Model.Organization.NameAndHostname</label>
+                        </div>
+                    </div>
+                }
+                <div class="row">
+                    <partial name="_UserFormRolesPartial" model="Model.MemberRoles" />
+                </div>
                 <hr>
                 <div class="form-group">
                     <input type="submit" value="Lagre" class="btn btn-success" />
@@ -47,5 +59,8 @@
     <div>
         <a asp-page="/Admin/Users/Index">Tilbake til brukeroversikten</a>
     </div>
-    </div>
 </div>
+
+@section Scripts {
+    <partial name="_UserFormScriptsPartial" />
+}

--- a/src/Eventuras.Web/Pages/Admin/Users/Create.cshtml.cs
+++ b/src/Eventuras.Web/Pages/Admin/Users/Create.cshtml.cs
@@ -1,25 +1,38 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using Eventuras.Domain;
+using Eventuras.Services;
+using Eventuras.Services.Organizations;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Eventuras.Domain;
-using Eventuras.Infrastructure;
-using Eventuras.Services;
-using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
 
-namespace Eventuras.Pages.Admin.Users
+namespace Eventuras.Web.Pages.Admin.Users
 {
     public class CreateModel : PageModel
     {
+        private readonly IOrganizationMemberRolesManagementService _memberRolesManagementService;
+        private readonly ICurrentOrganizationAccessorService _currentOrganizationAccessorService;
+        private readonly IOrganizationMemberManagementService _organizationMemberManagementService;
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly ILogger<CreateModel> _logger;
 
-        public CreateModel(UserManager<ApplicationUser> userManager)
+        public CreateModel(
+            IOrganizationMemberRolesManagementService memberRolesManagementService,
+            ICurrentOrganizationAccessorService currentOrganizationAccessorService,
+            IOrganizationMemberManagementService organizationMemberManagementService,
+            UserManager<ApplicationUser> userManager,
+            ILogger<CreateModel> logger)
         {
-            _userManager = userManager;
+            _memberRolesManagementService = memberRolesManagementService ?? throw new ArgumentNullException(nameof(memberRolesManagementService));
+            _currentOrganizationAccessorService = currentOrganizationAccessorService ?? throw new ArgumentNullException(nameof(currentOrganizationAccessorService));
+            _organizationMemberManagementService = organizationMemberManagementService ?? throw new ArgumentNullException(nameof(organizationMemberManagementService));
+            _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public string StatusMessage { get; set; }
@@ -27,9 +40,13 @@ namespace Eventuras.Pages.Admin.Users
         [BindProperty]
         public InputModel Input { get; set; }
 
+        public Organization Organization { get; set; }
+
+        [BindProperty]
+        public Dictionary<string, bool> MemberRoles { get; set; }
+
         public class InputModel
         {
-
             [Display(Name = "Navn", Description = "Hele navnet til brukeren")]
             [Required]
             [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
@@ -48,24 +65,66 @@ namespace Eventuras.Pages.Admin.Users
             [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 5)]
             public string PhoneNumber { get; set; }
 
+            public bool IsOrgMember { get; set; } = true;
         }
 
-        public IActionResult OnGet()
+        public async Task<IActionResult> OnGet()
         {
             Input = new InputModel();
-            return Page();
+            return await PageAsync();
         }
 
         public async Task<IActionResult> OnPostAsync()
         {
             if (!ModelState.IsValid)
             {
-                return Page();
+                return await PageAsync();
             }
 
             var user = new ApplicationUser { Name = Input.Name, UserName = Input.Email, Email = Input.Email, PhoneNumber = (Input.PhoneCountryCode + Input.PhoneNumber) };
-            var result = await _userManager.CreateAsync(user);
+            await _userManager.CreateAsync(user);
+
+            try
+            {
+                if (User.IsInRole(Roles.SuperAdmin))
+                {
+                    // Only SuperAdmin can choose whether to associate user with org,
+                    // Admins can only create org members.
+
+                    if (Input.IsOrgMember)
+                    {
+                        var member = await _organizationMemberManagementService.AddToOrganizationAsync(user);
+
+                        await _memberRolesManagementService.UpdateOrganizationMemberRolesAsync(member.Id,
+                            MemberRoles.Where(r => r.Value)
+                                .Select(r => r.Key)
+                                .ToArray());
+                    }
+                }
+                else
+                {
+                    await _organizationMemberManagementService.AddToOrganizationAsync(user);
+                }
+            }
+            catch (AccessViolationException e)
+            {
+                _logger.LogError(e, e.Message);
+                return Forbid();
+            }
+
             return RedirectToPage("./Index");
+        }
+
+        private async Task<IActionResult> PageAsync()
+        {
+            Organization = await _currentOrganizationAccessorService.GetCurrentOrganizationAsync(new OrganizationRetrievalOptions
+            {
+                LoadHostnames = true
+            });
+
+            MemberRoles ??= new Dictionary<string, bool> { { Roles.Admin, false } };
+
+            return Page();
         }
     }
 }

--- a/src/Eventuras.Web/Pages/Admin/Users/Edit.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Users/Edit.cshtml
@@ -1,52 +1,60 @@
 @page "{id}"
-@using Microsoft.AspNetCore.Identity
 @inject SignInManager<ApplicationUser> SignInManager
-@model Eventuras.Pages.Admin.Users.EditModel
+@model Eventuras.Web.Pages.Admin.Users.EditModel
 @{
     ViewData["Title"] = "Endre brukeropplysninger";
     Layout = "~/Pages/_Layout.cshtml";
 }
 <div class="container py-5 min-height-75">
-<h1>Endre brukeropplysninger</h1>
-<p class="lead">Endre hva som helst.</p>
+    <h1>Endre brukeropplysninger</h1>
+    <p class="lead">Endre hva som helst.</p>
 
-<div class="row">
-    <div class="col-md-4">
-        <partial name="_StatusMessage" model="Model.StatusMessage" />
+    <div class="row">
+        <div class="col-md-4">
+            <form method="post">
+                <div asp-validation-summary="All" class="text-danger"></div>
+                <div class="form-group">
+                    <label asp-for="Input.Name"></label>
+                    <input asp-for="Input.Name" class="form-control" />
+                    <span asp-validation-for="Input.Name" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Input.PhoneNumber"></label>
+                    <input asp-for="Input.PhoneNumber" class="form-control" />
+                    <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Input.Email"></label>
+                    <input asp-for="Input.Email" class="form-control" />
+                    <span asp-validation-for="Input.Email" class="text-danger"></span>
+                </div>
 
-        <form method="post">
-            <div asp-validation-summary="All" class="text-danger"></div>
-            <div class="form-group">
-                <label asp-for="Input.Name"></label>
-                <input asp-for="Input.Name" class="form-control" />
-                <span asp-validation-for="Input.Name" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Input.PhoneNumber"></label>
-                <input asp-for="Input.PhoneNumber" class="form-control" />
-                <span asp-validation-for="Input.PhoneNumber" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Input.Email"></label>
-                <input asp-for="Input.Email" class="form-control" />
-                <span asp-validation-for="Input.Email" class="text-danger"></span>
-            </div>
+                @if (Model.Organization != null && User.IsInRole(Roles.SuperAdmin))
+                {
+                    <div class="form-check">
+                        @Html.CheckBoxFor(model => model.Input.IsOrgMember, new { @class = "form-check-input", onchange = "javascript:enableRoleInputs(this.checked)" })
+                        <label asp-for="Input.IsOrgMember" class="form-check-label">Assosiert med @Model.Organization.NameAndHostname</label>
+                    </div>
+                }
 
-            @* SHOW SIGNATURE FIELD ONLY TO SUPERADMIN *@
-            @if (User.Identity.IsAuthenticated) {
-                @if ( User.IsInRole("SuperAdmin") ) {
+                <partial name="_UserFormRolesPartial" model="Model.MemberRoles" />
+
+                @* SHOW SIGNATURE FIELD ONLY TO SUPERADMIN *@
+                @if (User.IsInRole(Roles.SuperAdmin))
+                {
                     <div class="form-group">
                         <label asp-for="Input.SignatureImageBase64"></label>
                         <input asp-for="Input.SignatureImageBase64" class="form-control" />
                         <span asp-validation-for="Input.SignatureImageBase64" class="text-danger"></span>
                     </div>
                 }
-            }
-            <button type="submit" class="btn btn-success">Lagre</button>
-        </form>
+                <button type="submit" class="btn btn-success">Lagre</button>
+            </form>
+        </div>
     </div>
 </div>
 
 @section Scripts {
-   <partial name="_ValidationScriptsPartial" />
+    <partial name="_UserFormScriptsPartial" />
+    <partial name="_ValidationScriptsPartial" />
 }

--- a/src/Eventuras.Web/Pages/Admin/Users/Edit.cshtml.cs
+++ b/src/Eventuras.Web/Pages/Admin/Users/Edit.cshtml.cs
@@ -1,22 +1,38 @@
+using Eventuras.Domain;
+using Eventuras.Services;
+using Eventuras.Services.Organizations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using Eventuras.Domain;
 
-namespace Eventuras.Pages.Admin.Users
+namespace Eventuras.Web.Pages.Admin.Users
 {
     public class EditModel : PageModel
     {
         private readonly UserManager<ApplicationUser> _userManager;
+        private readonly ICurrentOrganizationAccessorService _currentOrganizationAccessorService;
+        private readonly IOrganizationMemberManagementService _organizationMemberManagementService;
+        private readonly IOrganizationMemberRolesManagementService _memberRolesManagementService;
+        private readonly ILogger<EditModel> _logger;
 
-        public EditModel(UserManager<ApplicationUser> userManager)
+        public EditModel(
+            UserManager<ApplicationUser> userManager,
+            ICurrentOrganizationAccessorService currentOrganizationAccessorService,
+            IOrganizationMemberManagementService organizationMemberManagementService,
+            IOrganizationMemberRolesManagementService memberRolesManagementService,
+            ILogger<EditModel> logger)
         {
-            _userManager = userManager;
+            _userManager = userManager ?? throw new ArgumentNullException(nameof(userManager));
+            _currentOrganizationAccessorService = currentOrganizationAccessorService ?? throw new ArgumentNullException(nameof(currentOrganizationAccessorService));
+            _organizationMemberManagementService = organizationMemberManagementService ?? throw new ArgumentNullException(nameof(organizationMemberManagementService));
+            _memberRolesManagementService = memberRolesManagementService ?? throw new ArgumentNullException(nameof(memberRolesManagementService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         [BindProperty]
@@ -39,12 +55,13 @@ namespace Eventuras.Pages.Admin.Users
             [Display(Name = "Signatur som Base64")]
             public string SignatureImageBase64 { get; set; }
 
+            public bool IsOrgMember { get; set; }
         }
 
+        public Organization Organization { get; set; }
 
-
-        [TempData]
-        public string StatusMessage { get; set; }
+        [BindProperty]
+        public Dictionary<string, bool> MemberRoles { get; set; }
 
         public async Task<IActionResult> OnGetAsync(string id)
         {
@@ -53,28 +70,14 @@ namespace Eventuras.Pages.Admin.Users
                 return NotFound();
             }
 
-            var user = await _userManager.FindByIdAsync(id);
-            if (user == null)
-            {
-                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
-            }
-
-            Input = new InputModel
-            {
-                Name = user.Name,
-                Email = user.Email,
-                PhoneNumber = user.PhoneNumber,
-                SignatureImageBase64 = user.SignatureImageBase64
-            };
-
-            return Page();
+            return await PageAsync(id);
         }
 
         public async Task<IActionResult> OnPostAsync(string id)
         {
             if (!ModelState.IsValid)
             {
-                return Page();
+                return await PageAsync(id);
             }
 
             var user = await _userManager.FindByIdAsync(id);
@@ -82,7 +85,6 @@ namespace Eventuras.Pages.Admin.Users
             {
                 throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
             }
-
 
             if (Input.Name != user.Name)
             {
@@ -127,8 +129,69 @@ namespace Eventuras.Pages.Admin.Users
                 }
             }
 
-            StatusMessage = "Profilen er oppdatert!";
-            return RedirectToPage();
+            try
+            {
+                if (User.IsInRole(Roles.SuperAdmin))
+                {
+                    if (Input.IsOrgMember)
+                    {
+                        var member = await _organizationMemberManagementService.AddToOrganizationAsync(user);
+
+                        await _memberRolesManagementService.UpdateOrganizationMemberRolesAsync(member.Id,
+                            MemberRoles.Where(r => r.Value)
+                                .Select(r => r.Key)
+                                .ToArray());
+                    }
+                    else
+                    {
+                        await _organizationMemberManagementService.RemoveFromOrganizationAsync(user);
+                    }
+                }
+            }
+            catch (AccessViolationException e)
+            {
+                _logger.LogError(e, e.Message);
+                return Forbid();
+            }
+
+            return RedirectToPage("Index");
+        }
+
+        private async Task<IActionResult> PageAsync(string id)
+        {
+            Organization ??= await _currentOrganizationAccessorService.GetCurrentOrganizationAsync(new OrganizationRetrievalOptions
+            {
+                LoadHostnames = true
+            });
+
+            var user = await _userManager.FindByIdAsync(id);
+            if (user == null)
+            {
+                throw new ApplicationException($"Unable to load user with ID '{_userManager.GetUserId(User)}'.");
+            }
+
+            var orgMember = await _organizationMemberManagementService
+                .FindOrganizationMemberAsync(user, Organization,
+                    new OrganizationMemberRetrievalOptions
+                    {
+                        LoadRoles = true
+                    });
+
+            Input = new InputModel
+            {
+                Name = user.Name,
+                Email = user.Email,
+                PhoneNumber = user.PhoneNumber,
+                SignatureImageBase64 = user.SignatureImageBase64,
+                IsOrgMember = orgMember != null
+            };
+
+            MemberRoles ??= new Dictionary<string, bool>
+            {
+                { Roles.Admin, orgMember?.HasRole(Roles.Admin) == true }
+            };
+
+            return Page();
         }
     }
 }

--- a/src/Eventuras.Web/Pages/Admin/Users/Index.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Users/Index.cshtml
@@ -1,5 +1,5 @@
 @page "{p:int?}"
-@model Eventuras.Pages.Admin.Users.IndexModel
+@model Eventuras.Web.Pages.Admin.Users.IndexModel
 @{
     ViewData["Title"] = "Brukere";
     Layout = "~/Pages/_Layout.cshtml";

--- a/src/Eventuras.Web/Pages/Admin/Users/Index.cshtml.cs
+++ b/src/Eventuras.Web/Pages/Admin/Users/Index.cshtml.cs
@@ -1,37 +1,17 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.EntityFrameworkCore;
-using Eventuras.Domain;
-using Microsoft.AspNetCore.Identity;
-using Eventuras.Infrastructure;
 
-namespace Eventuras.Pages.Admin.Users
+namespace Eventuras.Web.Pages.Admin.Users
 {
     public class IndexModel : PageModel
     {
-        private readonly ApplicationDbContext _context;
-        private readonly UserManager<ApplicationUser> _userManager;
-
-
-        public IndexModel(
-            ApplicationDbContext context,
-            UserManager<ApplicationUser> userManager
-            )
-
+        public IndexModel()
         {
-            _context = context;
-            _userManager = userManager;
         }
 
-        public List<ApplicationUser> Users { get; set; }
-
-        public async Task OnGetAsync()
+        public IActionResult OnGet()
         {
-            var users = await _userManager.Users.ToListAsync();
+            return Page();
         }
     }
 }

--- a/src/Eventuras.Web/Pages/Admin/Users/_UserFormRolesPartial.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Users/_UserFormRolesPartial.cshtml
@@ -1,0 +1,23 @@
+@model Dictionary<string, bool>
+
+@{ var i = 0; }
+@foreach (var (role, _) in Model)
+{
+    if (User.IsInRole(Roles.SuperAdmin))
+    {
+        <div class="form-check">
+            <label class="form-check-label">
+                @Html.Hidden($"MemberRoles[{i}].Key", role)
+                @Html.CheckBox($"MemberRoles[{i}].Value", Model[role], new { @class = "form-check-input role-checkbox" })
+                @role
+            </label>
+        </div>
+    }
+    else
+    {
+        // We still need to render something, otherwise anti-forgery check will fail (for unknown reason)
+        @Html.Hidden($"MemberRoles[{i}].Key", role)
+        @Html.Hidden($"MemberRoles[{i}].Value", Model[role])
+    }
+    i++;
+}

--- a/src/Eventuras.Web/Pages/Admin/Users/_UserFormScriptsPartial.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Users/_UserFormScriptsPartial.cshtml
@@ -1,0 +1,10 @@
+<script>
+    function enableRoleInputs(enable) {
+        var inputs = document.getElementsByClassName('role-checkbox');
+        for (var i = 0; i < inputs.length; ++i) {
+            var input = inputs[i];
+            input.disabled = !enable;
+            input.checked = input.checked && enable;
+        }
+    }
+</script>


### PR DESCRIPTION
 - Add users as org admins.
 - Only SuperAdmin can do that.
 - Admin can manage users (org members only).
 - SuperAdmin can manage all users.
 - Admins could manage org events (to be done next).

KNOWN ISSUES

 - There's no way to generate admin password now. TODO: Generate password button + send via Email?
 - Current users will not be marked as org members automatically (need to create org tree first). So nothing will be visible to admins until that.