### PR TITLE
fix: remove dates from edit event

### DIFF
--- a/src/Eventuras.Web/Pages/Admin/Events/Edit.cshtml
+++ b/src/Eventuras.Web/Pages/Admin/Events/Edit.cshtml
@@ -116,32 +116,7 @@
                     <span asp-validation-for="EventInfo.City" class="text-danger"></span>
                 </div>
                 <hr>
-                <h2>Datoer</h2>
-                <div class="row">
-                    <div class="form-group col-md-6">
-                        <label asp-for="EventInfo.DateStart" class="control-label"></label>
-                        <input asp-for="EventInfo.DateStart" class="form-control" />
-                        <span asp-validation-for="EventInfo.DateStart" class="text-danger"></span>
-                    </div>
-                    <div class="form-group col-md-6">
-                        <label asp-for="EventInfo.DateEnd" class="control-label"></label>
-                        <input asp-for="EventInfo.DateEnd" class="form-control" />
-                        <span asp-validation-for="EventInfo.DateEnd" class="text-danger"></span>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="form-group col-md-6">
-                        <label asp-for="EventInfo.LastRegistrationDate" class="control-label"></label>
-                        <input asp-for="EventInfo.LastRegistrationDate" class="form-control" />
-                        <span asp-validation-for="EventInfo.LastRegistrationDate" class="text-danger"></span>
-                    </div>
-                    <div class="form-group col-md-6">
-                        <label asp-for="EventInfo.LastCancellationDate" class="control-label"></label>
-                        <input asp-for="EventInfo.LastCancellationDate" class="form-control" />
-                        <span asp-validation-for="EventInfo.LastCancellationDate" class="text-danger"></span>
-                    </div>
-                </div>
-                <hr>
+                
                 <h2>Diplom</h2>
                 <div class="form-group">
                     <label asp-for="EventInfo.CertificateDescription" class="control-label"></label>


### PR DESCRIPTION
the dates disappears when editing events,
removing dates from the classic admin ui