### PR TITLE
feat: implement dynamic sorting by column name

### DIFF
--- a/src/Eventuras.Infrastructure/QueryableExtensions.cs
+++ b/src/Eventuras.Infrastructure/QueryableExtensions.cs
@@ -1,0 +1,121 @@
+﻿#nullable enable
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Eventuras.Infrastructure;
+
+public static class QueryableExtensions
+{
+    public static IOrderedQueryable<TEntity> OrderByColumn<TEntity>(this IQueryable<TEntity> query, string columnName)
+    {
+        var expression = GetPropertyAccessExpression<TEntity>(columnName);
+        return query.OrderBy(expression);
+    }
+
+    public static IOrderedQueryable<TEntity> ThenByColumn<TEntity>(this IOrderedQueryable<TEntity> query, string columnName)
+    {
+        var expression = GetPropertyAccessExpression<TEntity>(columnName);
+        return query.ThenBy(expression);
+    }
+
+    public static IOrderedQueryable<TEntity> OrderByColumnDescending<TEntity>(this IQueryable<TEntity> query, string columnName)
+    {
+        var expression = GetPropertyAccessExpression<TEntity>(columnName);
+        return query.OrderByDescending(expression);
+    }
+
+    public static IOrderedQueryable<TEntity> ThenByColumnDescending<TEntity>(this IOrderedQueryable<TEntity> query, string columnName)
+    {
+        var expression = GetPropertyAccessExpression<TEntity>(columnName);
+        return query.ThenByDescending(expression);
+    }
+
+    /// <summary>
+    /// Sorts query by multiple columns.
+    /// </summary>
+    /// <param name="query">Query to sort.</param>
+    /// <param name="defaultOrder">Default order by expression, if <paramref name="ordering"/> is an empty array.</param>
+    /// <param name="defaultOrderDescending">Default order direction.</param>
+    /// <param name="ordering">List of sort parameters.</param>
+    /// <typeparam name="TEntity">Type of the entity.</typeparam>
+    /// <returns>Sorted query.</returns>
+    public static IOrderedQueryable<TEntity> OrderByColumns<TEntity>(
+        this IQueryable<TEntity> query,
+        Expression<Func<TEntity, object?>> defaultOrder,
+        bool defaultOrderDescending,
+        (string ColumnName, bool Descending)[] ordering)
+    {
+        if (ordering.Length == 0) return defaultOrderDescending ? query.OrderByDescending(defaultOrder) : query.OrderBy(defaultOrder);
+
+        IOrderedQueryable<TEntity> oq = null!;
+        var first = true;
+
+        foreach (var order in ordering)
+        {
+            if (first)
+            {
+                oq = order.Descending ? query.OrderByColumnDescending(order.ColumnName) : query.OrderByColumn(order.ColumnName);
+                first = false;
+            }
+            else { oq = order.Descending ? oq.ThenByColumnDescending(order.ColumnName) : oq.ThenByColumn(order.ColumnName); }
+        }
+
+        return oq;
+    }
+
+    public static IOrderedQueryable<TEntity> OrderByColumns<TEntity>(
+        this IQueryable<TEntity> query,
+        Expression<Func<TEntity, object?>> defaultOrder,
+        bool defaultOrderDescending,
+        string[] columnsAndDirections)
+    {
+        var ordering = new (string, bool)[columnsAndDirections.Length];
+        for (var i = 0; i < columnsAndDirections.Length; i++)
+        {
+            ordering[i] = SplitColumnNameAndOrderDirection(columnsAndDirections[i]);
+        }
+        
+        return OrderByColumns(query, defaultOrder, defaultOrderDescending, ordering);
+    }
+
+    /// <summary>
+    /// Splits mixed column name and order direction in separate parameters.
+    /// </summary>
+    /// <remarks>
+    /// Column name is extracted from string until last column (":" symbol).
+    /// Order direction will be descending only if string ends in ":desc" or ":descending".
+    /// </remarks>
+    /// <param name="columnAndDirection">Mixed information on sorting. Allowed format: "(columnName)[:(desc|descending)]".</param>
+    /// <returns>Parameters for sorting.</returns>
+    public static (string ColumnName, bool Descending) SplitColumnNameAndOrderDirection(string columnAndDirection)
+    {
+        // sanitize whitespaces
+        var trimmed = columnAndDirection.AsSpan().Trim();
+
+        // check if string has ":"
+        var columnIndex = trimmed.LastIndexOf(':');
+        if (columnIndex == -1) return (columnAndDirection, false);
+
+        // check last word is ":desc" or ":descending"
+        var ending = trimmed[(columnIndex + 1)..];
+        var descending = ending.Equals("desc", StringComparison.InvariantCultureIgnoreCase)
+                      || ending.Equals("descending", StringComparison.InvariantCultureIgnoreCase);
+
+        return (trimmed[..columnIndex].ToString(), descending);
+    }
+
+    private static Expression<Func<TEntity, object>> GetPropertyAccessExpression<TEntity>(string propertyName)
+    {
+        var parameter = Expression.Parameter(typeof(TEntity), "entity");
+        var property = typeof(TEntity).GetProperty(propertyName, BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance);
+
+        if (property == null) throw new ArgumentException($"Property with name '{propertyName}' was not found on type '{typeof(TEntity)}'.");
+
+        var propertyAccess = Expression.Property(parameter, property);
+        var convert = Expression.Convert(propertyAccess, typeof(object));
+        return Expression.Lambda<Func<TEntity, object>>(convert, parameter);
+    }
+}

