### PR TITLE
Feat 617

### DIFF
--- a/src/Eventuras.Domain/EventInfo.cs
+++ b/src/Eventuras.Domain/EventInfo.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Runtime.ConstrainedExecution;
 using NodaTime;
 
 namespace Eventuras.Domain
@@ -117,7 +116,7 @@ namespace Eventuras.Domain
         [Display(Name = "Diplomtekst. Inkluder kursnummer og godkjenninger her!")]
         [DataType(DataType.MultilineText)]
         public string CertificateDescription { get; set; } //Text for the certificate if issued.
-        
+
         [NotMapped]
         public string CertificateEvidenceDescription
         {
@@ -148,6 +147,8 @@ namespace Eventuras.Domain
         public string ProjectCode { get; set; }
 
         public int OrganizationId { get; set; }
+
+        public EventInfoOptions Options { get; set; } = new();
 
         // Consider to remove this
         public bool Archived { get; set; }

--- a/src/Eventuras.Domain/EventInfoOptions.cs
+++ b/src/Eventuras.Domain/EventInfoOptions.cs
@@ -8,7 +8,7 @@ public class EventInfoOptions
 
     public class EventInfoRegistrationPolicy
     {
-        public int? AllowedRegistrationEditHours { get; set; } = null;
-        public bool AllowModificationsAfterCancellationDue { get; set; } = true;
+        public int? AllowedRegistrationEditHours { get; set; } = 24;
+        public bool AllowModificationsAfterLastCancellationDate { get; set; } = false;
     }
 }

--- a/src/Eventuras.Domain/EventInfoOptions.cs
+++ b/src/Eventuras.Domain/EventInfoOptions.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+
+namespace Eventuras.Domain;
+
+public class EventInfoOptions
+{
+    public EventInfoRegistrationPolicy RegistrationPolicy { get; set; } = new();
+
+    public class EventInfoRegistrationPolicy
+    {
+        public int? AllowedRegistrationEditHours { get; set; } = null;
+        public bool AllowModificationsAfterCancellationDue { get; set; } = true;
+    }
+}

--- a/src/Eventuras.Infrastructure/ApplicationDbContext.cs
+++ b/src/Eventuras.Infrastructure/ApplicationDbContext.cs
@@ -1,7 +1,7 @@
+using System.Linq;
 using Eventuras.Domain;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using System.Linq;
 
 namespace Eventuras.Infrastructure
 {
@@ -77,6 +77,15 @@ namespace Eventuras.Infrastructure
             //     .HasIndex(o => o.Code)
             //     .HasFilter($@"""{nameof(EventInfo.Archived)}"" = false")
             //     .IsUnique();
+
+            var eventInfo = builder.Entity<EventInfo>();
+            eventInfo.OwnsOne(e => e.Options,
+                b1 =>
+                {
+                    b1.OwnsOne(opt => opt.RegistrationPolicy);
+                    b1.Navigation(opt => opt.RegistrationPolicy).IsRequired();
+                });
+            eventInfo.Navigation(e => e.Options).IsRequired();
 
             builder.Entity<EventCollection>()
                 .HasMany(c => c.Events)

--- a/src/Eventuras.Infrastructure/Migrations/20230829115517_EventInfo_AddOptionsWithPolicies.Designer.cs
+++ b/src/Eventuras.Infrastructure/Migrations/20230829115517_EventInfo_AddOptionsWithPolicies.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eventuras.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eventuras.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230829115517_EventInfo_AddOptionsWithPolicies")]
+    partial class EventInfo_AddOptionsWithPolicies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Eventuras.Infrastructure/Migrations/20230829115517_EventInfo_AddOptionsWithPolicies.cs
+++ b/src/Eventuras.Infrastructure/Migrations/20230829115517_EventInfo_AddOptionsWithPolicies.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eventuras.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class EventInfo_AddOptionsWithPolicies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Options_RegistrationPolicy_AllowModificationsAfterCancellation~",
+                table: "EventInfos",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Options_RegistrationPolicy_AllowedRegistrationEditHours",
+                table: "EventInfos",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE public."EventInfos"
+                SET "Options_RegistrationPolicy_AllowModificationsAfterCancellation~" = true;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Options_RegistrationPolicy_AllowModificationsAfterCancellation~",
+                table: "EventInfos");
+
+            migrationBuilder.DropColumn(
+                name: "Options_RegistrationPolicy_AllowedRegistrationEditHours",
+                table: "EventInfos");
+        }
+    }
+}

