### PR TITLE
feat(historia): add Timeline collection for chronological event management

### DIFF
--- a/.changeset/long-buttons-spend.md
+++ b/.changeset/long-buttons-spend.md
@@ -1,0 +1,17 @@
+---
+"@eventuras/historia": minor
+---
+
+Add Timeline collection for chronological event management
+
+Implements a new Timeline collection (slug: `timelines`) for managing historical events with:
+
+- Flexible date precision (exact to century level, with circa support)
+- Event relationships (caused_by, led_to, part_of, concurrent_with)
+- Full versioning support for scholarly updates
+- Multi-tenant organization isolation
+- SEO optimization with schema.org Event markup
+
+Localized as "timelines" (English) / "tidslinjer" (Norwegian).
+
+See ADR 0008 for architectural decisions and rationale.

--- a/apps/historia/docs/adr/0008-timeline-events-collection.md
+++ b/apps/historia/docs/adr/0008-timeline-events-collection.md
@@ -1,7 +1,7 @@
 # ADR 0008 — Timeline Events Collection
 
 ## Status
-Draft
+Accepted
 
 ## Context
 
@@ -55,7 +55,7 @@ Without a dedicated Events/Timeline collection:
 
 ## Decision
 
-Implement an **Events collection** (slug: `events`) with flexible date representation and rich semantic relationships.
+Implement a **Timeline collection** (slug: `timelines`) with flexible date representation and rich semantic relationships.
 
 ### Versioning Strategy
 
@@ -102,12 +102,22 @@ import { slugField } from '@/fields/slug';
 import { storyField } from '@/fields/story';
 import { seoTab } from '@/lib/payload-plugin-seo';
 
-export const Events: CollectionConfig = {
-  slug: 'events',
+export const Timelines: CollectionConfig = {
+  slug: 'timelines',
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['title', 'startDate', 'eventType', 'updatedAt'],
-    defaultSort: 'startDate',
+    defaultColumns: ['title', 'updatedAt'],
+    livePreview: {
+      url: ({ data, req }) => {
+        const path = generatePreviewPath({
+          resourceId: typeof data?.resourceId === 'string' ? data.resourceId : undefined,
+          slug: typeof data?.slug === 'string' ? data.slug : undefined,
+          collection: 'timelines',
+          req,
+        });
+        return path;
+      },
+    },
   },
   versions: {
     drafts: {
@@ -150,6 +160,9 @@ export const Events: CollectionConfig = {
                 description: 'Brief summary for timeline tooltips and previews (max 300 characters)',
               },
             },
+
+            // Rich description
+            storyField([Content, Image]),
 
             // Featured image (reuses shared image field pattern from Articles)
             image,
@@ -219,56 +232,6 @@ export const Events: CollectionConfig = {
                   },
                 },
               ],
-            },
-
-            // Location
-            {
-              name: 'location',
-              type: 'relationship',
-              relationTo: 'places',
-              label: 'Location',
-              admin: {
-                description: 'Where did this event take place?',
-              },
-            },
-
-            // Participants
-            {
-              name: 'participants',
-              type: 'array',
-              label: 'Participants',
-              admin: {
-                description: 'People and organizations involved in this event',
-              },
-              fields: [
-                {
-                  name: 'entity',
-                  type: 'relationship',
-                  relationTo: ['persons', 'organizations'],
-                  required: true,
-                  label: 'Person/Organization',
-                },
-                {
-                  name: 'role',
-                  type: 'text',
-                  label: 'Role',
-                  admin: {
-                    description: 'Their role in the event (e.g., "signatory", "commander", "victim", "witness")',
-                  },
-                },
-              ],
-            },
-
-            // Sources
-            {
-              name: 'sources',
-              type: 'relationship',
-              relationTo: 'sources',
-              hasMany: true,
-              label: 'Sources',
-              admin: {
-                description: 'Historical sources documenting this event',
-              },
             },
 
             // Topics/categories
@@ -664,11 +627,11 @@ Store dates as "1939-09-01/1945-05-08" strings.
 
 ## Implementation Checklist
 
-- [ ] Create `apps/historia/src/collections/Events.ts`
-- [ ] Register collection in `payload.config.ts`
+- [x] Create `apps/historia/src/collections/Timelines.ts` (exports `Timelines`)
+- [x] Register collection in `payload.config.ts`
 - [ ] Implement date validation (endDate >= startDate)
-- [ ] Add to localized collection name mapping (events/hendelser)
-- [ ] Create frontend route: `/[locale]/c/event/[slug]`
+- [x] Add to localized collection name mapping (timelines/tidslinjer)
+- [ ] Create frontend route: `/[locale]/c/timelines/[slug]` (tidslinjer in Norwegian)
 - [ ] Implement schema.org Event JSON-LD
 - [ ] Create event page component (full details + timeline visualization)
 - [ ] Implement date formatting based on precision

