### PR TITLE
feat(api): add .NET Aspire for local dev orchestration and observability

### DIFF
--- a/.changeset/aspire-apphost.md
+++ b/.changeset/aspire-apphost.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/api": minor
+---
+
+Add .NET Aspire for local development orchestration and observability. Run `dotnet run --project src/Eventuras.AppHost` to start PostgreSQL and the API with an Aspire Dashboard for real-time logs, traces, and metrics. OpenTelemetry exports to Grafana (Prometheus/Loki/Tempo) when `OTEL_EXPORTER_OTLP_ENDPOINT` is set.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,9 @@ This project uses specialized agents for different contexts:
 
 - **Scope**: `apps/api/`
 - **File**: `.github/agents/backend-developer.md`
-- **Tech**: C# .NET, ASP.NET Core, Entity Framework Core, PostgreSQL
+- **Tech**: C# .NET, ASP.NET Core, Entity Framework Core, PostgreSQL, .NET Aspire
 - **Focus**: API development, business logic, database migrations, external integrations
+- **Run locally**: `dotnet run --project src/Eventuras.AppHost` (starts PostgreSQL + API + Aspire Dashboard)
 
 ### Frontend Agent
 
@@ -428,5 +429,27 @@ const variants = {
 - Should be explicitly documented with a comment explaining why
 
 ## Development Environment Tips
+
+### Running the API with Aspire
+
+The API project uses .NET Aspire for local development orchestration. Run the AppHost to start everything:
+
+```bash
+cd apps/api
+dotnet run --project src/Eventuras.AppHost
+```
+
+This automatically starts PostgreSQL in a Docker container and the API with the correct connection string. The Aspire Dashboard URL is printed to the terminal and provides real-time logs, traces, and metrics.
+
+The key Aspire projects:
+
+- `src/Eventuras.AppHost` — Orchestrator that defines the application model (PostgreSQL + API)
+- `src/Eventuras.ServiceDefaults` — Shared OpenTelemetry, health checks, service discovery, and HTTP resilience
+
+To run the API without Aspire (e.g., when you manage PostgreSQL separately):
+
+```bash
+dotnet run --project src/Eventuras.WebApi
+```
 
 ### Monorepo Navigation

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -19,6 +19,8 @@ COPY ./src/Eventuras.Services.SendGrid/*.csproj ./src/Eventuras.Services.SendGri
 COPY ./src/Eventuras.Services.Smtp/*.csproj ./src/Eventuras.Services.Smtp/
 COPY ./src/Eventuras.Services.Stripe/*.csproj ./src/Eventuras.Services.Stripe/
 COPY ./src/Eventuras.Services.Twilio/*.csproj ./src/Eventuras.Services.Twilio/
+COPY ./src/Eventuras.AppHost/*.csproj ./src/Eventuras.AppHost/
+COPY ./src/Eventuras.ServiceDefaults/*.csproj ./src/Eventuras.ServiceDefaults/
 COPY ./src/Eventuras.WebApi/*.csproj ./src/Eventuras.WebApi/
 COPY ./src/Losol.Communication.Email/*.csproj ./src/Losol.Communication.Email/
 COPY ./src/Losol.Communication.Sms/*.csproj ./src/Losol.Communication.Sms/

--- a/apps/api/Eventuras.slnx
+++ b/apps/api/Eventuras.slnx
@@ -16,6 +16,8 @@
     <Project Path="src/Eventuras.Services.Stripe/Eventuras.Services.Stripe.csproj" />
     <Project Path="src/Eventuras.Services.Twilio/Eventuras.Services.Twilio.csproj" />
     <Project Path="src/Eventuras.Services/Eventuras.Services.csproj" />
+    <Project Path="src/Eventuras.AppHost/Eventuras.AppHost.csproj" />
+    <Project Path="src/Eventuras.ServiceDefaults/Eventuras.ServiceDefaults.csproj" />
     <Project Path="src/Eventuras.WebApi/Eventuras.WebApi.csproj" />
     <Project Path="src/Losol.Communication.Email/Losol.Communication.Email.csproj" />
     <Project Path="src/Losol.Communication.Sms/Losol.Communication.Sms.csproj" />

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -34,9 +34,29 @@ Before you can run the API locally, ensure you have the following installed:
 
 ## Getting Started
 
-### Set Up PostgreSQL Database
+### Quick Start with Aspire (recommended)
 
-The easiest way would be to use an docker compose file, for example from the `losol/dockers` [repo](https://github.com/losol/dockers/tree/master/postgres).
+The fastest way to get started is with .NET Aspire, which orchestrates PostgreSQL and the API with a single command:
+
+```bash
+dotnet run --project src/Eventuras.AppHost
+```
+
+This will:
+
+- Start a PostgreSQL container with a pre-configured `eventuras` database
+- Start the API with the connection string automatically injected
+- Open the **Aspire Dashboard** where you can inspect logs, traces, and metrics in real time
+
+You still need to configure an identity provider (see below), but the database setup is handled for you.
+
+### Manual Setup
+
+If you prefer to manage PostgreSQL yourself, follow the steps below.
+
+#### Set Up PostgreSQL Database
+
+The easiest way would be to use a docker compose file, for example from the `losol/dockers` [repo](https://github.com/losol/dockers/tree/master/postgres).
 
 Create a new PostgreSQL database for the project, and assign a user with permissions to use the database.
 
@@ -54,9 +74,25 @@ dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Server=SERVER_NAM
 
 Remember to open the necessary firewall rules to allow your local machine to connect to the Azure PostgreSQL instance.
 
+#### Apply Database Migrations
+
+Run Entity Framework migrations to set up the database schema:
+
+```bash
+dotnet ef database update --project src/Eventuras.WebApi
+```
+
+#### Run the API
+
+Start the development server:
+
+```bash
+dotnet run --project src/Eventuras.WebApi
+```
+
 ### Set up identity provider
 
-Set Environment variables for identy provider detais, or set user-secrets for local development. You should at least set  the following: `Auth:ClientId`, `Auth:ClientSecret`, `Auth:Issuer`, and `Auth:ApiIdentifier`.
+Set environment variables for identity provider details, or set user-secrets for local development. You should at least set the following: `Auth:ClientId`, `Auth:ClientSecret`, `Auth:Issuer`, and `Auth:ApiIdentifier`.
 
 Example using dotnet user-secrets:
 
@@ -67,33 +103,18 @@ dotnet user-secrets set "Auth:Issuer" "https://your-tenant.auth0.com/" --project
 dotnet user-secrets set "Auth:ApiIdentifier" "your-api-id" --project src/Eventuras.WebApi
 ```
 
-
-### Apply Database Migrations
-
-Run Entity Framework migrations to set up the database schema:
-
-```bash
-dotnet ef database update --project src/Eventuras.WebApi
-```
-
-### Optional: Use ConvertoAPI for pdf generation
+### Optional: Use ConvertoAPI for PDF generation
 
 If you want to use ConvertoAPI for PDF generation, set `Converto:ClientId`, `Converto:ClientSecret`, `Converto:PdfEndpointUrl`, and `Converto:TokenEndpointUrl`.
 
-
-### Run the API
-
-Start the development server:
-
-```bash
-dotnet run --project src/Eventuras.WebApi
-```
+### Endpoints
 
 The API will be available at:
 - **HTTP**: `http://localhost:5000`
 - **HTTPS**: `https://localhost:5001`
 - **API Docs**: `http://localhost:5000/docs` (enabled in Development, or via `FeatureManagement:EnableApiDocs`)
 - **Integration tests**: `https://localhost:5002`
+- **Aspire Dashboard**: Shown in terminal output when running via AppHost
 
 
 ## Development
@@ -136,6 +157,41 @@ Once the application is running, you can explore the API documentation at:
 - OpenAPI JSON: `https://localhost:5001/openapi/v3.json`
 
 API docs are enabled by default in Development. In other environments, set `FeatureManagement:EnableApiDocs` to `true`.
+
+## Observability
+
+The API uses OpenTelemetry (via the ServiceDefaults project) to emit traces, metrics, and structured logs. During local development these are visible in the Aspire Dashboard. In production you can export the same telemetry to your Grafana stack.
+
+### Exporting to Grafana (Prometheus / Loki / Tempo)
+
+Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to point at an OpenTelemetry Collector or Grafana Alloy instance:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy.internal:4317
+```
+
+The collector/Alloy then forwards:
+
+- **Metrics** to Prometheus (for Grafana dashboards)
+- **Traces** to Tempo (for distributed tracing)
+- **Logs** to Loki (for log aggregation)
+
+Example Alloy receiver config:
+
+```alloy
+otelcol.receiver.otlp "default" {
+  grpc { endpoint = "0.0.0.0:4317" }
+  http { endpoint = "0.0.0.0:4318" }
+
+  output {
+    metrics = [otelcol.exporter.prometheus.default.input]
+    traces  = [otelcol.exporter.otlp.tempo.input]
+    logs    = [otelcol.exporter.loki.default.input]
+  }
+}
+```
+
+When running via the AppHost locally, `OTEL_EXPORTER_OTLP_ENDPOINT` is set automatically to point at the Aspire Dashboard. No extra config is needed for local development.
 
 ## Project Structure
 

--- a/apps/api/src/Eventuras.AppHost/Eventuras.AppHost.csproj
+++ b/apps/api/src/Eventuras.AppHost/Eventuras.AppHost.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.2.2" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAspireHost>true</IsAspireHost>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.2" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Eventuras.WebApi\Eventuras.WebApi.csproj" />
+  </ItemGroup>
+</Project>

--- a/apps/api/src/Eventuras.AppHost/Program.cs
+++ b/apps/api/src/Eventuras.AppHost/Program.cs
@@ -1,0 +1,12 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("postgres")
+    .WithDataVolume();
+
+var db = postgres.AddDatabase("DefaultConnection", databaseName: "eventuras");
+
+builder.AddProject<Projects.Eventuras_WebApi>("api")
+    .WithReference(db)
+    .WaitFor(db);
+
+builder.Build().Run();

--- a/apps/api/src/Eventuras.ServiceDefaults/Eventuras.ServiceDefaults.csproj
+++ b/apps/api/src/Eventuras.ServiceDefaults/Eventuras.ServiceDefaults.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsAspireSharedProject>true</IsAspireSharedProject>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+  </ItemGroup>
+</Project>

--- a/apps/api/src/Eventuras.ServiceDefaults/Extensions.cs
+++ b/apps/api/src/Eventuras.ServiceDefaults/Extensions.cs
@@ -1,0 +1,76 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Eventuras.ServiceDefaults;
+
+public static class Extensions
+{
+    public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.ConfigureOpenTelemetry();
+        builder.AddDefaultHealthChecks();
+
+        builder.Services.AddServiceDiscovery();
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder ConfigureOpenTelemetry(this IHostApplicationBuilder builder)
+    {
+        builder.Logging.AddOpenTelemetry(logging =>
+        {
+            logging.IncludeFormattedMessage = true;
+            logging.IncludeScopes = true;
+        });
+
+        var otel = builder.Services.AddOpenTelemetry()
+            .WithMetrics(metrics =>
+            {
+                metrics.AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation()
+                    .AddRuntimeInstrumentation();
+            })
+            .WithTracing(tracing =>
+            {
+                tracing.AddSource(builder.Environment.ApplicationName)
+                    .AddAspNetCoreInstrumentation()
+                    .AddHttpClientInstrumentation();
+            });
+
+        if (!string.IsNullOrWhiteSpace(builder.Configuration["OTEL_EXPORTER_OTLP_ENDPOINT"]))
+        {
+            otel.UseOtlpExporter();
+        }
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks()
+            .AddCheck("self", () => HealthCheckResult.Healthy(), tags: ["live"]);
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Maps the /alive liveness endpoint. The existing /health and /health/converto
+    /// endpoints in Program.cs are preserved as-is.
+    /// </summary>
+    public static WebApplication MapDefaultEndpoints(this WebApplication app)
+    {
+        app.MapHealthChecks("/alive", new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live"),
+        });
+
+        return app;
+    }
+}

--- a/apps/api/src/Eventuras.WebApi/Eventuras.WebApi.csproj
+++ b/apps/api/src/Eventuras.WebApi/Eventuras.WebApi.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\Eventuras.Services\Eventuras.Services.csproj" />
     <ProjectReference Include="..\Eventuras.Infrastructure\Eventuras.Infrastructure.csproj" />
     <ProjectReference Include="..\Eventuras.Domain\Eventuras.Domain.csproj" />
+    <ProjectReference Include="..\Eventuras.ServiceDefaults\Eventuras.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Losol.Communication.Email\Losol.Communication.Email.csproj" />
     <ProjectReference Include="..\Losol.Communication.Sms\Losol.Communication.Sms.csproj" />
   </ItemGroup>

--- a/apps/api/src/Eventuras.WebApi/Program.cs
+++ b/apps/api/src/Eventuras.WebApi/Program.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
+using Eventuras.ServiceDefaults;
 using Eventuras.Services;
 using Eventuras.Services.BackgroundJobs;
 using Eventuras.Services.Constants;
@@ -30,9 +31,11 @@ using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.AddServiceDefaults();
+
 // Configure Serilog (reads from appsettings.json "Serilog" section)
 builder.Host.UseSerilog((context, config) =>
-    config.ReadFrom.Configuration(context.Configuration));
+    config.ReadFrom.Configuration(context.Configuration), writeToProviders: true);
 
 // Configure Sentry (activates automatically when Sentry:Dsn is set)
 builder.WebHost.UseSentry();
@@ -88,7 +91,6 @@ builder.Services.AddSmsServices();
 builder.Services.AddInvoicingServices(builder.Configuration, features);
 builder.Services.AddApplicationServices(builder.Configuration);
 builder.Services.AddMemoryCache();
-builder.Services.AddHealthChecks();
 builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));
 
 builder.Services.AddCors(options =>
@@ -179,6 +181,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
+app.MapDefaultEndpoints();
 
 // Kubernetes liveness/readiness probe – excludes external dependency checks.
 app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions


### PR DESCRIPTION
Adds AppHost and ServiceDefaults projects so devs can start PostgreSQL and the API with a single command and get an Aspire Dashboard with logs, traces, and metrics out of the box. OpenTelemetry exports to Grafana/Prometheus/Loki/Tempo when OTEL_EXPORTER_OTLP_ENDPOINT is set.