--- a/src/Eventuras.Infrastructure/Migrations/20230906111207_EventInfo_AddOptionsWithPolicies.Designer.cs
+++ b/src/Eventuras.Infrastructure/Migrations/20230906111207_EventInfo_AddOptionsWithPolicies.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eventuras.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20230829115517_EventInfo_AddOptionsWithPolicies")]
+    [Migration("20230906111207_EventInfo_AddOptionsWithPolicies")]
     partial class EventInfo_AddOptionsWithPolicies
     {
         /// <inheritdoc />
@@ -1324,7 +1324,7 @@ namespace Eventuras.Infrastructure.Migrations
                                     b2.Property<int>("EventInfoOptionsEventInfoId")
                                         .HasColumnType("integer");
 
-                                    b2.Property<bool>("AllowModificationsAfterCancellationDue")
+                                    b2.Property<bool>("AllowModificationsAfterLastCancellationDate")
                                         .HasColumnType("boolean");
 
                                     b2.Property<int?>("AllowedRegistrationEditHours")

--- a/src/Eventuras.Infrastructure/Migrations/20230906111207_EventInfo_AddOptionsWithPolicies.cs
+++ b/src/Eventuras.Infrastructure/Migrations/20230906111207_EventInfo_AddOptionsWithPolicies.cs
@@ -11,7 +11,7 @@ namespace Eventuras.Infrastructure.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<bool>(
-                name: "Options_RegistrationPolicy_AllowModificationsAfterCancellation~",
+                name: "Options_RegistrationPolicy_AllowModificationsAfterLastCancella~",
                 table: "EventInfos",
                 type: "boolean",
                 nullable: false,
@@ -26,7 +26,7 @@ namespace Eventuras.Infrastructure.Migrations
             migrationBuilder.Sql(
                 """
                 UPDATE public."EventInfos"
-                SET "Options_RegistrationPolicy_AllowModificationsAfterCancellation~" = true;
+                SET "Options_RegistrationPolicy_AllowedRegistrationEditHours" = 24;
                 """);
         }
 
@@ -34,7 +34,7 @@ namespace Eventuras.Infrastructure.Migrations
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(
-                name: "Options_RegistrationPolicy_AllowModificationsAfterCancellation~",
+                name: "Options_RegistrationPolicy_AllowModificationsAfterLastCancella~",
                 table: "EventInfos");
 
             migrationBuilder.DropColumn(

--- a/src/Eventuras.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Eventuras.Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1321,7 +1321,7 @@ namespace Eventuras.Infrastructure.Migrations
                                     b2.Property<int>("EventInfoOptionsEventInfoId")
                                         .HasColumnType("integer");
 
-                                    b2.Property<bool>("AllowModificationsAfterCancellationDue")
+                                    b2.Property<bool>("AllowModificationsAfterLastCancellationDate")
                                         .HasColumnType("boolean");
 
                                     b2.Property<int?>("AllowedRegistrationEditHours")

--- a/src/Eventuras.Services/Certificates/CertificateRetrievalService.cs
+++ b/src/Eventuras.Services/Certificates/CertificateRetrievalService.cs
@@ -61,7 +61,7 @@ namespace Eventuras.Services.Certificates
 
             // TODO: add accessibility filter!
 
-            return await Paging<Certificate>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
     }
 }

--- a/src/Eventuras.Services/Events/EventInfoRetrievalService.cs
+++ b/src/Eventuras.Services/Events/EventInfoRetrievalService.cs
@@ -59,7 +59,7 @@ namespace Eventuras.Services.Events
                 query = await AddOrgFilterIfNeededAsync(query, cancellationToken);
             }
 
-            return await Paging<EventInfo>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
 
         private async Task<IQueryable<EventInfo>> AddOrgFilterIfNeededAsync(

--- a/src/Eventuras.Services/IntenalsVisibleTo.cs
+++ b/src/Eventuras.Services/IntenalsVisibleTo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Eventuras.Services.Tests")] // unit tests

--- a/src/Eventuras.Services/Notifications/NotificationRecipientRetrievalService.cs
+++ b/src/Eventuras.Services/Notifications/NotificationRecipientRetrievalService.cs
@@ -38,7 +38,7 @@ namespace Eventuras.Services.Notifications
                     .AddAccessFilterAsync(query, cancellationToken);
             }
 