--- a/apps/historia/src/app/(frontend)/[locale]/c/[collection]/pageCollections.ts
+++ b/apps/historia/src/app/(frontend)/[locale]/c/[collection]/pageCollections.ts
@@ -1,6 +1,6 @@
 import { Config } from '@/payload-types';
 
-export const pageCollections = ['articles', 'happenings', 'notes', 'organizations', 'persons', 'products', 'cases'] as const;
+export const pageCollections = ['articles', 'happenings', 'notes', 'organizations', 'persons', 'products', 'cases', 'timelines'] as const;
 export type ValidCollection = typeof pageCollections[number];
 type Collections = Config['collections'];
 export type PageCollectionsType = Extract<keyof Collections, ValidCollection>;
@@ -21,6 +21,7 @@ export const collectionTranslations: Record<string, Record<string, string>> = {
     persons: 'people',
     products: 'products',
     cases: 'cases',
+    timelines: 'timelines',
   },
   no: {
     articles: 'artikler',
@@ -30,6 +31,7 @@ export const collectionTranslations: Record<string, Record<string, string>> = {
     persons: 'folk',
     products: 'produkter',
     cases: 'spor',
+    timelines: 'tidslinjer',
   },
 };
 

--- a/apps/historia/src/collections/Timelines.ts
+++ b/apps/historia/src/collections/Timelines.ts
@@ -1,0 +1,216 @@
+import type { CollectionConfig } from 'payload';
+
+import { admins } from '@/access/admins';
+import { anyone } from '@/access/anyone';
+import { siteEditors } from '@/access/siteRoleAccess';
+import { accessOR } from '@/access/utils/accessOR';
+import { Content } from '@/blocks/Content/config';
+import { Image } from '@/blocks/Image/config';
+import { image } from '@/fields/image';
+import resourceId from '@/fields/resourceId';
+import { slugField } from '@/fields/slug';
+import { storyField } from '@/fields/story';
+import { seoTab } from '@/lib/payload-plugin-seo';
+import { generatePreviewPath } from '@/utilities/generatePreviewPath';
+
+export const Timelines: CollectionConfig = {
+  slug: 'timelines',
+  admin: {
+    useAsTitle: 'title',
+    defaultColumns: ['title', 'updatedAt'],
+    livePreview: {
+      url: ({ data, req }) => {
+        const path = generatePreviewPath({
+          resourceId: typeof data?.resourceId === 'string' ? data.resourceId : undefined,
+          slug: typeof data?.slug === 'string' ? data.slug : undefined,
+          collection: 'timelines',
+          req,
+        });
+        return path;
+      },
+    },
+    preview: (data, { req }) => {
+      const path = generatePreviewPath({
+        resourceId: typeof data?.resourceId === 'string' ? data.resourceId : undefined,
+        slug: typeof data?.slug === 'string' ? data.slug : undefined,
+        collection: 'timelines',
+        req,
+      });
+      return path;
+    },
+  },
+  access: {
+    create: accessOR(admins, siteEditors),
+    delete: admins,
+    read: anyone,
+    update: accessOR(admins, siteEditors),
+  },
+  versions: {
+    drafts: {
+      autosave: true,
+    },
+    maxPerDoc: 50,
+  },
+  fields: [
+    {
+      type: 'tabs',
+      tabs: [
+        {
+          label: 'Content',
+          fields: [
+            // Title
+            {
+              name: 'title',
+              type: 'text',
+              required: true,
+              localized: true,
+              label: 'Title',
+              admin: {
+                description:
+                  'Short, descriptive title (e.g., "Grunnloven undertegnes", "French Revolution begins")',
+              },
+            },
+
+            // Short summary for timeline tooltips
+            {
+              name: 'summary',
+              type: 'textarea',
+              maxLength: 300,
+              localized: true,
+              label: 'Summary',
+              admin: {
+                description: 'Brief summary for timeline tooltips and previews (max 300 characters)',
+              },
+            },
+
+            // Rich description
+            storyField([Content, Image]),
+
+            // Featured image
+            image,
+
+            // Date/Time group
+            {
+              name: 'temporal',
+              type: 'group',
+              label: 'Date & Time',
+              fields: [
+                {
+                  name: 'startDate',
+                  type: 'date',
+                  required: true,
+                  label: 'Start Date',
+                  admin: {
+                    description: 'Date when this occurred (or began for multi-day entries)',
+                    date: {
+                      pickerAppearance: 'dayAndTime',
+                    },
+                  },
+                },
+                {
+                  name: 'endDate',
+                  type: 'date',
+                  label: 'End Date',
+                  admin: {
+                    description: 'Optional end date for entries spanning multiple days/years',
+                    condition: (data) => !!data.temporal?.startDate,
+                    date: {
+                      pickerAppearance: 'dayAndTime',
+                    },
+                  },
+                },
+                {
+                  name: 'datePrecision',
+                  type: 'select',
+                  required: true,
+                  defaultValue: 'exact',
+                  label: 'Date Precision',
+                  options: [
+                    { label: 'Exact (day and time)', value: 'exact-time' },
+                    { label: 'Exact (day)', value: 'exact' },
+                    { label: 'Month', value: 'month' },
+                    { label: 'Year', value: 'year' },
+                    { label: 'Decade', value: 'decade' },
+                    { label: 'Century', value: 'century' },
+                    { label: 'Circa (approximate)', value: 'circa' },
+                  ],
+                  admin: {
+                    description: 'How precise is the date?',
+                  },
+                },
+                {
+                  name: 'displayDate',
+                  type: 'text',
+                  localized: true,
+                  label: 'Display Date (override)',
+                  admin: {
+                    description:
+                      'Optional human-readable date (e.g., "Early 1800s", "Spring 1814", "ca. 1850"). Overrides auto-formatted date.',
+                  },
+                },
+                {
+                  name: 'isOngoing',
+                  type: 'checkbox',
+                  defaultValue: false,
+                  label: 'Ongoing',
+                  admin: {
+                    description: 'Check if this is still happening (no end date)',
+                  },
+                },
+              ],
+            },
+
+            // Topics/categories
+            {
+              name: 'topics',
+              type: 'relationship',
+              relationTo: 'topics',
+              hasMany: true,
+              label: 'Topics',
+              admin: {
+                description: 'Thematic categories (e.g., "Norwegian Constitution", "World War II")',
+              },
+            },
+
+            // Related timeline entries
+            {
+              name: 'relatedEvents',
+              type: 'array',
+              label: 'Related Entries',
+              admin: {
+                description: 'Connect to other timeline entries (cause/effect, hierarchy)',
+              },
+              fields: [
+                {
+                  name: 'event',
+                  type: 'relationship',
+                  relationTo: 'timelines',
+                  required: true,
+                  label: 'Timeline Entry',
+                },
+                {
+                  name: 'relationshipType',
+                  type: 'select',
+                  required: true,
+                  label: 'Relationship',
+                  options: [
+                    { label: 'Caused by', value: 'caused_by' },
+                    { label: 'Led to', value: 'led_to' },
+                    { label: 'Part of', value: 'part_of' },
+                    { label: 'Concurrent with', value: 'concurrent_with' },
+                    { label: 'Related to', value: 'related_to' },
+                  ],
+                },
+              ],
+            },
+
+            // Resource ID + slug
+            ...slugField(),
+            resourceId,
+          ],
+        },
+        seoTab(),
+      ],
+    },
+  ],
+};

