### PR TITLE
feat(historia): implement dynamic allowed domains for images

### DIFF
--- a/apps/historia/next.config.js
+++ b/apps/historia/next.config.js
@@ -2,10 +2,13 @@ import { withPayload } from '@payloadcms/next/withPayload'
 import { withSentryConfig } from '@sentry/nextjs'
 
 import redirects from './redirects.js'
+import { allowedOrigins, getAllowedDomainsFromAllowedOrigins } from './src/config/allowed-origins.ts'
 
 const NEXT_PUBLIC_CMS_URL = process.env.VERCEL_PROJECT_PRODUCTION_URL
   ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : undefined || process.env.NEXT_PUBLIC_CMS_URL || 'http://localhost:3100'
+
+const allowedImageDomains = getAllowedDomainsFromAllowedOrigins(allowedOrigins) || []
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -13,9 +16,17 @@ const nextConfig = {
 
   images: {
     remotePatterns: [
+      ...allowedImageDomains.map((hostname) => ({
+        protocol: 'https',
+        hostname,
+      })),
+      ...allowedImageDomains.map((hostname) => ({
+        protocol: 'http',
+        hostname,
+      })),
+      // Always allow the CMS URL
       ...[NEXT_PUBLIC_CMS_URL].map((item) => {
         const url = new URL(item)
-
         return {
           hostname: url.hostname,
           protocol: url.protocol.replace(':', ''),

--- a/apps/historia/src/app/api/auth/vipps/_utils/request-origin.ts
+++ b/apps/historia/src/app/api/auth/vipps/_utils/request-origin.ts
@@ -2,7 +2,7 @@ type Options = {
   allowedDomains?: string[];
 };
 
-import { allowedOrigins } from '@/config/allowed-origins';
+import { allowedOrigins, getAllowedDomainsFromAllowedOrigins } from '@/config/allowed-origins';
 
 function firstForwardedValue(value: string | null): string | undefined {
   if (!value) return undefined;
@@ -45,23 +45,6 @@ export function getPublicRequestOrigin(request: Request, options: Options = {}):
   const protocol = proto || (selectedHost.includes('localhost') ? 'http' : 'https');
 
   return `${protocol}://${selectedHost}`;
-}
-
-function getAllowedDomainsFromAllowedOrigins(origins: string[]): string[] | undefined {
-  const domains = origins
-    .map(origin => {
-      try {
-        // Typical case: origin is like "https://example.com"
-        return new URL(origin).host;
-      } catch {
-        // Fallback: allow hostnames/hosts directly
-        return origin;
-      }
-    })
-    .map(s => s.trim())
-    .filter(Boolean);
-
-  return domains.length ? domains : undefined;
 }
 
 export function getAllowedVippsLoginDomains(): string[] | undefined {

--- a/apps/historia/src/config/allowed-origins.ts
+++ b/apps/historia/src/config/allowed-origins.ts
@@ -1,3 +1,20 @@
 export const allowedOrigins = process.env.CMS_ALLOWED_ORIGINS
   ? process.env.CMS_ALLOWED_ORIGINS.split(',').map(s => s.trim()).filter(Boolean)
   : [];
+
+export function getAllowedDomainsFromAllowedOrigins(origins: string[]): string[] | undefined {
+  const domains = origins
+    .map(origin => {
+      try {
+        // Typical case: origin is like "https://example.com"
+        return new URL(origin).host;
+      } catch {
+        // Fallback: allow hostnames/hosts directly
+        return origin;
+      }
+    })
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  return domains.length ? domains : undefined;
+}


### PR DESCRIPTION
This pull request refactors how allowed domains are derived from the list of allowed origins and improves domain management for both image handling and authentication logic. The main change is moving the `getAllowedDomainsFromAllowedOrigins` utility to a shared config file, ensuring consistent domain extraction and reducing code duplication.
