### PR TITLE
Enabled status filtering on participant list

### DIFF
--- a/apps/web/playwright-e2e/001-admin-event-create-registration.spec.ts
+++ b/apps/web/playwright-e2e/001-admin-event-create-registration.spec.ts
@@ -1,9 +1,13 @@
 /* eslint no-process-env: 0 */
 
 import { test } from '@playwright/test';
-import fs from 'fs';
 
-import { addProductToEvent, checkIfAccessToAdmin, createEvent, writeCreatedEvent } from './functions';
+import {
+  addProductToEvent,
+  checkIfAccessToAdmin,
+  createEvent,
+  writeCreatedEvent,
+} from './functions';
 
 test.describe.configure({ mode: 'serial' });
 const eventName = `This is a playwright event - ${Math.floor(Date.now() / 1000 / 10)}`;
@@ -16,7 +20,7 @@ test.describe('create event and add products to it', () => {
   });
   test('create simple event', async ({ page }) => {
     eventId = await createEvent(page, eventName);
-    writeCreatedEvent(eventId)
+    writeCreatedEvent(eventId);
   });
 
   test('add products to event', async ({ page }) => {

--- a/apps/web/playwright-e2e/002a-user-register-for-event.spec.ts
+++ b/apps/web/playwright-e2e/002a-user-register-for-event.spec.ts
@@ -1,15 +1,20 @@
 /* eslint no-process-env: 0 */
 
 import { test } from '@playwright/test';
-import fs from 'fs'
+
 import Logger from '@/utils/Logger';
 
-import { checkIfLoggedIn, readCreatedEvent, registerForEvent, validateRegistration } from './functions';
+import {
+  checkIfLoggedIn,
+  readCreatedEvent,
+  registerForEvent,
+  validateRegistration,
+} from './functions';
 test.describe.configure({ mode: 'serial' });
 test.use({ storageState: 'playwright-auth/user.json' });
 
 test.describe('register for event', () => {
-  let createdEvent = readCreatedEvent()
+  const createdEvent = readCreatedEvent();
   test.beforeAll(() => {
     if (!createdEvent.eventId) {
       Logger.error(

--- a/apps/web/playwright-e2e/002b-user-edit-event-products.spec.ts
+++ b/apps/web/playwright-e2e/002b-user-edit-event-products.spec.ts
@@ -13,7 +13,6 @@ test.skip('edit event products', () => {
     await checkIfLoggedIn(page);
   });
 
-
   test('edit event products', async ({ page }) => {
     await editRegistrationOrders(page, readCreatedEvent().eventId);
   });

--- a/apps/web/playwright-e2e/003-anonymous-register-through-event-registration.spec.ts
+++ b/apps/web/playwright-e2e/003-anonymous-register-through-event-registration.spec.ts
@@ -20,7 +20,7 @@ const userName = `${tagAndNs.nameSpace}.newuser-${Math.floor(
   Date.now() / 1000 / 10
 )}@inbox.testmail.app`;
 test.describe('should be able to register as an anonymous user when hitting the event registration page', () => {
-  const createdEvent = readCreatedEvent()
+  const createdEvent = readCreatedEvent();
   test('registration button should be visible for anonymous users', async ({ page }) => {
     await visitAndClickEventRegistrationButton(page, createdEvent.eventId);
     ///api/auth/signin?callbackUrl=%2Fuser%2Fevents%2F6%2Fregistration

--- a/apps/web/playwright-e2e/003-anonymous-visit-unautherized-pages.spec.ts
+++ b/apps/web/playwright-e2e/003-anonymous-visit-unautherized-pages.spec.ts
@@ -6,7 +6,6 @@ import { checkIfUnAuthorized, readCreatedEvent } from './functions';
 
 test.describe.configure({ mode: 'serial' });
 
-
 test.describe('should not be authorized on the following pages', () => {
   const unAuthorizedUris = [
     '/admin',

--- a/apps/web/playwright-e2e/functions.ts
+++ b/apps/web/playwright-e2e/functions.ts
@@ -1,27 +1,25 @@
 const ns = { namespace: 'e2e' };
 import { chromium, expect, Page, test as setup } from '@playwright/test';
-import fs from 'fs'
+import fs from 'fs';
+
 import Logger from '@/utils/Logger';
 
 import { fetchLoginCode } from './utils';
 type CreatedEvent = {
-  eventId: string
-}
+  eventId: string;
+};
 export const readCreatedEvent = (): CreatedEvent => {
-  let createdEvent: CreatedEvent = { eventId: "-1" }
+  let createdEvent: CreatedEvent = { eventId: '-1' };
   try {
-
-    createdEvent = JSON.parse(fs.readFileSync('./playwright-e2e/createdEvent.json', 'utf8'))
-  } catch (e: any) {
-
-  }
-  return createdEvent
-}
+    createdEvent = JSON.parse(fs.readFileSync('./playwright-e2e/createdEvent.json', 'utf8'));
+  } catch (e: any) {}
+  return createdEvent;
+};
 
 export const writeCreatedEvent = (eventId: string) => {
   const eventToStore = JSON.stringify({ eventId });
   fs.writeFileSync('./playwright-e2e/createdEvent.json', eventToStore);
-}
+};
 export const authenticate = async (userName: string, authFile: string) => {
   setup.use({
     locale: 'en-GB',
@@ -89,7 +87,7 @@ export const createEvent = async (page: Page, eventName: string) => {
 
   await page.getByRole('option', { name: 'RegistrationsOpen' }).click();
 
-  await page.getByRole('tab', { name: 'Advanced' }).click()
+  await page.getByRole('tab', { name: 'Advanced' }).click();
 
   const eventId = await page.locator('[data-test-id="eventeditor-form-eventid"]').inputValue();
   Logger.info(ns, `Event id from test: ${eventId}`);

--- a/apps/web/src/app/admin/events/EventStatistics.tsx
+++ b/apps/web/src/app/admin/events/EventStatistics.tsx
@@ -1,32 +1,53 @@
+'use client';
 import { EventStatisticsDto } from '@losol/eventuras';
 import createTranslation from 'next-translate/createTranslation';
 
 import NumberCard from '@/components/ui/NumberCard';
+import { ParticipationTypes, ParticipationTypesKey } from '@/types';
 
 type EventStatisticsProps = {
   statistics: EventStatisticsDto;
+  highlightedSelection: string;
+  onSelectionChanged: (selection: string) => void;
 };
 
-const EventStatistics: React.FC<EventStatisticsProps> = ({ statistics }) => {
+const EventStatistics: React.FC<EventStatisticsProps> = ({
+  statistics,
+  onSelectionChanged,
+  highlightedSelection,
+}) => {
   const { t } = createTranslation();
   const byStatus = statistics ? statistics.byStatus : null;
-
   const counts = {
-    participants:
+    [ParticipationTypes.participants]:
       (byStatus?.draft ?? 0) +
       (byStatus?.verified ?? 0) +
       (byStatus?.attended ?? 0) +
       (byStatus?.finished ?? 0) +
       (byStatus?.notAttended ?? 0),
-    waitingList: byStatus?.waitingList ?? 0,
-    cancelled: byStatus?.cancelled ?? 0,
+    [ParticipationTypes.waitingList]: byStatus?.waitingList ?? 0,
+    [ParticipationTypes.cancelled]: byStatus?.cancelled ?? 0,
+  };
+
+  const toggleSelection = (currentSelection: ParticipationTypes) => {
+    onSelectionChanged(currentSelection);
   };
 
   return (
     <div className="grid gap-1 grid-cols-3  md:grid-cols-4 break-words">
-      <NumberCard number={counts.participants} label={t('common:labels.participants')} />
-      <NumberCard number={counts.waitingList} label={t('common:labels.waitingList')} />
-      <NumberCard number={counts.cancelled} label={t('common:labels.cancelled')} />
+      {Object.keys(ParticipationTypes).map((key: string) => {
+        const k = key as ParticipationTypesKey;
+        const className = highlightedSelection === key ? 'font-bold border' : '';
+        return (
+          <button
+            key={key}
+            onClick={() => toggleSelection(ParticipationTypes[k])}
+            className={className}
+          >
+            <NumberCard number={counts[k]} label={t(`common:labels.${key}`)} />
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/apps/web/src/app/admin/events/[id]/ParticipantsSection.tsx
+++ b/apps/web/src/app/admin/events/[id]/ParticipantsSection.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { EventDto, ProductDto, RegistrationDto } from '@losol/eventuras';
+import { EventStatisticsDto } from '@losol/eventuras/dist/models/EventStatisticsDto';
+import { useMemo, useState } from 'react';
+
+import { Container } from '@/components/ui';
+import Section from '@/components/ui/Section';
+import { ParticipationTypes, ParticipationTypesKey } from '@/types';
+
+import EventParticipantList from '../EventParticipantList';
+import EventStatistics from '../EventStatistics';
+
+export type ParticipantsSectionProps = {
+  statistics: EventStatisticsDto;
+  participants: RegistrationDto[];
+  eventInfo: EventDto;
+  eventProducts: ProductDto[];
+};
+
+const initialSelectedStatistics = {
+  [ParticipationTypes.participants]: false,
+  [ParticipationTypes.waitingList]: false,
+  [ParticipationTypes.cancelled]: false,
+};
+
+export type StatisticsSelection = typeof initialSelectedStatistics;
+
+const ParticipantsSection: React.FC<ParticipantsSectionProps> = props => {
+  const [selectedStatistic, setSelectedStatistic] =
+    useState<StatisticsSelection>(initialSelectedStatistics);
+  const highlightedSelection = useMemo(
+    () =>
+      Object.keys(initialSelectedStatistics).filter(k => {
+        const tK = k as ParticipationTypesKey;
+        return selectedStatistic[tK] === true;
+      })[0],
+    [selectedStatistic]
+  );
+  return (
+    <>
+      <Section className="py-12">
+        <Container>
+          <EventStatistics
+            highlightedSelection={highlightedSelection}
+            statistics={props.statistics}
+            onSelectionChanged={(selection: string) => {
+              const s = selection as ParticipationTypesKey;
+              setSelectedStatistic({
+                ...initialSelectedStatistics,
+                [selection]: !selectedStatistic[s],
+              });
+            }}
+          />
+        </Container>
+      </Section>
+      <Section className="py-12">
+        <Container>
+          {props.participants && (
+            <EventParticipantList
+              participants={props.participants ?? []}
+              event={props.eventInfo}
+              eventProducts={props.eventProducts ?? []}
+              filteredStatus={highlightedSelection}
+            />
+          )}
+        </Container>
+      </Section>
+    </>
+  );
+};
+
+export default ParticipantsSection;

--- a/apps/web/src/app/admin/events/[id]/page.tsx
+++ b/apps/web/src/app/admin/events/[id]/page.tsx
@@ -11,8 +11,7 @@ import Environment from '@/utils/Environment';
 import Logger from '@/utils/Logger';
 
 import EventAdminActionsMenu from '../EventAdminActionsMenu';
-import EventParticipantList from '../EventParticipantList';
-import EventStatistics from '../EventStatistics';
+import ParticipantsSection from './ParticipantsSection';
 
 type EventInfoProps = {
   params: {
@@ -86,22 +85,12 @@ const EventDetailPage: React.FC<EventInfoProps> = async ({ params }) => {
           </div>
         </Container>
       </Section>
-      <Section className="py-12">
-        <Container>
-          <EventStatistics statistics={statistics.value!} />
-        </Container>
-      </Section>
-      <Section className="py-12">
-        <Container>
-          {registrations && (
-            <EventParticipantList
-              participants={registrations.value?.data ?? []}
-              event={eventinfo.value!}
-              eventProducts={eventProducts.value ?? []}
-            />
-          )}
-        </Container>
-      </Section>
+      <ParticipantsSection
+        eventInfo={eventinfo.value!}
+        participants={registrations.value!.data!}
+        statistics={statistics.value!}
+        eventProducts={eventProducts.value!}
+      />
     </Layout>
   );
 };

--- a/apps/web/src/components/ui/DataTable.tsx
+++ b/apps/web/src/components/ui/DataTable.tsx
@@ -2,6 +2,8 @@
 
 import { RankingInfo, rankItem } from '@tanstack/match-sorter-utils';
 import {
+  ColumnFilter,
+  ColumnFiltersState,
   FilterFn,
   flexRender,
   getCoreRowModel,
@@ -23,6 +25,7 @@ type DataTableProps = {
   clientsidePagination?: boolean;
   state?: Partial<TableState>;
   enableGlobalSearch?: boolean;
+  columnFilters?: ColumnFilter[];
 };
 
 declare module '@tanstack/table-core' {
@@ -48,10 +51,17 @@ const fuzzyFilter: FilterFn<any> = (row, columnId, value, addMeta) => {
 
 const DataTable = (props: DataTableProps) => {
   const { columns, data, clientsidePagination, pageSize = 25, state } = props;
+  const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([]);
   const [globalFilter, setGlobalFilter] = React.useState('');
   const handleClientPageChange = (newPage: number) => {
     table.setPageIndex(newPage);
   };
+
+  useEffect(() => {
+    if (props.columnFilters) {
+      setColumnFilters(props.columnFilters);
+    }
+  }, [props.columnFilters]);
 
   const table = useReactTable({
     columns,
@@ -59,6 +69,7 @@ const DataTable = (props: DataTableProps) => {
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     onGlobalFilterChange: setGlobalFilter,
+    onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
     filterFns: {
       fuzzy: fuzzyFilter,
@@ -72,6 +83,7 @@ const DataTable = (props: DataTableProps) => {
     state: {
       ...state,
       globalFilter,
+      columnFilters,
     },
   });
 

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -37,4 +37,11 @@ export type UserProfile = {
   phoneNumber?: string;
 };
 
+export enum ParticipationTypes {
+  participants = 'participants',
+  waitingList = 'waitingList',
+  cancelled = 'cancelled',
+}
+export type ParticipationTypesKey = keyof typeof ParticipationTypes;
+
 export type ProductSelected = Pick<ProductOrderDto, 'productId' | 'quantity'>;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-   "compilerOptions": {
+  "compilerOptions": {
     "target": "es2022",
     "lib": ["dom", "dom.iterable", "ES2022"],
     "allowJs": true,
@@ -17,7 +17,7 @@
     "jsx": "preserve",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*", "public/*"]
+      "@/*": ["./src/*", "public/*"],
     },
     "plugins": [
       {


### PR DESCRIPTION
Added click handlers to the status counters on top of the participation list which filters accordingly.

- Moved main section of participant list and status counters to seperate 'client' component, to enable state and event handlers whilst keeping the page server-side
- Added filter function to status column in EventParticipantList
- Added DataTable prop to be able to directly inject column filters