### PR TITLE
Detaching entity after save.

### DIFF
--- a/src/Eventuras.Infrastructure/ApplicationDbContextExtensions.cs
+++ b/src/Eventuras.Infrastructure/ApplicationDbContextExtensions.cs
@@ -1,14 +1,28 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eventuras.Infrastructure
 {
     public static class ApplicationDbContextExtensions
     {
+        public static async Task CreateAsync<T>(this ApplicationDbContext context, T entity, CancellationToken cancellationToken = default)
+        {
+            await context.AddAsync(entity, cancellationToken);
+            await context.SaveChangesAsync(cancellationToken);
+            context.DisableChangeTracking(entity);
+        }
+
         public static async Task UpdateAsync<T>(this ApplicationDbContext context, T entity, CancellationToken cancellationToken = default)
         {
             context.Update(entity);
             await context.SaveChangesAsync(cancellationToken);
+            context.DisableChangeTracking(entity);
+        }
+
+        public static void DisableChangeTracking<T>(this ApplicationDbContext context, T entity)
+        {
+            context.Entry(entity).State = EntityState.Detached;
         }
     }
 }

--- a/src/Eventuras.Services/EventCollections/EventCollectionManagementService.cs
+++ b/src/Eventuras.Services/EventCollections/EventCollectionManagementService.cs
@@ -51,8 +51,7 @@ namespace Eventuras.Services.EventCollections
             {
                 throw new NotAccessibleException();
             }
-            await _context.EventCollections.AddAsync(collection, cancellationToken);
-            await _context.SaveChangesAsync(cancellationToken);
+            await _context.CreateAsync(collection, cancellationToken);
         }
 
         public async Task UpdateCollectionAsync(EventCollection collection, CancellationToken cancellationToken)

--- a/src/Eventuras.Services/EventCollections/EventCollectionMappingService.cs
+++ b/src/Eventuras.Services/EventCollections/EventCollectionMappingService.cs
@@ -47,8 +47,7 @@ namespace Eventuras.Services.EventCollections
 
             try
             {
-                await _context.EventCollectionMappings.AddAsync(mapping, cancellationToken);
-                await _context.SaveChangesAsync(cancellationToken);
+                await _context.CreateAsync(mapping, cancellationToken);
             }
             catch (DbUpdateException e) when (e.IsUniqueKeyViolation())
             {

--- a/src/Eventuras.Services/Events/EventManagementService.cs
+++ b/src/Eventuras.Services/Events/EventManagementService.cs
@@ -28,8 +28,7 @@ namespace Eventuras.Services.Events
                 throw new ArgumentNullException(nameof(info));
             }
 
-            await _context.EventInfos.AddAsync(info);
-            await _context.SaveChangesAsync();
+            await _context.CreateAsync(info);
         }
 
         public async Task UpdateEventAsync(EventInfo info)

--- a/src/Eventuras.Services/ExternalSync/AbstractExternalSyncProviderService.cs
+++ b/src/Eventuras.Services/ExternalSync/AbstractExternalSyncProviderService.cs
@@ -78,8 +78,7 @@ namespace Eventuras.Services.ExternalSync
 
             try
             {
-                await _context.ExternalRegistrations.AddAsync(externalRegistration);
-                await _context.SaveChangesAsync();
+                await _context.CreateAsync(externalRegistration);
             }
             catch (DbUpdateException e) when (e.IsUniqueKeyViolation())
             {
@@ -109,8 +108,7 @@ namespace Eventuras.Services.ExternalSync
 
             try
             {
-                await _context.ExternalAccounts.AddAsync(externalAccount);
-                await _context.SaveChangesAsync();
+                await _context.CreateAsync(externalAccount);
                 return externalAccount;
             }
             catch (DbUpdateException e) when (e.IsUniqueKeyViolation())

--- a/src/Eventuras.Services/ExternalSync/ExternalEventManagementService.cs
+++ b/src/Eventuras.Services/ExternalSync/ExternalEventManagementService.cs
@@ -62,11 +62,9 @@ namespace Eventuras.Services.ExternalSync
                 ExternalEventId = externalEventId
             };
 
-            await _context.AddAsync(newExternalEvent);
-
             try
             {
-                await _context.SaveChangesAsync();
+                await _context.CreateAsync(newExternalEvent);
             }
             catch (DbUpdateException e) when (e.IsUniqueKeyViolation())
             {

--- a/src/Eventuras.Services/Organizations/OrganizationManagementService.cs
+++ b/src/Eventuras.Services/Organizations/OrganizationManagementService.cs
@@ -40,8 +40,7 @@ namespace Eventuras.Services.Organizations
 
             try
             {
-                await _context.Organizations.AddAsync(organization);
-                await _context.SaveChangesAsync();
+                await _context.CreateAsync(organization);
             }
             catch (DbUpdateException e) when (e.IsUniqueKeyViolation())
             {
@@ -126,7 +125,7 @@ namespace Eventuras.Services.Organizations
                 }
                 else
                 {
-                    await _context.OrganizationHostnames.AddAsync(new OrganizationHostname
+                    await _context.CreateAsync(new OrganizationHostname
                     {
                         OrganizationId = id,
                         Hostname = hostname,

--- a/src/Eventuras.Services/Organizations/OrganizationMemberManagementService.cs
+++ b/src/Eventuras.Services/Organizations/OrganizationMemberManagementService.cs
@@ -76,8 +76,7 @@ namespace Eventuras.Services.Organizations
                         OrganizationId = organization.OrganizationId,
                         UserId = user.Id
                     };
-                    await _context.OrganizationMembers.AddAsync(member);
-                    await _context.SaveChangesAsync();
+                    await _context.CreateAsync(member);
                 }
                 catch (DbUpdateException e) when (e.IsUniqueKeyViolation())
                 {

--- a/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
+++ b/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eventuras.Services.Events;
 using Eventuras.Services.Users;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eventuras.Services.Registrations
 {
@@ -54,8 +55,7 @@ namespace Eventuras.Services.Registrations
 
             await _registrationAccessControlService.CheckRegistrationCreateAccessAsync(registration, cancellationToken);
 
-            await _context.Registrations.AddAsync(registration, cancellationToken);
-            await _context.SaveChangesAsync(cancellationToken);
+            await _context.CreateAsync(registration, cancellationToken);
 
             return registration;
         }


### PR DESCRIPTION
Trying to fix `The instance of entity type 'EventInfo' cannot be tracked because another instance with the same key value for {'EventInfoId'} is already being tracked. When attaching existing entities, ensure that only one entity instance with a given key value is attached. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the conflicting key values.``