-            return await Paging<Notification>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
     }
 }

--- a/src/Eventuras.Services/Notifications/NotificationRetrievalService.cs
+++ b/src/Eventuras.Services/Notifications/NotificationRetrievalService.cs
@@ -65,7 +65,7 @@ namespace Eventuras.Services.Notifications
                     .AddAccessFilterAsync(query, cancellationToken);
             }
 
-            return await Paging<Notification>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
     }
 }

--- a/src/Eventuras.Services/Orders/OrderRetrievalService.cs
+++ b/src/Eventuras.Services/Orders/OrderRetrievalService.cs
@@ -57,7 +57,7 @@ namespace Eventuras.Services.Orders
                     .AddAccessFilterAsync(query, cancellationToken);
             }
 
-            return await Paging<Registration>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
     }
 }

--- a/src/Eventuras.Services/Paging.cs
+++ b/src/Eventuras.Services/Paging.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,12 +9,12 @@ namespace Eventuras.Services
     public class Paging<T>
     {
         /// <summary>
-        /// Data for this page. 
+        /// Data for this page.
         /// </summary>
         public T[] Data { get; }
 
         /// <summary>
-        /// Total of records for this query. 
+        /// Total of records for this query.
         /// </summary>
         public int TotalRecords { get; }
 
@@ -22,23 +23,32 @@ namespace Eventuras.Services
             Data = data;
             TotalRecords = totalRecords;
         }
+    }
 
-        public static async Task<Paging<TP>> CreateAsync<TP>(
-            IQueryable<TP> query,
+    public static class Paging
+    {
+        public static async Task<Paging<T>> CreateAsync<T>(
+            IQueryable<T> query,
             PagingRequest request,
             CancellationToken cancellationToken = default)
         {
             var count = await query.CountAsync(cancellationToken);
-            var data = await query
-                .Skip(request.Offset)
-                .Take(request.Limit)
-                .ToArrayAsync(cancellationToken);
-            return new Paging<TP>(data, count);
+            var data = count == 0 ? Array.Empty<T>() : await query.Skip(request.Offset).Take(request.Limit).ToArrayAsync(cancellationToken);
+
+            return new Paging<T>(data, count);
         }
 
-        public static Paging<TP> Empty<TP>()
+        public static Paging<T> Create<T>(IQueryable<T> query, PagingRequest request)
         {
-            return new Paging<TP>(new TP[0], 0);
+            var count = query.Count();
+            var data = count == 0 ? Array.Empty<T>() : query.Skip(request.Offset).Take(request.Limit).ToArray();
+
+            return new Paging<T>(data, count);
+        }
+
+        public static Paging<T> Empty<T>()
+        {
+            return new Paging<T>(Array.Empty<T>(), 0);
         }
     }
 }

--- a/src/Eventuras.Services/Registrations/RegistrationAccessControlService.cs
+++ b/src/Eventuras.Services/Registrations/RegistrationAccessControlService.cs
@@ -80,7 +80,7 @@ namespace Eventuras.Services.Registrations
                 if (currDuration > maxDuration) throw new NotAccessibleException("Registration is too old to be updated.");
             }
 
-            if (!registrationPolicy.AllowModificationsAfterCancellationDue && eventInfo.LastCancellationDate != null)
+            if (!registrationPolicy.AllowModificationsAfterLastCancellationDate && eventInfo.LastCancellationDate != null)
             {
                 if (DateTimeOffset.UtcNow > eventInfo.LastCancellationDate.Value.ToDateTimeUnspecified())
                     throw new NotAccessibleException("Registration can not be updated after event's last cancellation date.");

--- a/src/Eventuras.Services/Registrations/RegistrationRetrievalService.cs
+++ b/src/Eventuras.Services/Registrations/RegistrationRetrievalService.cs
@@ -87,7 +87,7 @@ namespace Eventuras.Services.Registrations
                     .AddAccessFilterAsync(query, cancellationToken);
             }
 
-            return await Paging<Registration>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
     }
 }

--- a/src/Eventuras.Services/Users/UserRetrievalService.cs
+++ b/src/Eventuras.Services/Users/UserRetrievalService.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
 using Eventuras.Services.Auth;