--- a/src/Eventuras.Services/Events/EventInfoRetrievalService.cs
+++ b/src/Eventuras.Services/Events/EventInfoRetrievalService.cs
@@ -52,7 +52,7 @@ namespace Eventuras.Services.Events
                 .AsNoTracking()
                 .UseOptions(options ?? new EventInfoRetrievalOptions())
                 .UseFilter(request.Filter)
-                .UseOrder(request.Order);
+                .UseOrder(request.Ordering);
 
             if (request.Filter.AccessibleOnly)
             {
@@ -66,7 +66,7 @@ namespace Eventuras.Services.Events
             IQueryable<EventInfo> query,
             CancellationToken cancellationToken)
         {
-            var principal = _httpContextAccessor.HttpContext.User;
+            var principal = _httpContextAccessor.HttpContext!.User;
             if (principal.IsAnonymous())
             {
                 var organization = await _currentOrganizationAccessorService

--- a/src/Eventuras.Services/Events/EventInfoRetrievalServiceExtensions.cs
+++ b/src/Eventuras.Services/Events/EventInfoRetrievalServiceExtensions.cs
@@ -99,7 +99,7 @@ namespace Eventuras.Services.Events
                     service.ListEventsAsync(new EventListRequest(offset, limit)
                     {
                         Filter = EventInfoFilter.OnDemandEvents(filter),
-                        Order = EventRetrievalOrder.Title
+                        Ordering = new[] { "title:asc" }
                     }, options, token), cancellationToken))
                 .ToList();
         }

--- a/src/Eventuras.Services/Events/EventListRequest.cs
+++ b/src/Eventuras.Services/Events/EventListRequest.cs
@@ -2,20 +2,8 @@ namespace Eventuras.Services.Events
 {
     public class EventListRequest : PagingRequest
     {
-        public EventListRequest()
-        {
-        }
+        public EventListRequest(int offset, int limit) : base(offset, limit) { }
 
-        public EventListRequest(int offset, int limit) : base(offset, limit)
-        {
-        }
-
-        public EventListRequest(PagingRequest request) : base(request)
-        {
-        }
-
-        public EventInfoFilter Filter { get; set; } = new EventInfoFilter();
-
-        public EventRetrievalOrder Order { get; set; } = EventRetrievalOrder.StartDate;
+        public EventInfoFilter Filter { get; init; } = new EventInfoFilter();
     }
 }

--- a/src/Eventuras.Services/Events/EventQueryableExtensions.cs
+++ b/src/Eventuras.Services/Events/EventQueryableExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using NodaTime;
 using System;
 using System.Linq;
+using Eventuras.Infrastructure;
 
 namespace Eventuras.Services.Events
 {
@@ -163,20 +164,9 @@ namespace Eventuras.Services.Events
             return query;
         }
 
