### PR TITLE
feat(ratio): new navlist component

### DIFF
--- a/apps/web/src/app/events/EventDetails.tsx
+++ b/apps/web/src/app/events/EventDetails.tsx
@@ -1,18 +1,21 @@
-'use client';
-
+import React from 'react';
 import { MarkdownContent } from '@eventuras/markdown';
 import { EventDto } from '@eventuras/sdk';
 import { Heading } from '@eventuras/ratio-ui';
 import { useTranslations } from 'next-intl';
-import React from 'react';
-
 import Link from '@/components/Link';
+import { NavList } from '@eventuras/ratio-ui/core/NavList';
+import { Section } from '@eventuras/ratio-ui/layout/Section';
 
 type EventProps = {
   eventinfo: EventDto;
   bgClassNames?: string;
 };
 
+/**
+ * Renders event details with top sticky navigation for sections.
+ * @param props - See {@link EventProps}.
+ */
 const EventDetails: React.FC<EventProps> = ({ eventinfo }) => {
   const t = useTranslations();
 
@@ -20,46 +23,36 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo }) => {
 
   const sections = [
     {
-      id: 'more-information',
+      id: 'information',
+      href: '#more-information',
       title: t('common.events.moreinformation'),
       content: eventinfo.moreInformation,
     },
     {
       id: 'program',
+      href: '#program',
       title: t('common.events.program'),
       content: eventinfo.program,
     },
     {
       id: 'practical-information',
+      href: '#practical-information',
       title: t('common.events.practicalinformation'),
       content: eventinfo.practicalInformation,
     },
-  ].filter(section => section.content);
+  ];
 
   return (
-    <section
-      id="eventdetails"
-      className="eventdetails bg-primary-100/30 dark:bg-primary-900 py-10 min-h-screen"
-    >
-      <div className="flex flex-col md:flex-row container mx-auto">
-        <div className="mb-8 md:mb-0 md:sticky md:top-20 md:flex md:flex-col md:mr-8 md:w-1/4 mt-10">
-          {sections.map((section, index) => (
-            <Link key={index} href={`#${section.id}`} variant="button-text">
-              {section.title}
-            </Link>
-          ))}
-        </div>
+    <Section className="pb-24">
+      <NavList items={sections} LinkComponent={Link} sticky />
 
-        <div className="grow md:w-3/4">
-          {sections.map((section, index) => (
-            <section key={index} id={section.id} className="mb-8">
-              <Heading as="h2">{section.title}</Heading>
-              <MarkdownContent markdown={section.content} />
-            </section>
-          ))}
-        </div>
-      </div>
-    </section>
+      {sections.map(section => (
+        <Section key={section.id} id={section.id} container>
+          <Heading as="h2">{section.title}</Heading>
+          <MarkdownContent markdown={section.content!} />
+        </Section>
+      ))}
+    </Section>
   );
 };
 

