### PR TITLE
feat(ratio): add storybook theming

### DIFF
--- a/libs/ratio-ui/.storybook/main.ts
+++ b/libs/ratio-ui/.storybook/main.ts
@@ -26,6 +26,10 @@ const config: StorybookConfig = {
   "framework": {
     "name": getAbsolutePath('@storybook/react-vite'),
     "options": {}
-  }
+  },
+  core: {
+    disableTelemetry: true,
+    disableWhatsNewNotifications: true,
+  },
 };
 export default config;

--- a/libs/ratio-ui/.storybook/manager.ts
+++ b/libs/ratio-ui/.storybook/manager.ts
@@ -1,0 +1,6 @@
+import { addons } from '@storybook/manager-api';
+import ratioTheme from './theme';
+
+addons.setConfig({
+  theme: ratioTheme,
+});

--- a/libs/ratio-ui/.storybook/preview.ts
+++ b/libs/ratio-ui/.storybook/preview.ts
@@ -1,9 +1,15 @@
 import type { Preview } from '@storybook/react';
 import { withThemeByDataAttribute } from '@storybook/addon-themes';
+import ratioTheme from "./theme";
 
 import "../src/ratio-ui.css";
 
 const preview: Preview = {
+  parameters: {
+    docs: {
+      theme: ratioTheme,
+    },
+  },
   decorators: [
     withThemeByDataAttribute({
       themes: {

--- a/libs/ratio-ui/.storybook/theme.ts
+++ b/libs/ratio-ui/.storybook/theme.ts
@@ -1,0 +1,8 @@
+import { create } from '@storybook/theming';
+
+export default create({
+  base: 'dark',
+  brandTitle: '🧱 Ratio UI',
+  brandUrl: '/',
+  brandTarget: '_self',
+});

--- a/libs/ratio-ui/package.json
+++ b/libs/ratio-ui/package.json
@@ -46,6 +46,7 @@
     "@storybook/addon-styling-webpack": "^1.0.1",
     "@storybook/addon-themes": "^8.6.12",
     "@storybook/blocks": "^8.6.12",
+    "@storybook/manager-api": "^8.6.12",
     "@storybook/react": "^8.6.12",
     "@storybook/react-vite": "^8.6.12",
     "@storybook/test": "^8.6.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,7 +150,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@eventuras/fides-auth": "*",
-        "@eventuras/forms": "*",
         "@eventuras/markdown": "*",
         "@eventuras/ratio-ui": "*",
         "@eventuras/scribo": "*",
@@ -255,7 +254,6 @@
       "name": "@eventuras/datatable",
       "version": "0.1.0",
       "dependencies": {
-        "@eventuras/forms": "*",
         "@eventuras/ratio-ui": "*",
         "@tanstack/match-sorter-utils": "^8.19.4",
         "@tanstack/react-table": "^8.21.3"
@@ -367,6 +365,7 @@
     "libs/forms": {
       "name": "@eventuras/forms",
       "version": "0.1.0",
+      "extraneous": true,
       "devDependencies": {
         "@eventuras/eslint-config": "*",
         "@eventuras/typescript-config": "*"
@@ -380,7 +379,6 @@
       "name": "@eventuras/markdown",
       "version": "0.1.0",
       "dependencies": {
-        "@eventuras/forms": "*",
         "@eventuras/ratio-ui": "*",
         "@eventuras/scribo": "*",
         "@eventuras/smartform": "*",
@@ -399,7 +397,6 @@
       "name": "@eventuras/markdowninput",
       "version": "0.1.0",
       "dependencies": {
-        "@eventuras/forms": "*",
         "@eventuras/ratio-ui": "*",
         "@eventuras/scribo": "*",
         "@eventuras/smartform": "*"
@@ -435,6 +432,7 @@
         "@storybook/addon-styling-webpack": "^1.0.1",
         "@storybook/addon-themes": "^8.6.12",
         "@storybook/blocks": "^8.6.12",
+        "@storybook/manager-api": "^8.6.12",
         "@storybook/react": "^8.6.12",
         "@storybook/react-vite": "^8.6.12",
         "@storybook/test": "^8.6.12",
@@ -542,7 +540,6 @@
       "name": "@eventuras/smartform",
       "version": "0.1.0",
       "dependencies": {
-        "@eventuras/forms": "*",
         "@eventuras/ratio-ui": "*",
         "react-hook-form": "^7.55.0"
       },
@@ -3439,10 +3436,6 @@
     },
     "node_modules/@eventuras/fides-auth": {
       "resolved": "libs/fides-auth",
-      "link": true
-    },
-    "node_modules/@eventuras/forms": {
-      "resolved": "libs/forms",
       "link": true
     },
     "node_modules/@eventuras/historia": {


### PR DESCRIPTION
This pull request introduces several updates to the Storybook configuration for the `ratio-ui` library, including the addition of a custom theme, disabling telemetry, and enhancing the preview and manager setup. These changes aim to improve the developer experience and align the Storybook environment with the project's branding.
