### PR TITLE
feat(infra): add optional HA support to all Helm charts

### DIFF
--- a/apps/api/k8s/README.md
+++ b/apps/api/k8s/README.md
@@ -6,22 +6,42 @@ ArgoCD Application(Set) and routing are managed externally (e.g. eventuras-infra
 
 ## Configuration
 
-| Parameter                   | Description                                  | Default                 |
-| --------------------------- | -------------------------------------------- | ----------------------- |
-| `replicaCount`              | Number of replicas                           | `1`                     |
-| `image.registry`            | Image registry                               | `docker.io`             |
-| `image.repository`          | Image repository                             | `losolio/eventuras-api` |
-| `image.tag`                 | Image tag (required)                         | `""`                    |
-| `image.pullPolicy`          | Image pull policy                            | `IfNotPresent`          |
-| `service.port`              | Service port                                 | `80`                    |
-| `service.targetPort`        | Container port                               | `8080`                  |
-| `resources.requests.memory` | Memory request                               | `256Mi`                 |
-| `resources.requests.cpu`    | CPU request                                  | `100m`                  |
-| `resources.limits.memory`   | Memory limit                                 | `1Gi`                   |
-| `resources.limits.cpu`      | CPU limit                                    | `1000m`                 |
-| `healthCheck.path`          | Health check path                            | `/health`               |
-| `podAnnotations`            | Pod annotations (e.g. Infisical auto-reload) | `{}`                    |
-| `env`                       | Non-sensitive environment variables          | `{}`                    |
+| Parameter                            | Description                                  | Default                 |
+| ------------------------------------ | -------------------------------------------- | ----------------------- |
+| `replicaCount`                       | Number of replicas                           | `1`                     |
+| `image.registry`                     | Image registry                               | `docker.io`             |
+| `image.repository`                   | Image repository                             | `losolio/eventuras-api` |
+| `image.tag`                          | Image tag (required)                         | `""`                    |
+| `image.pullPolicy`                   | Image pull policy                            | `IfNotPresent`          |
+| `service.port`                       | Service port                                 | `80`                    |
+| `service.targetPort`                 | Container port                               | `8080`                  |
+| `resources.requests.memory`          | Memory request                               | `256Mi`                 |
+| `resources.requests.cpu`             | CPU request                                  | `100m`                  |
+| `resources.limits.memory`            | Memory limit                                 | `1Gi`                   |
+| `resources.limits.cpu`               | CPU limit                                    | `1000m`                 |
+| `healthCheck.path`                   | Health check path                            | `/health`               |
+| `podAnnotations`                     | Pod annotations (e.g. Infisical auto-reload) | `{}`                    |
+| `env`                                | Non-sensitive environment variables          | `{}`                    |
+| `strategy`                           | Deployment strategy (e.g. RollingUpdate)     | `{}`                    |
+| `podDisruptionBudget.enabled`        | Enable PodDisruptionBudget                   | `false`                 |
+| `podDisruptionBudget.minAvailable`   | Minimum available pods during disruption     | `1`                     |
+| `topologySpreadConstraints`          | Spread pods across nodes                     | `[]`                    |
+
+### High availability
+
+By default the chart runs a single replica with no HA settings, suitable for development or single-node clusters. For production, override via ArgoCD:
+
+```yaml
+replicaCount: 2
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
 
 Sensitive values belong in `eventuras-api-secrets` (Kubernetes Secret / Infisical).
 

--- a/apps/api/k8s/templates/deployment.yaml
+++ b/apps/api/k8s/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
@@ -21,6 +25,10 @@ spec:
       # Security: Disable service account token automounting
       # API doesn't need to call Kubernetes API
       automountServiceAccountToken: false
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"

--- a/apps/api/k8s/templates/pdb.yaml
+++ b/apps/api/k8s/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+{{- end }}

--- a/apps/api/k8s/values.yaml
+++ b/apps/api/k8s/values.yaml
@@ -35,6 +35,26 @@ healthCheck:
   timeoutSeconds: 10
   readinessPeriodSeconds: 60
 
+# High-availability settings (disabled by default for single-node compatibility)
+# Override in environment-specific values for prod
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+topologySpreadConstraints: []
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app: eventuras-api
+
 # Pod annotations – merged onto template.metadata.annotations
 # Use this to trigger rollouts on secret changes (e.g. Infisical auto-reload)
 podAnnotations: {}

--- a/apps/convertoapi/k8s/README.md
+++ b/apps/convertoapi/k8s/README.md
@@ -52,6 +52,22 @@ config:
 
 The API also needs matching credentials (`Converto__ClientId`, `Converto__ClientSecret`).
 
+## High availability
+
+By default the chart runs a single replica with no HA settings, suitable for development or single-node clusters. For production, override via ArgoCD:
+
+```yaml
+replicaCount: 2
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
 ## Resource considerations
 
 Playwright spawns a Chromium browser for each PDF render (~200-400 MB memory).

--- a/apps/convertoapi/k8s/chart/templates/deployment.yaml
+++ b/apps/convertoapi/k8s/chart/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     {{- include "converto.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "converto.selectorLabels" . | nindent 6 }}
@@ -19,6 +23,10 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}

--- a/apps/convertoapi/k8s/chart/templates/pdb.yaml
+++ b/apps/convertoapi/k8s/chart/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    {{- include "converto.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "converto.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/apps/convertoapi/k8s/chart/values.yaml
+++ b/apps/convertoapi/k8s/chart/values.yaml
@@ -31,6 +31,27 @@ healthCheck:
   periodSeconds: 30
   timeoutSeconds: 5
 
+# High-availability settings (disabled by default for single-node compatibility)
+# Override in environment-specific values for prod
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+topologySpreadConstraints: []
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app.kubernetes.io/name: converto
+#         app.kubernetes.io/instance: <release-name>
+
 # Pod-level security context
 podSecurityContext:
   runAsNonRoot: true

--- a/apps/historia/k8s/README.md
+++ b/apps/historia/k8s/README.md
@@ -22,6 +22,26 @@ ArgoCD Application(Set) and routing are managed externally (e.g. eventuras-infra
 | `healthCheck.path` | Health check path | `/api/health` |
 | `podAnnotations` | Pod annotations (e.g. Infisical auto-reload) | `{}` |
 | `env` | Non-sensitive environment variables | `{}` |
+| `strategy` | Deployment strategy (e.g. RollingUpdate) | `{}` |
+| `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
+| `podDisruptionBudget.minAvailable` | Minimum available pods during disruption | `1` |
+| `topologySpreadConstraints` | Spread pods across nodes | `[]` |
+
+### High availability
+
+By default the chart runs a single replica with no HA settings, suitable for development or single-node clusters. For production, override via ArgoCD:
+
+```yaml
+replicaCount: 2
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
 
 Sensitive values belong in `historia-secrets` (Kubernetes Secret / Infisical).
 

--- a/apps/historia/k8s/templates/deployment.yaml
+++ b/apps/historia/k8s/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
@@ -19,6 +23,10 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"

--- a/apps/historia/k8s/templates/pdb.yaml
+++ b/apps/historia/k8s/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+{{- end }}

--- a/apps/historia/k8s/values.yaml
+++ b/apps/historia/k8s/values.yaml
@@ -35,6 +35,26 @@ healthCheck:
   timeoutSeconds: 5
   readinessPeriodSeconds: 10
 
+# High-availability settings (disabled by default for single-node compatibility)
+# Override in environment-specific values for prod
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+topologySpreadConstraints: []
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app: historia
+
 # Pod annotations – merged onto template.metadata.annotations
 # Use this to trigger rollouts on secret changes (e.g. Infisical auto-reload)
 podAnnotations: {}

--- a/apps/idem-admin/k8s/README.md
+++ b/apps/idem-admin/k8s/README.md
@@ -127,6 +127,22 @@ Environment-specific configuration is managed via Helm values:
 
 See [chart/values.yaml](chart/values.yaml) for all available parameters.
 
+### High availability
+
+By default the chart runs a single replica, suitable for development or single-node clusters. For production, override via ArgoCD:
+
+```yaml
+replicaCount: 2
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
 ## Environment Variables
 
 Common environment variables set via Argo CD:

--- a/apps/idem-admin/k8s/chart/templates/deployment.yaml
+++ b/apps/idem-admin/k8s/chart/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
@@ -17,6 +21,10 @@ spec:
       # Security: Disable service account token automounting
       # idem-admin doesn't need to call Kubernetes API
       automountServiceAccountToken: false
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/apps/idem-admin/k8s/chart/templates/pdb.yaml
+++ b/apps/idem-admin/k8s/chart/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+{{- end }}

--- a/apps/idem-admin/k8s/chart/values.yaml
+++ b/apps/idem-admin/k8s/chart/values.yaml
@@ -27,6 +27,26 @@ resources:
     cpu: "500m"
     ephemeral-storage: "2Gi"
 
+# High-availability settings (disabled by default for single-node compatibility)
+# Override in environment-specific values for prod
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+topologySpreadConstraints: []
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app: idem-admin
+
 env: {}
 # Set by Argo:
 #   NODE_ENV: production

--- a/apps/idem-idp/k8s/README.md
+++ b/apps/idem-idp/k8s/README.md
@@ -132,6 +132,22 @@ Environment-specific configuration is managed via Helm values:
 
 See [chart/README.md](chart/README.md#configuration) for all available parameters.
 
+### High availability
+
+By default the chart runs a single replica, suitable for development or single-node clusters. For production, override via ArgoCD:
+
+```yaml
+replicaCount: 2
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
 ## Database Setup
 
 Idem IDP requires a PostgreSQL database. Make sure to:

--- a/apps/idem-idp/k8s/chart/README.md
+++ b/apps/idem-idp/k8s/chart/README.md
@@ -39,6 +39,10 @@ helm:
 | Value | Description | Example |
 |-------|-------------|---------|
 | `replicaCount` | Number of replicas | `1`, `2`, `3` |
+| `strategy` | Deployment strategy | `{}` |
+| `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
+| `podDisruptionBudget.minAvailable` | Min available pods during disruption | `1` |
+| `topologySpreadConstraints` | Spread pods across nodes | `[]` |
 | `image.registry` | Container registry | `docker.io` |
 | `image.repository` | Image repository | `losolio/idem-idp` |
 | `image.tag` | Image tag | `sha-abc123`, `v1.2.3` |

--- a/apps/idem-idp/k8s/chart/templates/deployment.yaml
+++ b/apps/idem-idp/k8s/chart/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
@@ -19,6 +23,10 @@ spec:
       {{- end }}
     spec:
       automountServiceAccountToken: false
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"

--- a/apps/idem-idp/k8s/chart/templates/pdb.yaml
+++ b/apps/idem-idp/k8s/chart/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+{{- end }}

--- a/apps/idem-idp/k8s/chart/values.yaml
+++ b/apps/idem-idp/k8s/chart/values.yaml
@@ -31,6 +31,26 @@ healthCheck:
   timeoutSeconds: 5
   readinessPeriodSeconds: 10
 
+# High-availability settings (disabled by default for single-node compatibility)
+# Override in environment-specific values for prod
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+topologySpreadConstraints: []
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app: idem-idp
+
 # Pod annotations
 podAnnotations: {}
 

--- a/apps/web/k8s/README.md
+++ b/apps/web/k8s/README.md
@@ -22,6 +22,26 @@ ArgoCD Application(Set) and routing are managed externally (e.g. eventuras-infra
 | `healthCheck.path` | Health check path | `/api/healthz` |
 | `podAnnotations` | Pod annotations (e.g. Infisical auto-reload) | `{}` |
 | `env` | Non-sensitive environment variables | `{}` |
+| `strategy` | Deployment strategy (e.g. RollingUpdate) | `{}` |
+| `podDisruptionBudget.enabled` | Enable PodDisruptionBudget | `false` |
+| `podDisruptionBudget.minAvailable` | Minimum available pods during disruption | `1` |
+| `topologySpreadConstraints` | Spread pods across nodes | `[]` |
+
+### High availability
+
+By default the chart runs a single replica with no HA settings, suitable for development or single-node clusters. For production, override via ArgoCD:
+
+```yaml
+replicaCount: 2
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
 
 Sensitive values belong in `eventuras-web-secrets` (Kubernetes Secret / Infisical).
 

--- a/apps/web/k8s/templates/deployment.yaml
+++ b/apps/web/k8s/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ .Chart.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
@@ -21,6 +25,10 @@ spec:
       # Security: Disable service account token automounting
       # Next.js app doesn't need to call Kubernetes API
       automountServiceAccountToken: false
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"

--- a/apps/web/k8s/templates/pdb.yaml
+++ b/apps/web/k8s/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (.Values.replicaCount | int) 1) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+{{- end }}

--- a/apps/web/k8s/values.yaml
+++ b/apps/web/k8s/values.yaml
@@ -35,6 +35,26 @@ healthCheck:
   timeoutSeconds: 5
   readinessPeriodSeconds: 10
 
+# High-availability settings (disabled by default for single-node compatibility)
+# Override in environment-specific values for prod
+strategy: {}
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 0
+#     maxSurge: 1
+
+podDisruptionBudget:
+  enabled: false
+  minAvailable: 1
+
+topologySpreadConstraints: []
+#   - maxSkew: 1
+#     topologyKey: kubernetes.io/hostname
+#     whenUnsatisfiable: ScheduleAnyway
+#     labelSelector:
+#       matchLabels:
+#         app: eventuras-web
+
 # Pod annotations – merged onto template.metadata.annotations
 # Use this to trigger rollouts on secret changes (e.g. Infisical auto-reload)
 podAnnotations: {}


### PR DESCRIPTION
Add configurable strategy, PodDisruptionBudget, and topologySpreadConstraints to all 6 charts (api, web, convertoapi, idem-idp, idem-admin, historia).

Defaults remain single-replica with no HA settings, keeping single-node compatibility. For production, override via ArgoCD with replicaCount >= 2 to enable rolling updates and PDB.

PDB includes a safety guard requiring replicaCount > 1 to prevent blocking node-drain on single-replica deployments.