### PR TITLE
ci(ratio): adds storybook ci

### DIFF
--- a/.github/workflows/main-ratio-ui.yml
+++ b/.github/workflows/main-ratio-ui.yml
@@ -1,0 +1,93 @@
+name: "Ratio UI - Build & Deploy Storybook"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "libs/ratio-ui/**"
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "libs/ratio-ui/**"
+      - ".github/workflows/main-ratio-ui.yml"
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    name: Build & Deploy Storybook
+    environment: ratio-ui
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Storybook
+        working-directory: libs/ratio-ui
+        run: npm run storybook:build -- --output-dir ../../storybook-static
+
+      - name: Install Wrangler CLI
+        run: npm install -g wrangler
+
+      - name: Deploy to Cloudflare Pages (Production)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy storybook-static --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT }} --branch=main --commit-dirty=true
+
+      - name: Deploy to Cloudflare Pages (Preview)
+        id: preview-deploy
+        if: github.event_name == 'pull_request'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy storybook-static --project-name=${{ secrets.CLOUDFLARE_PAGES_PROJECT }} --branch=preview-${{ github.event.pull_request.number }} --commit-dirty=true
+
+      - name: Save Preview URL
+        if: github.event_name == 'pull_request'
+        run: |
+          # Extract and save the preview URL from wrangler output
+          echo "PREVIEW_URL=https://preview-${{ github.event.pull_request.number }}.${{ secrets.CLOUDFLARE_PAGES_PROJECT }}.pages.dev" >> $GITHUB_ENV
+
+      - name: Manage Preview Comment
+        if: github.event_name == 'pull_request' && github.event.action == 'synchronize'
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const body = `🚀 Storybook preview!
+            📖 **Preview URL:** ${{ env.PREVIEW_URL }}`;
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber
+            });
+            const existing = comments.data.find(c => c.body.startsWith('🚀 Storybook preview!'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body
+              });
+            }

--- a/libs/ratio-ui/src/core/Badge/Badge.stories.tsx
+++ b/libs/ratio-ui/src/core/Badge/Badge.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from '@storybook/react';
+import Badge from './Badge';
+
+const meta: Meta<typeof Badge> = {
+  title: 'Core/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: { type: 'select' },
+      options: ['neutral', 'info', 'positive', 'negative'],
+    },
+    block: { control: 'boolean' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Neutral: Story = {
+  args: {
+    children: 'Neutral badge',
+    variant: 'neutral',
+  },
+};
+
+export const Info: Story = {
+  args: {
+    children: 'Info badge',
+    variant: 'info',
+  },
+};
+
+export const Positive: Story = {
+  args: {
+    children: 'Success!',
+    variant: 'positive',
+  },
+};
+
+export const Negative: Story = {
+  args: {
+    children: 'Error',
+    variant: 'negative',
+  },
+};
+
+export const Block: Story = {
+  args: {
+    children: 'Block badge',
+    variant: 'info',
+    block: true,
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      <Badge variant="neutral">Neutral badge</Badge>
+      <Badge variant="info">Info badge</Badge>
+      <Badge variant="positive">Success!</Badge>
+      <Badge variant="negative">Error badge</Badge>
+    </div>
+  ),
+};

--- a/libs/ratio-ui/src/core/Badge/Badge.tsx
+++ b/libs/ratio-ui/src/core/Badge/Badge.tsx
@@ -16,21 +16,21 @@ const Badge: React.FC<BadgeProps> = ({
   let variantClass = '';
 
   if (variant === 'neutral') {
-    variantClass = 'bg-gray-500 dark:bg-gray-700';
+    variantClass = 'bg-gray-700 dark:bg-gray-800';
   } else if (variant === 'info') {
-    variantClass = 'bg-blue-500 dark:bg-blue-700';
+    variantClass = 'bg-blue-600 dark:bg-blue-800';
   } else if (variant === 'positive') {
-    variantClass = 'bg-green-500 dark:bg-green-700';
+    variantClass = 'bg-green-700 dark:bg-green-800';
   } else if (variant === 'negative') {
-    variantClass = 'bg-red-500 dark:bg-red-700';
+    variantClass = 'bg-red-600 dark:bg-red-800 text-white';
   }
 
-  const blockClass = block ? 'block py-2 my-2' : '';
+  const blockClass = block ? 'block' : '';
 
   const allClasses = `
     ${blockClass}
     ${variantClass}
-    px-2 py-1 text-xs font-semibold leading-none text-white rounded-xs
+    p-2 text-xs leading-none text-white rounded
     ${className}
   `.trim();
 

--- a/libs/ratio-ui/src/core/Card/Card.stories.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.stories.tsx
@@ -1,0 +1,58 @@
+
+
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { Card, CardProps } from './Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Core/Card',
+  component: Card,
+  tags: ['autodocs'],
+  argTypes: {
+    dark: { control: 'boolean' },
+    container: { control: 'boolean' },
+    backgroundColorClass: { control: 'text' },
+    backgroundImageUrl: { control: 'text' },
+    padding: { control: 'text' },
+    margin: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  args: {
+    children: 'This is a default card.',
+  },
+};
+
+export const Dark: Story = {
+  args: {
+    dark: true,
+    children: 'This is a dark card.',
+    backgroundColorClass: 'bg-slate-800',
+  },
+};
+
+export const WithContainer: Story = {
+  args: {
+    container: true,
+    children: 'This card wraps its children in a Container component.',
+  },
+};
+
+export const WithBackgroundImage: Story = {
+  args: {
+    backgroundImageUrl: 'https://via.placeholder.com/400x200',
+    children: 'Card with a background image.',
+  },
+};
+
+export const CustomPaddingAndMargin: Story = {
+  args: {
+    padding: '8',
+    margin: '4',
+    children: 'Card with custom padding and margin.',
+  },
+};


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for building and deploying the `ratio-ui` Storybook, adds Storybook stories for `Badge` and `Card` components, and updates the `Badge` component's styles for better consistency. Below are the key changes grouped by theme:

### CI/CD Workflow for Storybook Deployment:
* Added a new GitHub Actions workflow in `.github/workflows/main-ratio-ui.yml` to automate the build and deployment of the `ratio-ui` Storybook. The workflow supports both production deployments on the `main` branch and preview deployments for pull requests using Cloudflare Pages. It also posts preview URLs as comments on pull requests.

### Storybook Enhancements:
* Added `Badge` component stories in `libs/ratio-ui/src/core/Badge/Badge.stories.tsx` to showcase different variants (`neutral`, `info`, `positive`, `negative`), block styling, and a combined view of all variants.
* Added `Card` component stories in `libs/ratio-ui/src/core/Card/Card.stories.tsx` to demonstrate default, dark, container-wrapped, background image, and custom padding/margin configurations.

### Component Style Updates:
* Updated the `Badge` component styles in `libs/ratio-ui/src/core/Badge/Badge.tsx` to improve color contrast and consistency, including changes to `variantClass` for all variants and adjustments to padding and block styling.