--- a/apps/historia/src/payload-types.ts
+++ b/apps/historia/src/payload-types.ts
@@ -97,6 +97,7 @@ export interface Config {
     shipments: Shipment;
     sources: Source;
     terms: Term;
+    timelines: Timeline;
     topics: Topic;
     transactions: Transaction;
     users: User;
@@ -138,6 +139,7 @@ export interface Config {
     shipments: ShipmentsSelect<false> | ShipmentsSelect<true>;
     sources: SourcesSelect<false> | SourcesSelect<true>;
     terms: TermsSelect<false> | TermsSelect<true>;
+    timelines: TimelinesSelect<false> | TimelinesSelect<true>;
     topics: TopicsSelect<false> | TopicsSelect<true>;
     transactions: TransactionsSelect<false> | TransactionsSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
@@ -1759,6 +1761,81 @@ export interface Term {
   slugLock?: boolean | null;
   updatedAt: string;
   createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "timelines".
+ */
+export interface Timeline {
+  id: string;
+  tenant?: (string | null) | Website;
+  /**
+   * Short, descriptive title (e.g., "Grunnloven undertegnes", "French Revolution begins")
+   */
+  title: string;
+  /**
+   * Brief summary for timeline tooltips and previews (max 300 characters)
+   */
+  summary?: string | null;
+  story?: (ContentBlock | ImageBlock)[] | null;
+  image?: Image;
+  temporal: {
+    /**
+     * Date when this occurred (or began for multi-day entries)
+     */
+    startDate: string;
+    /**
+     * Optional end date for entries spanning multiple days/years
+     */
+    endDate?: string | null;
+    /**
+     * How precise is the date?
+     */
+    datePrecision: 'exact-time' | 'exact' | 'month' | 'year' | 'decade' | 'century' | 'circa';
+    /**
+     * Optional human-readable date (e.g., "Early 1800s", "Spring 1814", "ca. 1850"). Overrides auto-formatted date.
+     */
+    displayDate?: string | null;
+    /**
+     * Check if this is still happening (no end date)
+     */
+    isOngoing?: boolean | null;
+  };
+  /**
+   * Thematic categories (e.g., "Norwegian Constitution", "World War II")
+   */
+  topics?: (string | Topic)[] | null;
+  /**
+   * Connect to other timeline entries (cause/effect, hierarchy)
+   */
+  relatedEvents?:
+    | {
+        event: string | Timeline;
+        relationshipType: 'caused_by' | 'led_to' | 'part_of' | 'concurrent_with' | 'related_to';
+        id?: string | null;
+      }[]
+    | null;
+  slug?: string | null;
+  slugLock?: boolean | null;
+  resourceId: string;
+  meta?: {
+    /**
+     * 50-60 characters recommended for optimal display in search results. Leave empty to auto-generate from title.
+     */
+    title?: string | null;
+    /**
+     * 150-160 characters recommended for search result snippets. Leave empty to use excerpt or lead text.
+     */
+    description?: string | null;
+    /**
+     * Image used when sharing on social media (Facebook, LinkedIn, Twitter). Recommended: Use the "socialShare" format (1200×630px) for best results. Leave empty to use featured image.
+     */
+    image?: (string | null) | Media;
+  };
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
@@ -2415,6 +2492,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'terms';
         value: string | Term;
+      } | null)
+    | ({
+        relationTo: 'timelines';
+        value: string | Timeline;
       } | null)
     | ({
         relationTo: 'topics';
@@ -3207,6 +3288,53 @@ export interface TermsSelect<T extends boolean = true> {
   slugLock?: T;
   updatedAt?: T;
   createdAt?: T;
+  _status?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "timelines_select".
+ */
+export interface TimelinesSelect<T extends boolean = true> {
+  tenant?: T;
+  title?: T;
+  summary?: T;
+  story?:
+    | T
+    | {
+        content?: T | ContentBlockSelect<T>;
+        image?: T | ImageBlockSelect<T>;
+      };
+  image?: T | ImageSelect<T>;
+  temporal?:
+    | T
+    | {
+        startDate?: T;
+        endDate?: T;
+        datePrecision?: T;
+        displayDate?: T;
+        isOngoing?: T;
+      };
+  topics?: T;
+  relatedEvents?:
+    | T
+    | {
+        event?: T;
+        relationshipType?: T;
+        id?: T;
+      };
+  slug?: T;
+  slugLock?: T;
+  resourceId?: T;
+  meta?:
+    | T
+    | {
+        title?: T;
+        description?: T;
+        image?: T;
+      };
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema

--- a/apps/historia/src/payload.config.ts
+++ b/apps/historia/src/payload.config.ts
@@ -30,6 +30,7 @@ import { Quotes } from './collections/Quotes';
 import { Shipments } from './collections/Shipments';
 import { Sources } from './collections/Sources';
 import { Terms } from './collections/Terms';
+import { Timelines } from './collections/Timelines';
 import { Topics } from './collections/Topics';
 import { Transactions } from './collections/Transactions';
 import { Users } from './collections/Users';
@@ -157,7 +158,7 @@ export default buildConfig({
       },
       push: true,
     }),
-  collections: [Articles, BusinessEvents, Carts, Cases, Happenings, Licenses, Media, Notes, Orders, Organizations, Pages, Persons, Places, Products, Quotes, Shipments, Sources, Terms, Topics, Transactions, Users, Websites],
+  collections: [Articles, BusinessEvents, Carts, Cases, Happenings, Licenses, Media, Notes, Orders, Organizations, Pages, Persons, Places, Products, Quotes, Shipments, Sources, Terms, Timelines, Topics, Transactions, Users, Websites],
   cors: allowedOrigins,
   csrf: allowedOrigins,
   editor: defaultLexical,

--- a/apps/historia/src/plugins.ts
+++ b/apps/historia/src/plugins.ts
@@ -119,6 +119,7 @@ export const plugins: Plugin[] = [
       shipments: {},
       sources: {},
       terms: {},
+      timelines: {},
       topics: {},
       transactions: {},
     },

--- a/apps/historia/src/utilities/generatePreviewPath.ts
+++ b/apps/historia/src/utilities/generatePreviewPath.ts
@@ -6,6 +6,7 @@ const collectionPrefixMap: Partial<Record<CollectionSlug, string>> = {
   articles: 'c',
   notes: 'c',
   products: 'c',
+  timelines: 'c',
   pages: '',
   quotes: 'i',
   sources: 'i',


### PR DESCRIPTION
Adds a new timelines collection to Historia (Payload CMS) to support managing chronological “timeline event” content, along with wiring for previews, multi-tenancy, and localized collection routing.