### PR TITLE
Multi-tenancy, Part 4. Order access restriction. Little refactoring.

### DIFF
--- a/src/Eventuras.Services/Orders/IOrderService.cs
+++ b/src/Eventuras.Services/Orders/IOrderService.cs
@@ -1,11 +1,12 @@
-﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Eventuras.Domain;
 using static Eventuras.Domain.PaymentMethod;
 
-namespace Eventuras.Services
+namespace Eventuras.Services.Orders
 {
+    // FIXME: make refactoring, split into multiple services according to ISP and SRP
+
     public interface IOrderService
     {
         // Orders

--- a/src/Eventuras.Services/Orders/IOrderVmConversionService.cs
+++ b/src/Eventuras.Services/Orders/IOrderVmConversionService.cs
@@ -1,8 +1,8 @@
-using Eventuras.Domain;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Eventuras.Domain;
 
-namespace Eventuras.Services
+namespace Eventuras.Services.Orders
 {
     public interface IOrderVmConversionService
     {

--- a/src/Eventuras.Services/Orders/OrderQueryableExtensions.cs
+++ b/src/Eventuras.Services/Orders/OrderQueryableExtensions.cs
@@ -1,0 +1,37 @@
+using Eventuras.Domain;
+using System;
+using System.Linq;
+
+namespace Eventuras.Services.Orders
+{
+    internal static class OrderQueryableExtensions
+    {
+        public static IQueryable<Order> HavingOrganization(this IQueryable<Order> query, Organization organization)
+        {
+            if (organization == null)
+                throw new ArgumentNullException(nameof(organization));
+
+            return query.Where(o => o.Registration.EventInfo.OrganizationId == organization.OrganizationId);
+        }
+
+        public static IQueryable<Order> HavingNoOrganization(this IQueryable<Order> query)
+        {
+            return query.HavingNoOrganizationOr();
+        }
+
+        public static IQueryable<Order> HavingNoOrganizationOr(this IQueryable<Order> query, Organization organization = null)
+        {
+            if (organization != null)
+            {
+                query = query.Where(e => e.Registration.EventInfo.OrganizationId == null ||
+                                         e.Registration.EventInfo.OrganizationId == organization.OrganizationId);
+            }
+            else
+            {
+                query = query.Where(e => e.Registration.EventInfo.OrganizationId == null);
+            }
+
+            return query;
+        }
+    }
+}

--- a/src/Eventuras.Services/Orders/OrderServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services/Orders/OrderServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Eventuras.Services.Orders
+{
+    internal static class OrderServiceCollectionExtensions
+    {
+        public static void AddOrderServices(this IServiceCollection services)
+        {
+            services.AddScoped<IOrderService, OrderService>();
+            services.AddTransient<IOrderVmConversionService, OrderVmConversionService>();
+        }
+    }
+}

--- a/src/Eventuras.Services/Orders/OrderVmConversionService.cs
+++ b/src/Eventuras.Services/Orders/OrderVmConversionService.cs
@@ -1,14 +1,13 @@
-using Eventuras.Domain;
-using Eventuras.Infrastructure;
-using Microsoft.EntityFrameworkCore;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Eventuras.Domain;
+using Eventuras.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 
-namespace Eventuras.Services
+namespace Eventuras.Services.Orders
 {
-    public class OrderVmConversionService : IOrderVmConversionService
+    internal class OrderVmConversionService : IOrderVmConversionService
     {
         private readonly ApplicationDbContext context;
 

--- a/src/Eventuras.Services/RegistrationService.cs
+++ b/src/Eventuras.Services/RegistrationService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Eventuras.Services.Orders;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using static Eventuras.Domain.PaymentMethod;

--- a/src/Eventuras.Services/ServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Eventuras.Services.Auth;
 using Eventuras.Services.Events;
 using Eventuras.Services.Invoicing;
 using Eventuras.Services.ExternalSync;
+using Eventuras.Services.Orders;
 using Eventuras.Services.Organizations;
 using Eventuras.Services.Registrations;
 using Eventuras.Services.Users;
@@ -17,15 +18,14 @@ namespace Eventuras.Services
             services.AddScoped<StripeInvoiceProvider>();
             services.AddScoped<IRegistrationService, RegistrationService>();
             services.AddScoped<IProductsService, ProductsService>();
-            services.AddScoped<IOrderService, OrderService>();
             services.AddScoped<ICertificatesService, CertificatesService>();
             services.AddScoped<IMessageLogService, MessageLogService>();
-            services.AddTransient<IOrderVmConversionService, OrderVmConversionService>();
             services.AddRegistrationServices();
             services.AddOrganizationServices();
             services.AddUserServices();
             services.AddAuthServices();
             services.AddEventServices();
+            services.AddOrderServices();
             services.AddExternalSyncServices();
             return services;
         }

--- a/src/Eventuras.Web/Controllers/Api/V0/OrdersController.cs
+++ b/src/Eventuras.Web/Controllers/Api/V0/OrdersController.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using Eventuras.Services.Orders;
 using static Eventuras.Domain.Order;
 using static Eventuras.Domain.PaymentMethod;
 

--- a/src/Eventuras.Web/Controllers/Api/V0/PaymentsController.cs
+++ b/src/Eventuras.Web/Controllers/Api/V0/PaymentsController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Eventuras.Services.Invoicing;
 using Eventuras.Services;
+using Eventuras.Services.Orders;
 using Microsoft.AspNetCore.Mvc;
 using Stripe;
 

--- a/src/Eventuras.Web/Controllers/Api/V0/RegistrationsController.cs
+++ b/src/Eventuras.Web/Controllers/Api/V0/RegistrationsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Threading.Tasks;
+using Eventuras.Services.Orders;
 using static Eventuras.Domain.PaymentMethod;
 using static Eventuras.Domain.Registration;
 

--- a/src/Eventuras.Web/Pages/Admin/Events/AddRegistration.cshtml.cs
+++ b/src/Eventuras.Web/Pages/Admin/Events/AddRegistration.cshtml.cs
@@ -11,6 +11,7 @@ using Mapster;
 using static Eventuras.Domain.PaymentMethod;
 using Eventuras.Infrastructure;
 using Eventuras.Services.Events;
+using Eventuras.Services.Orders;
 
 namespace Eventuras.Pages.Admin.Events
 {

--- a/src/Eventuras.Web/Pages/Admin/Events/Orders.cshtml.cs
+++ b/src/Eventuras.Web/Pages/Admin/Events/Orders.cshtml.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Eventuras.Domain;
 using Eventuras.Services;
 using Eventuras.Services.Events;
+using Eventuras.Services.Orders;
 
 namespace Eventuras.Pages.Admin.Events
 {

--- a/src/Eventuras.Web/Pages/Admin/Orders/Details.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Orders/Details.cshtml
@@ -3,6 +3,7 @@
 @inject IProductsService productsService
 @inject IPaymentMethodService paymentmethodService
 @using Eventuras.Web.Pages.Admin.Orders
+@using Eventuras.Services.Orders
 @{
     var id = Convert.ToInt32(RouteData.Values["id"]);
     var order = await orderService.GetByIdAsync(id);

--- a/src/Eventuras.Web/Pages/Admin/Orders/Index.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Orders/Index.cshtml
@@ -1,4 +1,5 @@
 @page "{p:int?}"
+@using Eventuras.Services.Orders
 @inject IOrderService orderService
 @{
     int pageNumber = 1;


### PR DESCRIPTION
 - Move order services into Eventuras.Services.Orders namespace.
 - Add filtering of the orders by EventInfo.OrganizationId.
 - SuperAdmin can see all orders.
 - Admins can only see orders for events in their org.