### PR TITLE
Features/recaptcha

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY ./src/Eventuras.WebApi/*.csproj ./src/Eventuras.WebApi/
 COPY ./src/Eventuras.Services/*.csproj ./src/Eventuras.Services/
 COPY ./src/Eventuras.Services.Converto/*.csproj ./src/Eventuras.Services.Converto/
 COPY ./src/Eventuras.Services.Auth0/*.csproj ./src/Eventuras.Services.Auth0/
+COPY ./src/Eventuras.Services.Google.RecaptchaV3/*.csproj ./src/Eventuras.Services.Google.RecaptchaV3/
 COPY ./src/Eventuras.Services.PowerOffice/*.csproj ./src/Eventuras.Services.PowerOffice/
 COPY ./src/Eventuras.Services.Stripe/*.csproj ./src/Eventuras.Services.Stripe/
 COPY ./src/Eventuras.Services.TalentLms/*.csproj ./src/Eventuras.Services.TalentLms/

--- a/Eventuras.sln
+++ b/Eventuras.sln
@@ -41,6 +41,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eventuras.Services.PowerOff
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eventuras.Services.Stripe", "src\Eventuras.Services.Stripe\Eventuras.Services.Stripe.csproj", "{BED0F767-B5EB-4F98-A319-6A5185CFF159}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eventuras.Services.Google.RecaptchaV3", "src\Eventuras.Services.Google.RecaptchaV3\Eventuras.Services.Google.RecaptchaV3.csproj", "{64812344-6DD5-49F1-BBF5-3874A20B062B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -255,6 +257,18 @@ Global
 		{BED0F767-B5EB-4F98-A319-6A5185CFF159}.Release|x64.Build.0 = Release|Any CPU
 		{BED0F767-B5EB-4F98-A319-6A5185CFF159}.Release|x86.ActiveCfg = Release|Any CPU
 		{BED0F767-B5EB-4F98-A319-6A5185CFF159}.Release|x86.Build.0 = Release|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Debug|x64.Build.0 = Debug|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Debug|x86.Build.0 = Debug|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Release|x64.ActiveCfg = Release|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Release|x64.Build.0 = Release|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Release|x86.ActiveCfg = Release|Any CPU
+		{64812344-6DD5-49F1-BBF5-3874A20B062B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -277,6 +291,7 @@ Global
 		{E1A9972C-62ED-4468-89ED-CFD928974C8A} = {DBDA05E0-4065-4C83-8C2B-29C1A77BFA98}
 		{4CE167A4-1CC3-4652-A61B-05F1D2C300C4} = {B280334D-A924-4F2E-9AF3-BA7566335FB0}
 		{BED0F767-B5EB-4F98-A319-6A5185CFF159} = {B280334D-A924-4F2E-9AF3-BA7566335FB0}
+		{64812344-6DD5-49F1-BBF5-3874A20B062B} = {B280334D-A924-4F2E-9AF3-BA7566335FB0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {73E41161-D239-4EB6-8C90-A0FEA88D4E7C}

--- a/src/Eventuras.Services.Google.RecaptchaV3/Eventuras.Services.Google.RecaptchaV3.csproj
+++ b/src/Eventuras.Services.Google.RecaptchaV3/Eventuras.Services.Google.RecaptchaV3.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Eventuras.Services\Eventuras.Services.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="5.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/Eventuras.Services.Google.RecaptchaV3/IRecaptchaV3VerificationService.cs
+++ b/src/Eventuras.Services.Google.RecaptchaV3/IRecaptchaV3VerificationService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace Eventuras.Services.Google.RecaptchaV3
+{
+    public interface IRecaptchaV3VerificationService
+    {
+        Task<bool> VerifyTokenAsync(string token);
+    }
+}

--- a/src/Eventuras.Services.Google.RecaptchaV3/RecaptchaV3Config.cs
+++ b/src/Eventuras.Services.Google.RecaptchaV3/RecaptchaV3Config.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Eventuras.Services.Google.RecaptchaV3
+{
+    public class RecaptchaV3Config
+    {
+        public bool Enabled { get; set; }
+
+        [Required] public string ApiSecret { get; set; }
+
+        /// <summary>
+        /// Optional site key to be used for Recaptcha page rendering
+        /// (and this generating the captcha response token).
+        /// </summary>
+        public string SiteKey { get; set; }
+    }
+}

--- a/src/Eventuras.Services.Google.RecaptchaV3/RecaptchaV3ServiceCollectionExtensions.cs
+++ b/src/Eventuras.Services.Google.RecaptchaV3/RecaptchaV3ServiceCollectionExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Eventuras.Services.Google.RecaptchaV3
+{
+    public static class RecaptchaV3ServiceCollectionExtensions
+    {
+        public static IServiceCollection AddRecaptchaV3(
+            this IServiceCollection services,
+            IConfiguration configuration)
+        {
+            services.AddOptions<RecaptchaV3Config>()
+                .ValidateDataAnnotations()
+                .Bind(configuration);
+
+            services.AddScoped<IRecaptchaV3VerificationService, RecaptchaV3VerificationService>();
+            return services;
+        }
+    }
+}

--- a/src/Eventuras.Services.Google.RecaptchaV3/RecaptchaV3VerificationService.cs
+++ b/src/Eventuras.Services.Google.RecaptchaV3/RecaptchaV3VerificationService.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+
+namespace Eventuras.Services.Google.RecaptchaV3
+{
+    public class RecaptchaV3VerificationService : IRecaptchaV3VerificationService
+    {
+        private const string ApiUrl = "https://www.google.com/recaptcha/api/siteverify";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IOptions<RecaptchaV3Config> _options;
+        private readonly ILogger<RecaptchaV3VerificationService> _logger;
+
+        public RecaptchaV3VerificationService(
+            IHttpClientFactory httpClientFactory,
+            IOptions<RecaptchaV3Config> options,
+            ILogger<RecaptchaV3VerificationService> logger)
+        {
+            _httpClientFactory = httpClientFactory ?? throw
+                new ArgumentNullException(nameof(httpClientFactory));
+
+            _options = options ?? throw
+                new ArgumentNullException(nameof(options));
+
+            _logger = logger ?? throw
+                new ArgumentNullException(nameof(logger));
+        }
+
+        public async Task<bool> VerifyTokenAsync(string token)
+        {
+            if (string.IsNullOrEmpty(token))
+            {
+                throw new ArgumentNullException(nameof(token));
+            }
+
+            var client = _httpClientFactory.CreateClient();
+            var response = await client.PostAsync(ApiUrl,
+                new FormUrlEncodedContent(
+                    new KeyValuePair<string, string>[]
+                    {
+                        new("secret", _options.Value.ApiSecret),
+                        new("response", token)
+                    }));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Non-successful response returned by captcha verification API: {Code}",
+                    response.StatusCode);
+
+                var message = await response.Content.ReadAsStringAsync();
+                _logger.LogDebug("Response message: {Message}", message);
+
+                return false;
+            }
+
+            var content = await response.Content.ReadAsStringAsync();
+            var json = JToken.Parse(content);
+            if (!json.Any())
+            {
+                _logger.LogWarning("Invalid JSON returned by captcha verification API: {Content}", content);
+                return false;
+            }
+
+            _logger.LogDebug("JSON returned: {Content}", content);
+            return json.Value<bool>("success");
+        }
+    }
+}

--- a/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
+++ b/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
@@ -37,7 +37,9 @@ namespace Eventuras.Services.Registrations
 
             _context = context ?? throw
                 new ArgumentNullException(nameof(context));
-            _registrationOrderManagementService = registrationOrderManagementService;
+
+            _registrationOrderManagementService = registrationOrderManagementService ?? throw
+                new ArgumentNullException(nameof(registrationOrderManagementService));
         }
 
         public async Task<Registration> CreateRegistrationAsync(

--- a/src/Eventuras.Web/Eventuras.Web.csproj
+++ b/src/Eventuras.Web/Eventuras.Web.csproj
@@ -44,6 +44,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Eventuras.Services.Auth0\Eventuras.Services.Auth0.csproj" />
     <ProjectReference Include="..\Eventuras.Services.Converto\Eventuras.Services.Converto.csproj" />
+    <ProjectReference Include="..\Eventuras.Services.Google.RecaptchaV3\Eventuras.Services.Google.RecaptchaV3.csproj" />
     <ProjectReference Include="..\Eventuras.Services.PowerOffice\Eventuras.Services.PowerOffice.csproj" />
     <ProjectReference Include="..\Eventuras.Services.Stripe\Eventuras.Services.Stripe.csproj" />
     <ProjectReference Include="..\Eventuras.Services.TalentLms\Eventuras.Services.TalentLms.csproj" />

--- a/src/Eventuras.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Eventuras.Web/Extensions/ServiceCollectionExtensions.cs
@@ -30,6 +30,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using System.Globalization;
 using System.Net.Http.Headers;
+using Eventuras.Services.Google.RecaptchaV3;
 using Eventuras.Services.Organizations.Settings;
 using Eventuras.Services.PowerOffice;
 using Eventuras.Services.Stripe;
@@ -241,6 +242,8 @@ namespace Eventuras.Web.Extensions
 
             // Add Health Checks
             services.AddApplicationHealthChecks(configuration.GetSection(Constants.HealthCheckConfigurationKey));
+
+            services.AddRecaptchaV3(configuration.GetSection("Google:RecaptchaV3"));
 
             // Added for the renderpage service
             services.AddHttpContextAccessor();

--- a/src/Eventuras.Web/Pages/Events/Register/Index.cshtml
+++ b/src/Eventuras.Web/Pages/Events/Register/Index.cshtml
@@ -1,6 +1,9 @@
 ﻿@page "{id:int}"
 @model Eventuras.Web.Pages.Events.Register.EventRegistrationModel
 @using static Eventuras.Domain.PaymentMethod;
+@using Microsoft.Extensions.Options
+@using Eventuras.Services.Google.RecaptchaV3
+@inject IOptions<RecaptchaV3Config> _options
 @{
     ViewData["Title"] = Model.EventInfo.Title + "- Påmelding";
 
@@ -21,7 +24,8 @@
 }
 
 @if (Model.EventInfo.Status == Eventuras.Domain.EventInfo.EventInfoStatus.RegistrationsOpen) {
-    <form method="post">
+    <form method="post" id="reg-form">
+    <input type="hidden" asp-for="Registration.CaptchaResponse" id="reg-captcha-response">
         <div class="row justify-content-between py-3">
             <div class="col-md-9">
                 <div class="form-group">
@@ -191,7 +195,10 @@
 
 
                 <div class="form-group py-3">
-                    <input type="submit" value="Registrer meg" class="btn btn-lg btn-success" />
+                    <input type="submit" value="Registrer meg" class="btn btn-lg btn-success g-recaptcha"
+                           data-sitekey="@_options.Value.SiteKey" 
+                                   data-callback='onSubmit' 
+                                   data-action='submit'/>
                 </div>
 
                     </div>
@@ -209,6 +216,13 @@
     }
 </script>
 @section Scripts {
+    <script src="https://www.google.com/recaptcha/api.js"></script>
+    <script>
+        function onSubmit(token) {
+            document.getElementById('reg-captcha-response').value = token;
+            document.getElementById("reg-form").submit();
+        }
+    </script>
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
 }
 

--- a/src/Eventuras.Web/Pages/Events/Register/RegisterVM.cs
+++ b/src/Eventuras.Web/Pages/Events/Register/RegisterVM.cs
@@ -76,6 +76,8 @@ namespace Eventuras.Web.Pages.Events.Register
 
         public RegistrationStatus Status { get; set; } = RegistrationStatus.Draft;
         public RegistrationType Type { get; set; } = RegistrationType.Participant;
+        
+        public string CaptchaResponse { get; set; }
 
         public RegisterVM() { }
         public RegisterVM(EventInfo eventinfo, PaymentProvider? defaultPaymentMethod = null)

--- a/tests/Eventuras.Web.Tests/CustomWebApplicationFactory.cs
+++ b/tests/Eventuras.Web.Tests/CustomWebApplicationFactory.cs
@@ -33,6 +33,8 @@ namespace Eventuras.IntegrationTests
                         {"AppSettings:SmsProvider", "Mock"},
                         {"AppSettings:UsePowerOffice", "false"},
                         {"AppSettings:UseStripeInvoice", "false"},
+                        {"Google:RecaptchaV3:ApiSecret", "anything"},
+                        {"Google:RecaptchaV3:Enabled", "false"},
                         {"SuperAdmin:Email", TestingConstants.SuperAdminEmail},
                         {"SuperAdmin:Password", TestingConstants.SuperAdminPassword}
                     }))


### PR DESCRIPTION
Integrated with ReCaptcha3 (invisible one).
    
It calculates score transparently to user, and sends it to the server as a hidden input field. No user input is required.

Setup requires registering captcha keys here: https://www.google.com/recaptcha/admin/create and then putting them into config as `Google:RecaptchaV3:SiteKey` and `Google:RecaptchaV3:ApiSecret` correspondingly. Also set `Google:RecaptchaV3:Enabled` to `true` to enable recaptcha check.

NOTE: once merged, you have to add these two App config params to have it working!