### PR TITLE
ci: update husky setup for CI compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "private": true,
   "packageManager": "npm@11.5.2",
   "dependencies": {
-    "husky": "^9.1.7",
     "turbo": "^2.5.5"
   },
   "devDependencies": {
@@ -14,6 +13,7 @@
     "@eventuras/eslint-config": "*",
     "@eventuras/typescript-config": "*",
     "eslint": "^9.32.0",
+    "husky": "^9.1.7",
     "lint-staged": "^16.1.4",
     "prettier": "^3.6.2",
     "typescript": "^5.9.2"
@@ -40,6 +40,6 @@
     "npm:reinstall": "npm run npm:clean && npm install --force",
     "npm:update": "npx npm-check-updates --deep -u",
     "npm:clean": "npm exec --workspaces -- npx rimraf node_modules && npx rimraf node_modules && npx rimraf package-lock.json",
-    "prepare": "husky"
+    "prepare": "node -e \"if (process.env.CI !== 'true') { require('husky').install() }\""
   }
 }


### PR DESCRIPTION
Moves `husky` from dependencies to devDependencies and updates the `prepare` script to conditionally install Husky only in non-CI environments. This optimizes package usage and prevents unnecessary installations during CI runs.