### PR TITLE
feat: add new properties to ProductDto

### DIFF
--- a/src/Eventuras.WebApi/Controllers/Events/Products/ProductDto.cs
+++ b/src/Eventuras.WebApi/Controllers/Events/Products/ProductDto.cs
@@ -22,6 +22,12 @@ namespace Eventuras.WebApi.Controllers.Events.Products
 
         public ProductVariantDto[] Variants { get; set; }
 
+        public int MinimumQuantity { get; set; }
+
+        public bool IsMandatory => MinimumQuantity > 0;
+
+        public bool EnableQuantity { get; set; }
+
 
         public ProductDto()
         {
@@ -45,6 +51,8 @@ namespace Eventuras.WebApi.Controllers.Events.Products
                 .Where(v => !v.Archived)
                 .Select(v => new ProductVariantDto(v))
                 .ToArray() ?? Array.Empty<ProductVariantDto>();
+            MinimumQuantity = product.MinimumQuantity;
+            EnableQuantity = product.EnableQuantity;
         }
     }
 }


### PR DESCRIPTION
Closes #592

Added three properties to the DTO: "minimumQuantity", "isMandatory" and "enableQuantity", as requested in #592 

Now response JSON looks like this:
```json
[
  {
    "productId": 2,
    "name": "First product",
    "description": "1513",
    "more": null,
    "price": 64,
    "vatPercent": 0,
    "visibility": "Event",
    "variants": [],
    "minimumQuantity": 30,
    "isMandatory": true,
    "enableQuantity": false
  },
  {
    "productId": 1,
    "name": " Second product",
    "description": "asdf",
    "more": null,
    "price": 23,
    "vatPercent": 0,
    "visibility": "Event",
    "variants": [],
    "minimumQuantity": 1,
    "isMandatory": true,
    "enableQuantity": false
  }
]
```