--- a/libs/ratio-ui/src/core/NavList/NavList.stories.tsx
+++ b/libs/ratio-ui/src/core/NavList/NavList.stories.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import { NavList, NavListProps, NavListItem } from './NavList';
+
+const sampleItems: NavListItem[] = [
+  { href: '#overview', title: 'Overview' },
+  { href: '#features', title: 'Features' },
+  { href: '#pricing', title: 'Pricing' },
+  { href: '#faq', title: 'FAQ' },
+];
+
+const meta: Meta<NavListProps> = {
+  title: 'NavList',
+  component: NavList,
+  argTypes: {
+    sticky: { control: 'boolean' },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<NavListProps>;
+
+export const Default: Story = {
+  args: {
+    items: sampleItems,
+    LinkComponent: (props) => <a {...props} />,
+    sticky: false,
+  },
+};
+
+export const Sticky: Story = {
+  args: {
+    items: sampleItems,
+    LinkComponent: (props) => <a {...props} />,
+    sticky: true,
+  },
+  render: (args) => (
+    <div style={{ height: '200vh' /* make page tall */ }}>
+      <NavList {...args} />
+      <div style={{ padding: '2rem' }}>
+        {/* Dummy sections to scroll through */}
+        <section id="overview" style={{ height: '50vh' }}>
+          <h2>Overview</h2>
+          <p>Lots of content here…</p>
+        </section>
+        <section id="features" style={{ height: '50vh' }}>
+          <h2>Features</h2>
+          <p>More content here…</p>
+        </section>
+        <section id="pricing" style={{ height: '50vh' }}>
+          <h2>Pricing</h2>
+          <p>Even more content…</p>
+        </section>
+        <section id="faq" style={{ height: '50vh' }}>
+          <h2>FAQ</h2>
+          <p>And some final content…</p>
+        </section>
+      </div>
+    </div>
+  ),
+};
+
+export const Scrollable: Story = {
+  args: {
+    items: Array.from({ length: 10 }, (_, i) => ({
+      href: `#item-${i + 1}`,
+      title: `Linkitem ${i + 1}`,
+    })),
+    LinkComponent: (props) => <a {...props} />,
+    sticky: false,
+  },
+};

--- a/libs/ratio-ui/src/core/NavList/NavList.tsx
+++ b/libs/ratio-ui/src/core/NavList/NavList.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+export interface NavListItem {
+  href: string;
+  title: string;
+}
+
+export interface NavListProps {
+  items: NavListItem[];
+  LinkComponent: React.JSXElementConstructor<{ href: string; children: React.ReactNode }>;
+  sticky?: boolean;
+}
+
+/**
+ * Renders a horizontal list of anchor links, optionally sticky.
+ */
+export const NavList: React.FC<NavListProps> = ({ items, LinkComponent, sticky = false }) => {
+  return (
+    <nav
+      className={`bg-white dark:bg-primary-900 z-10 py-2 shadow-xs${
+        sticky ? ' sticky top-0' : ''
+      }`}
+    >
+      <ul className="container mx-auto flex space-x-6 overflow-x-auto px-4">
+        {items.map(item => (
+          <li key={item.href} className='whitespace-nowrap'>
+            <LinkComponent href={item.href}>{item.title}</LinkComponent>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
+
+NavList.displayName = 'NavList';

--- a/libs/ratio-ui/src/core/NavList/index.ts
+++ b/libs/ratio-ui/src/core/NavList/index.ts
@@ -1,0 +1,2 @@
+export { NavList } from './NavList';
+export type { NavListProps } from './NavList';

--- a/libs/ratio-ui/src/layout/Container/Container.tsx
+++ b/libs/ratio-ui/src/layout/Container/Container.tsx
@@ -6,6 +6,8 @@ interface ContainerProps {
   className?: string;
 }
 
+export const CONTAINER_CLASSES = 'p-3 container mx-auto';
+
 const Container: React.FC<ContainerProps> = ({
   children,
   as: Component = 'div',
@@ -13,7 +15,7 @@ const Container: React.FC<ContainerProps> = ({
   ...rest
 }) => {
   return (
-    <Component className={`p-3 container mx-auto ${className}`} {...rest}>
+    <Component className={`${CONTAINER_CLASSES} ${className}`} {...rest}>
       {children}
     </Component>
   );

--- a/libs/ratio-ui/src/layout/Section/Section.tsx
+++ b/libs/ratio-ui/src/layout/Section/Section.tsx
@@ -16,7 +16,7 @@ export interface SectionProps
   [key: string]: any;
 }
 
-const Section: React.FC<SectionProps> = ({
+export const Section: React.FC<SectionProps> = ({
   children,
   className = '',
   // spacing props
@@ -34,7 +34,7 @@ const Section: React.FC<SectionProps> = ({
 }) => {
 
   const spacingClasses = buildSpacingClasses({ padding, margin, border, width, height });
-  const style = getBackgroundStyle(backgroundImageUrl, undefined);
+  const style = getBackgroundStyle(backgroundImageUrl);
 
   const classes = [spacingClasses, backgroundColorClass, className]
     .filter(Boolean)

--- a/libs/ratio-ui/src/layout/Section/index.ts
+++ b/libs/ratio-ui/src/layout/Section/index.ts
@@ -1,0 +1,2 @@
+export { Section } from './Section';
+export type { SectionProps } from './Section';


### PR DESCRIPTION
This pull request introduces a new `NavList` component for rendering navigation links, refactors the `EventDetails` component to use this new component, and includes several other code improvements and adjustments. The most significant changes are grouped below by theme.

### New Component: `NavList`

* Introduced the `NavList` component in `libs/ratio-ui/src/core/NavList/NavList.tsx`, which renders a horizontal list of anchor links with an optional sticky behavior. The component uses a customizable `LinkComponent` for rendering links.
* Added Storybook stories for the `NavList` component in `libs/ratio-ui/src/core/NavList/NavList.stories.tsx`, including examples for default, sticky, and scrollable configurations.
* Exported the `NavList` component and its types from `libs/ratio-ui/src/core/NavList/index.ts`.

### Refactoring: `EventDetails` Component

* Refactored the `EventDetails` component in `apps/web/src/app/events/EventDetails.tsx` to use the new `NavList` component for rendering the navigation links. Simplified the layout by replacing custom sticky navigation logic with the `NavList`.
