### PR TITLE
chore(api): update health check configurations and logging levels

### DIFF
--- a/apps/api/k8s/workload/templates/deployment.yaml
+++ b/apps/api/k8s/workload/templates/deployment.yaml
@@ -52,5 +52,5 @@ spec:
               path: {{ .Values.healthCheck.path }}
               port: {{ .Values.service.targetPort }}
             initialDelaySeconds: 5
-            periodSeconds: 10
+            periodSeconds: {{ .Values.healthCheck.readinessPeriodSeconds | default 60 }}
             timeoutSeconds: {{ .Values.healthCheck.timeoutSeconds }}

--- a/apps/api/k8s/workload/values.yaml
+++ b/apps/api/k8s/workload/values.yaml
@@ -40,6 +40,7 @@ healthCheck:
   initialDelaySeconds: 15
   periodSeconds: 30
   timeoutSeconds: 10
+  readinessPeriodSeconds: 60  # How often Kubernetes checks if the pod is ready to serve traffic
 
 # Pod annotations – merged onto template.metadata.annotations
 # Use this to trigger rollouts on secret changes (e.g. Infisical auto-reload)

--- a/apps/api/src/Eventuras.Services.Converto/ConvertoServicesExtensions.cs
+++ b/apps/api/src/Eventuras.Services.Converto/ConvertoServicesExtensions.cs
@@ -14,11 +14,13 @@ public static class ConvertoServicesExtensions
         services.TryAddSingleton<IConvertoClient, ConvertoClient>();
         services.TryAddTransient<IPdfRenderService, ConvertoPdfRenderService>();
 
+        // Registered with the "converto" tag so it is only exposed on /health/converto,
+        // not on the /health endpoint used by Kubernetes probes.
         services.Configure<HealthCheckServiceOptions>(options =>
         {
             options.Registrations.Add(new HealthCheckRegistration("pdf",
                 ActivatorUtilities.GetServiceOrCreateInstance<ConvertoHealthCheck>,
-                null, null));
+                null, new[] { "converto" }));
         });
 
         return services;

--- a/apps/api/src/Eventuras.WebApi/appsettings.json
+++ b/apps/api/src/Eventuras.WebApi/appsettings.json
@@ -21,7 +21,11 @@
   },
   "Logging": {
     "LogLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Eventuras.Services.Converto.ConvertoHealthCheck": "Warning",
+      "Eventuras.Services.Converto.ConvertoClient": "Warning",
+      "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Warning",
+      "System.Net.Http.HttpClient": "Warning"
     }
   },
   "Sentry": {


### PR DESCRIPTION
Updates the API’s health check and logging configuration to reduce noise from Converto-related checks and to separate Kubernetes probe behavior from manual Converto diagnostics.