-        public static IQueryable<EventInfo> UseOrder(this IQueryable<EventInfo> query, EventRetrievalOrder order)
+        public static IQueryable<EventInfo> UseOrder(this IQueryable<EventInfo> query, string[] columnsAndDirections)
         {
-            switch (order)
-            {
-                case EventRetrievalOrder.Title:
-                    query = query.OrderBy(e => e.Title);
-                    break;
-
-                default:
-                    query = query.OrderBy(e => e.DateStart);
-                    break;
-            }
-
-            return query;
+            return query.OrderByColumns(ei => ei.DateStart, false, columnsAndDirections);
         }
 
         public static IQueryable<EventInfo> HavingOrganization(this IQueryable<EventInfo> query,

--- a/src/Eventuras.Services/PagingRequest.cs
+++ b/src/Eventuras.Services/PagingRequest.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 
 namespace Eventuras.Services
@@ -12,49 +14,33 @@ namespace Eventuras.Services
         /// </summary>
         public const int MaxRecordsPerPage = 250;
 
-        private int _offset;
-        private int _limit = MaxRecordsPerPage;
+        private readonly int _offset;
+        private readonly int _limit = MaxRecordsPerPage;
 
-        public PagingRequest()
-        {
-        }
+        public PagingRequest() { }
 
         public PagingRequest(int offset, int limit)
         {
-            if (offset < 0)
-            {
-                throw new ArgumentException("negative offset", nameof(offset));
-            }
+            if (offset < 0) { throw new ArgumentException("negative offset", nameof(offset)); }
 
-            if (limit < 0)
-            {
-                throw new ArgumentException("negative limit", nameof(offset));
-            }
+            if (limit < 0) { throw new ArgumentException("negative limit", nameof(offset)); }
 
             Offset = offset;
             Limit = limit;
         }
 
-        public PagingRequest(PagingRequest request)
-        {
-            if (request == null)
-            {
-                return;
-            }
-            Offset = request.Offset;
-            Limit = request.Limit;
-        }
-
         public int Offset
         {
-            get => _offset;
-            set => _offset = Math.Max(0, value);
+            get => _offset; 
+            init => _offset = Math.Max(0, value);
         }
 
         public int Limit
         {
-            get => _limit;
-            set => _limit = Math.Min(MaxRecordsPerPage, value);
+            get => _limit; 
+            init => _limit = Math.Min(MaxRecordsPerPage, value);
         }
+
+        public string[] Ordering { get; init; } = Array.Empty<string>();
     }
 }

--- a/src/Eventuras.WebApi/Controllers/v3/Events/EventsController.cs
+++ b/src/Eventuras.WebApi/Controllers/v3/Events/EventsController.cs
@@ -53,7 +53,8 @@ namespace Eventuras.WebApi.Controllers.v3.Events
 
             var events = await _eventInfoService.ListEventsAsync(new EventListRequest(query.Offset, query.Limit)
             {
-                Filter = query.ToEventInfoFilter()
+                Filter = query.ToEventInfoFilter(),
+                Ordering = query.Ordering,
             },
             cancellationToken: cancellationToken);
 
@@ -61,7 +62,6 @@ namespace Eventuras.WebApi.Controllers.v3.Events
             _logger.LogInformation("Successfully retrieved the events list.");
 
             return PageResponseDto<EventDto>.FromPaging(query, events, e => new EventDto(e));
-
         }
 
         // GET: v3/events/5

--- a/src/Eventuras.WebApi/Models/PageQueryDto.cs
+++ b/src/Eventuras.WebApi/Models/PageQueryDto.cs
@@ -1,3 +1,5 @@
+#nullable enable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 
@@ -6,13 +8,15 @@ namespace Eventuras.WebApi.Models
     public class PageQueryDto
     {
         [Range(1, int.MaxValue)]
-        public int Page { get; set; } = 1;
+        public int Page { get; init; } = 1;
 
         [Range(0, 250)]
-        public int Count { get; set; } = 100;
+        public int Count { get; init; } = 100;
 
         public int Limit => Count;
 
         public int Offset => (Page - 1) * Count;
+
+        public string[] Ordering { get; init; } = Array.Empty<string>();
     }
 }

--- a/tests/Eventuras.Services.Tests/ServiceMocks.cs
+++ b/tests/Eventuras.Services.Tests/ServiceMocks.cs
@@ -26,7 +26,7 @@ public static class ServiceMocks
             {
                 var query = eventInfos.AsQueryable();
                 query = query.UseFilter(request.Filter);
-                query = query.UseOrder(request.Order);
+                query = query.UseOrder(request.Ordering);
                 return Paging.Create(query, request);
             })
             .Verifiable();


### PR DESCRIPTION
Closes #666 (kinda evil) and #667

Implementation details:
Provide column name, followed by sort direction. For example:
`/events?ordering=title:asc`.
Allowed values for sorting direction are `desc` and `descending`. Any other text (or it's absence) is interpreted as ascending.

To sort by multiple columns, provide column names as follows:
`/events?ordering=title&ordering=description:desc`.
Notice query parameter `ordering` is specified twice.

Important note on issue #666: sorting dates descending is not automatic, please specify direction manually (`:desc`).
Due to complexity it brings.