@@ -5,9 +8,6 @@ using Eventuras.Services.Exceptions;
 using Eventuras.Services.Organizations;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace Eventuras.Services.Users
 {
@@ -91,7 +91,7 @@ namespace Eventuras.Services.Users
                 var user = _httpContextAccessor.HttpContext.User;
                 if (!user.IsAdmin())
                 {
-                    return Paging<ApplicationUser>.Empty<ApplicationUser>();
+                    return Paging.Empty<ApplicationUser>();
                 }
 
                 if (!user.IsSuperAdmin())
@@ -104,7 +104,7 @@ namespace Eventuras.Services.Users
                 }
             }
 
-            return await Paging<ApplicationUser>.CreateAsync(query, request, cancellationToken);
+            return await Paging.CreateAsync(query, request, cancellationToken);
         }
     }
 }

--- a/src/Eventuras.WebApi/Controllers/Events/EventFormDto.cs
+++ b/src/Eventuras.WebApi/Controllers/Events/EventFormDto.cs
@@ -1,19 +1,19 @@
-using Eventuras.Domain;
-using Eventuras.WebApi.Models;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using Eventuras.Domain;
 using NodaTime;
 
 namespace Eventuras.WebApi.Controllers.Events
 {
     public class EventFormDto : IValidatableObject
     {
-
         [Required]
         public string Title { get; set; }
+
         [Required]
         public string Slug { get; set; }
+
         public EventInfo.EventInfoType Type { get; set; } = EventInfo.EventInfoType.Course;
         public EventInfo.EventInfoStatus Status { get; set; } = EventInfo.EventInfoStatus.Draft;
         public int OrganizationId { get; set; }
@@ -28,13 +28,11 @@ namespace Eventuras.WebApi.Controllers.Events
         public string City { get; set; }
         public LocalDate? StartDate { get; set; }
         public LocalDate? EndDate { get; set; }
+        public EventInfoOptionsDto Options { get; set; } = new(new());
 
         public void CopyTo(EventInfo eventInfo)
         {
-            if (eventInfo == null)
-            {
-                throw new ArgumentNullException(nameof(eventInfo));
-            }
+            if (eventInfo == null) { throw new ArgumentNullException(nameof(eventInfo)); }
 
             eventInfo.Type = Type;
             eventInfo.Status = Status;
@@ -52,6 +50,31 @@ namespace Eventuras.WebApi.Controllers.Events
             eventInfo.City = City;
             eventInfo.DateStart = StartDate;
             eventInfo.DateEnd = EndDate;
+            eventInfo.Options = Options.MapToEntity();
+        }
+
+        public static EventFormDto FromEntity(EventInfo entity)
+        {
+            return new EventFormDto
+            {
+                Title = entity.Title,
+                Slug = entity.Slug,
+                Type = entity.Type,
+                Status = entity.Status,
+                OrganizationId = entity.OrganizationId,
+                Category = entity.Category,
+                Description = entity.Description,
+                ManageRegistrations = entity.ManageRegistrations,
+                OnDemand = entity.OnDemand,
+                Featured = entity.Featured,
+                Program = entity.Program,
+                PracticalInformation = entity.PracticalInformation,
+                Location = entity.Location,
+                City = entity.City,
+                StartDate = entity.DateStart,
+                EndDate = entity.DateEnd,
+                Options = EventInfoOptionsDto.MapFromEntity(entity.Options),
+            };
         }
 
         public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
@@ -59,8 +82,8 @@ namespace Eventuras.WebApi.Controllers.Events
             if (StartDate.HasValue && EndDate.HasValue && StartDate.Value > EndDate.Value)
             {
                 yield return new ValidationResult("start date must precede end date", new List<string>
-                {
-                    nameof(StartDate),
+                        {
+                            nameof(StartDate),
                     nameof(EndDate)
                 });
             }

--- a/src/Eventuras.WebApi/Controllers/Events/EventInfoOptionsDto.cs
+++ b/src/Eventuras.WebApi/Controllers/Events/EventInfoOptionsDto.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+
+using System.ComponentModel.DataAnnotations;
+using Eventuras.Domain;
+
+namespace Eventuras.WebApi.Controllers.Events;
+
+public record EventInfoOptionsDto(EventInfoOptionsDto.EventInfoRegistrationPolicyDto RegistrationPolicy)
+{
+    public EventInfoOptions MapToEntity()
+    {
+        var registrationPolicy = new EventInfoOptions.EventInfoRegistrationPolicy
+        {
+            AllowedRegistrationEditHours = RegistrationPolicy.AllowedRegistrationEditHours,
+            AllowModificationsAfterCancellationDue = RegistrationPolicy.AllowModificationsAfterCancellationDue
+        };
+
+        return new EventInfoOptions { RegistrationPolicy = registrationPolicy };
+    }
+
+    public static EventInfoOptionsDto MapFromEntity(EventInfoOptions entity)
+    {
+        return new EventInfoOptionsDto(new EventInfoRegistrationPolicyDto(entity.RegistrationPolicy.AllowedRegistrationEditHours,
+            entity.RegistrationPolicy.AllowModificationsAfterCancellationDue));
+    }
+
+    public record EventInfoRegistrationPolicyDto(
+        [Range(0, 365 * 24)] int? AllowedRegistrationEditHours = 24,
+        bool AllowModificationsAfterCancellationDue = false);
+};

--- a/src/Eventuras.WebApi/Controllers/Events/EventInfoOptionsDto.cs
+++ b/src/Eventuras.WebApi/Controllers/Events/EventInfoOptionsDto.cs
@@ -12,7 +12,7 @@ public record EventInfoOptionsDto(EventInfoOptionsDto.EventInfoRegistrationPolic
         var registrationPolicy = new EventInfoOptions.EventInfoRegistrationPolicy
         {
             AllowedRegistrationEditHours = RegistrationPolicy.AllowedRegistrationEditHours,
-            AllowModificationsAfterCancellationDue = RegistrationPolicy.AllowModificationsAfterCancellationDue
+            AllowModificationsAfterLastCancellationDate = RegistrationPolicy.AllowModificationsAfterCancellationDue
         };
 
         return new EventInfoOptions { RegistrationPolicy = registrationPolicy };
@@ -21,7 +21,7 @@ public record EventInfoOptionsDto(EventInfoOptionsDto.EventInfoRegistrationPolic
     public static EventInfoOptionsDto MapFromEntity(EventInfoOptions entity)
     {
         return new EventInfoOptionsDto(new EventInfoRegistrationPolicyDto(entity.RegistrationPolicy.AllowedRegistrationEditHours,
-            entity.RegistrationPolicy.AllowModificationsAfterCancellationDue));
+            entity.RegistrationPolicy.AllowModificationsAfterLastCancellationDate));
     }
 
     public record EventInfoRegistrationPolicyDto(

--- a/tests/Eventuras.Services.Tests/HttpContextAccessorUtils.cs
+++ b/tests/Eventuras.Services.Tests/HttpContextAccessorUtils.cs
@@ -1,0 +1,21 @@
+﻿#nullable enable
+
+using System.Linq;
+using System.Security.Claims;
+
+namespace Eventuras.Services.Tests;
+
+public static class HttpContextAccessorUtils
+{
+    public static ClaimsPrincipal GetUser(string userId, params string[] roles)
+    {
+        var identity = new ClaimsIdentity();
+        identity.AddClaim(new(ClaimTypes.NameIdentifier, userId ));
+        identity.AddClaims(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+
+        var principal = new ClaimsPrincipal();
+        principal.AddIdentity(identity);
+
+        return principal;
+    }
+}

--- a/tests/Eventuras.Services.Tests/Registrations/RegistrationAccessControlServiceTests.cs
+++ b/tests/Eventuras.Services.Tests/Registrations/RegistrationAccessControlServiceTests.cs
@@ -1,0 +1,205 @@
+﻿#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Eventuras.Domain;
+using Eventuras.Services.Events;
+using Eventuras.Services.Exceptions;
+using Eventuras.Services.Organizations;
+using Eventuras.Services.Registrations;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using NodaTime;
+using Xunit;
+using static Eventuras.Services.Tests.HttpContextAccessorUtils;
+
+namespace Eventuras.Services.Tests.Registrations;
+
+public class RegistrationAccessControlServiceTests
+{
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithDefaultEventInfoOptions_PassesForOwner()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+
+        var ei = new EventInfo();
+        var reg = new Registration { UserId = userId, EventInfoId = ei.EventInfoId, EventInfo = ei };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None);
+
+        // Assert
+        eiMock.Verify(s => s.GetEventInfoByIdAsync(It.IsAny<int>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithDefaultEventInfoOptions_ThrowsForNonOwner()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+        var otherUserId = Guid.NewGuid().ToString();
+
+        var ei = new EventInfo();
+        var reg = new Registration { UserId = otherUserId, EventInfoId = ei.EventInfoId, EventInfo = ei };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await Assert.ThrowsAsync<NotAccessibleException>(
+            async () => await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None));
+
+        // Assert
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithDefaultEventInfoOptions_PassesForAdmin()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId, Roles.SuperAdmin);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+        var otherUserId = Guid.NewGuid().ToString();
+
+        var ei = new EventInfo();
+        var reg = new Registration { UserId = otherUserId, EventInfoId = ei.EventInfoId, EventInfo = ei };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None);
+
+        // Assert
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithAllowedRegistrationEditHours_PassesBeforeDue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+
+        var policy = new EventInfoOptions.EventInfoRegistrationPolicy { AllowedRegistrationEditHours = 24 };
+        var ei = new EventInfo { Options = new EventInfoOptions { RegistrationPolicy = policy } };
+        var reg = new Registration { UserId = userId, EventInfoId = ei.EventInfoId, EventInfo = ei };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None);
+
+        // Assert
+        eiMock.Verify(s => s.GetEventInfoByIdAsync(It.IsAny<int>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithAllowedRegistrationEditHours_ThrowsAfterDue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+
+        var policy = new EventInfoOptions.EventInfoRegistrationPolicy { AllowedRegistrationEditHours = 24 };
+        var ei = new EventInfo { Options = new EventInfoOptions { RegistrationPolicy = policy } };
+        var registrationTime = Instant.FromDateTimeUtc(DateTime.UtcNow.AddDays(-2));
+        var reg = new Registration { UserId = userId, EventInfoId = ei.EventInfoId, EventInfo = ei, RegistrationTime = registrationTime };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await Assert.ThrowsAsync<NotAccessibleException>(
+            async () => await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None));
+
+        // Assert
+        eiMock.Verify(s => s.GetEventInfoByIdAsync(It.IsAny<int>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithCancellationDueLimit_PassesBeforeDue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+
+        var policy = new EventInfoOptions.EventInfoRegistrationPolicy { AllowModificationsAfterCancellationDue = false };
+        var cancellationDue = LocalDate.FromDateTime(DateTime.UtcNow.AddDays(1));
+        var ei = new EventInfo { Options = new EventInfoOptions { RegistrationPolicy = policy }, LastCancellationDate = cancellationDue };
+        var reg = new Registration { UserId = userId, EventInfoId = ei.EventInfoId, EventInfo = ei };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None);
+
+        // Assert
+        eiMock.Verify(s => s.GetEventInfoByIdAsync(It.IsAny<int>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task CheckRegistrationUpdateAccessAsync_WithCancellationDueLimit_ThrowsAfterDue()
+    {
+        // Arrange
+        var userId = Guid.NewGuid().ToString();
+        var user = GetUser(userId);
+        HttpContextAccessor.HttpContext = new DefaultHttpContext { User = user };
+
+        var policy = new EventInfoOptions.EventInfoRegistrationPolicy { AllowModificationsAfterCancellationDue = false };
+        var cancellationDue = LocalDate.FromDateTime(DateTime.UtcNow.AddDays(-2));
+        var ei = new EventInfo { Options = new EventInfoOptions { RegistrationPolicy = policy }, LastCancellationDate = cancellationDue };
+        var reg = new Registration { UserId = userId, EventInfoId = ei.EventInfoId, EventInfo = ei };
+
+        var eventInfoRetrievalService = ServiceMocks.MockEventInfoRetrievalService(out var eiMock, ei);
+        var organizationAccessorService = Mock.Of<ICurrentOrganizationAccessorService>(MockBehavior.Strict); // should not be called
+
+        var testSubject = new RegistrationAccessControlService(HttpContextAccessor, eventInfoRetrievalService, organizationAccessorService);
+
+        // Act
+        await Assert.ThrowsAsync<NotAccessibleException>(
+            async () => await testSubject.CheckRegistrationUpdateAccessAsync(reg, CancellationToken.None));
+
+        // Assert
+        eiMock.Verify(s => s.GetEventInfoByIdAsync(It.IsAny<int>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        eiMock.VerifyNoOtherCalls();
+    }
+
+    private static readonly IHttpContextAccessor HttpContextAccessor = new HttpContextAccessor();
+}

--- a/tests/Eventuras.Services.Tests/ServiceMocks.cs
+++ b/tests/Eventuras.Services.Tests/ServiceMocks.cs
@@ -1,0 +1,36 @@
+﻿using System.Linq;
+using System.Threading;
+using Eventuras.Domain;
+using Eventuras.Services.Events;
+using Eventuras.Services.Exceptions;
+using Moq;
+
+namespace Eventuras.Services.Tests;
+
+public static class ServiceMocks
+{
+    public static IEventInfoRetrievalService MockEventInfoRetrievalService(out Mock<IEventInfoRetrievalService> mock, params EventInfo[] eventInfos)
+    {
+        mock = new Mock<IEventInfoRetrievalService>();
+
+        mock.Setup(s => s.GetEventInfoByIdAsync(It.IsAny<int>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((int id, EventInfoRetrievalOptions _, CancellationToken _) =>
+            {
+                var found = eventInfos.FirstOrDefault(ei => ei.EventInfoId == id) ?? throw new NotFoundException();
+                return found;
+            })
+            .Verifiable();
+
+        mock.Setup(s => s.ListEventsAsync(It.IsAny<EventListRequest>(), It.IsAny<EventInfoRetrievalOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((EventListRequest request, EventInfoRetrievalOptions _, CancellationToken _) =>
+            {
+                var query = eventInfos.AsQueryable();
+                query = query.UseFilter(request.Filter);
+                query = query.UseOrder(request.Order);
+                return Paging.Create(query, request);
+            })
+            .Verifiable();
+
+        return mock.Object;
+    }
+}

--- a/tests/Eventuras.Web.Tests/Controllers/Api/V0/OrdersControllerTest.cs
+++ b/tests/Eventuras.Web.Tests/Controllers/Api/V0/OrdersControllerTest.cs
@@ -173,11 +173,11 @@ namespace Eventuras.Web.Tests.Controllers.Api.V0
             var lines = info.Lines.ToArray();
             Assert.Equal(3, info.Lines.Count);
 
-            var orderLine = lines[0];
+            var orderLine = lines.Single(l => l.Type == InvoiceLineType.Text);
             Assert.Equal(InvoiceLineType.Text, orderLine.Type);
             Assert.Equal($"Deltakelse for {user.Entity.Name} på {eventInfo.Entity.Title}", orderLine.Description);
 
-            var productVariantLine = lines[1];
+            var productVariantLine = lines.First(l => l.Type == InvoiceLineType.Product && l.ProductCode.Contains('-'));
             Assert.Equal(InvoiceLineType.Product, productVariantLine.Type);
             Assert.Equal($"{product.Entity.Name} ({variant.Entity.Name})", productVariantLine.Description);
             Assert.Equal($"K{product.Entity.ProductId}-{variant.Entity.ProductVariantId}",
@@ -187,7 +187,7 @@ namespace Eventuras.Web.Tests.Controllers.Api.V0
             Assert.Equal(1, productVariantLine.Quantity);
             Assert.Equal(1050, productVariantLine.Total);
 
-            var noVariantLine = lines[2];
+            var noVariantLine = lines.First(l => l.Type == InvoiceLineType.Product && !l.ProductCode.Contains('-'));
             Assert.Equal(InvoiceLineType.Product, noVariantLine.Type);
             Assert.Equal(anotherProduct.Entity.Name, noVariantLine.Description);
             Assert.Equal($"K{anotherProduct.Entity.ProductId}", noVariantLine.ProductCode);


### PR DESCRIPTION
Closes #617 

Implements two policy parameters:
* AllowedRegistrationEditHours - amount of time the user (owner) is allowed to update his registration. Set null to disable check. Default null.
* AllowModificationsAfterCancellationDue - flag of allowance of update after event info last cancellation date. Set false to enable check. Default true.

Use PUT or PATCH endpoint of `/v3/events/{id}` to change settings

```json 
{ 
  // ... rest of EventFromDto model
  "options": {
    "registrationPolicy": {
      "allowedRegistrationEditHours": "<integer>",
      "allowModificationsAfterCancellationDue": "<boolean>"
    }
  }
  // ... rest of EventFormDto model
}
```

On policy violation 403 is returned