### PR TITLE
Refactor/eventuras logger

### DIFF
--- a/.changeset/logger-transport-architecture.md
+++ b/.changeset/logger-transport-architecture.md
@@ -13,7 +13,8 @@ Add pluggable transport architecture for structured logging.
 - **OpenTelemetry as optional peer deps**: OTel packages moved from hard dependencies to optional peer dependencies — install only if you need tracing.
 - **Browser/edge safety**: `process.env` access is guarded via `globalThis` checks — no more crashes in client components or edge runtimes.
 - **Configurable service name**: OTel integration no longer hardcodes a service name — uses `OTEL_SERVICE_NAME` env var or accepts it as an option.
-- **Pretty printing**: `prettyPrint` option for human-readable log output. Auto-enabled in development when using PinoTransport.
+- **Pretty printing**: Built-in zero-dependency pretty formatter for human-readable dev output. Auto-enabled in development when using PinoTransport.
+- **Pipeline-friendly output**: ISO timestamps and string log levels (`"info"` instead of `30`) by default — no level mapping needed in Loki/Grafana Alloy.
 - **Type safety**: All `any` types in OTel module replaced with proper interfaces.
 
 ## Public API

--- a/.changeset/logger-transport-architecture.md
+++ b/.changeset/logger-transport-architecture.md
@@ -15,6 +15,9 @@ Add pluggable transport architecture for structured logging.
 - **Configurable service name**: OTel integration no longer hardcodes a service name — uses `OTEL_SERVICE_NAME` env var or accepts it as an option.
 - **Pretty printing**: Built-in zero-dependency pretty formatter for human-readable dev output. Auto-enabled in development when using PinoTransport.
 - **Pipeline-friendly output**: ISO timestamps and string log levels (`"info"` instead of `30`) by default — no level mapping needed in Loki/Grafana Alloy.
+- **Node subpath export**: `@eventuras/logger/node` exposes `createPrettyStream`/`formatLogLine` — keeping the root entrypoint free of `node:stream` imports for browser safety.
+- **Environment detection**: `createDefaultTransport()` auto-selects ConsoleTransport in non-Node environments (browsers, edge runtimes).
+- **Static method overloads**: `Logger.info('message')` now works alongside `Logger.info({ namespace: 'x' }, 'message')`.
 - **Type safety**: All `any` types in OTel module replaced with proper interfaces.
 
 ## Public API
@@ -29,6 +32,10 @@ logger.error({ error: err }, 'Something failed');
 
 // Static logging (unchanged)
 Logger.info({ namespace: 'quick' }, 'One-off log');
+
+// NEW: Static logging with string shorthand
+Logger.info('Quick message');
+Logger.error('Something broke');
 
 // NEW: Custom transport
 import { ConsoleTransport } from '@eventuras/logger';

--- a/.changeset/logger-transport-architecture.md
+++ b/.changeset/logger-transport-architecture.md
@@ -1,0 +1,45 @@
+---
+"@eventuras/logger": minor
+---
+
+Add pluggable transport architecture for structured logging.
+
+## What changed
+
+- **LogTransport interface**: New extension point for custom log backends. Implement `log()`, `child()`, and optionally `flush()`/`shutdown()` to route logs anywhere.
+- **PinoTransport** (default): Wraps Pino — used automatically with zero config. Exposes `.pino` for advanced integrations (OTel instrumentation, custom serializers).
+- **ConsoleTransport**: Lightweight transport using `console.log/warn/error`. Works in browsers, edge runtimes, and test environments without Node.js dependencies.
+- **Configurable transport**: `Logger.configure({ transport: new ConsoleTransport() })` to swap backends at startup.
+- **OpenTelemetry as optional peer deps**: OTel packages moved from hard dependencies to optional peer dependencies — install only if you need tracing.
+- **Browser/edge safety**: `process.env` access is guarded via `globalThis` checks — no more crashes in client components or edge runtimes.
+- **Configurable service name**: OTel integration no longer hardcodes a service name — uses `OTEL_SERVICE_NAME` env var or accepts it as an option.
+- **Type safety**: All `any` types in OTel module replaced with proper interfaces.
+
+## Public API
+
+The existing API is fully backwards compatible:
+
+```ts
+// Scoped logger (unchanged)
+const logger = Logger.create({ namespace: 'MyModule' });
+logger.info('Hello');
+logger.error({ error: err }, 'Something failed');
+
+// Static logging (unchanged)
+Logger.info({ namespace: 'quick' }, 'One-off log');
+
+// NEW: Custom transport
+import { ConsoleTransport } from '@eventuras/logger';
+Logger.configure({ transport: new ConsoleTransport() });
+
+// NEW: Access transport
+const transport = Logger.getTransport();
+```
+
+`Logger.getPinoInstance()` is deprecated — use `Logger.getTransport()` or cast to `PinoTransport` if you need the raw Pino instance.
+
+## Package metadata
+
+- Package is now publishable (removed `private` flag)
+- Added `license`, `repository`, `homepage`, `bugs`, `keywords`, `engines` fields
+- ESM-only, Node 20+

--- a/.changeset/logger-transport-architecture.md
+++ b/.changeset/logger-transport-architecture.md
@@ -13,6 +13,7 @@ Add pluggable transport architecture for structured logging.
 - **OpenTelemetry as optional peer deps**: OTel packages moved from hard dependencies to optional peer dependencies — install only if you need tracing.
 - **Browser/edge safety**: `process.env` access is guarded via `globalThis` checks — no more crashes in client components or edge runtimes.
 - **Configurable service name**: OTel integration no longer hardcodes a service name — uses `OTEL_SERVICE_NAME` env var or accepts it as an option.
+- **Pretty printing**: `prettyPrint` option for human-readable log output. Auto-enabled in development when using PinoTransport.
 - **Type safety**: All `any` types in OTel module replaced with proper interfaces.
 
 ## Public API

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -92,9 +92,9 @@ interface LogTransport {
 }
 ```
 
-### PinoTransport (default)
+### PinoTransport (default in Node.js)
 
-[Pino](https://getpino.io) is included as a dependency and used automatically. No configuration needed for most use cases.
+[Pino](https://getpino.io) is included as a dependency and used automatically in Node.js environments. In browser/edge runtimes, `ConsoleTransport` is used as the default instead.
 
 ```typescript
 import { Logger, PinoTransport } from "@eventuras/logger";
@@ -111,7 +111,7 @@ Logger.configure({
 
 ### ConsoleTransport
 
-A lightweight transport using native `console` methods. Useful for browsers, edge runtimes, and testing:
+A lightweight transport using native `console` methods. Automatically selected as the default in browser and edge runtimes. Also useful for testing:
 
 ```typescript
 import { Logger, ConsoleTransport } from "@eventuras/logger";
@@ -286,6 +286,22 @@ import type {
   LoggerConfig,
   ErrorLoggerOptions,
 } from "@eventuras/logger";
+```
+
+## Subpath Exports
+
+| Import path                       | Contents                                                        | Environment |
+| --------------------------------- | --------------------------------------------------------------- | ----------- |
+| `@eventuras/logger`               | Logger, types, PinoTransport, ConsoleTransport, httpLogger      | Universal   |
+| `@eventuras/logger/node`          | `formatLogLine`, `createPrettyStream` (depends on `node:stream`) | Node.js     |
+| `@eventuras/logger/opentelemetry` | `setupOpenTelemetryLogger`, `shutdownOpenTelemetryLogger`        | Node.js     |
+
+### Node-only Pretty-print Utilities
+
+The pretty-print formatter and stream are available via a separate entry point to avoid pulling `node:stream` into browser bundles:
+
+```typescript
+import { createPrettyStream, formatLogLine } from "@eventuras/logger/node";
 ```
 
 ## License

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -290,4 +290,4 @@ import type {
 
 ## License
 
-MIT
+Apache-2.0

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -1,26 +1,16 @@
 # @eventuras/logger
 
-A flexible logging solution for Eventuras with two separate utilities:
-
-- **Logger** - Production-ready structured logging with Pino
-- **Debug** - Development debugging with debug-js
-- **OpenTelemetry** - Optional integration for sending logs to any OTel-compatible backend
+A structured logging library with pluggable transports and optional OpenTelemetry integration. Works in Node.js and browser environments.
 
 ## Features
 
-### Logger (Production)
-- 🎯 **Scoped loggers** - Create logger instances with persistent context
-- 🎨 **Pretty printing** - Beautiful logs in development mode
-- 🔒 **Auto-redaction** - Protect sensitive data in logs
-- 📊 **Log levels** - Control verbosity per logger or globally
-- 🔍 **Correlation IDs** - Track requests across services
-- 🌐 **Context fields** - Add persistent metadata to all logs
-
-### Debug (Development)
-- 🐛 **Namespace filtering** - Enable/disable debug output by namespace
-- 🎯 **Browser support** - Works in browser with localStorage
-- 📦 **Lightweight** - Only debug-js, no production overhead
-- 🔧 **Development-only** - Separate from production logging
+- 🎯 **Scoped loggers** — Create instances with persistent context and namespace
+- 🔌 **Pluggable transports** — Use Pino (default), console, or bring your own
+- 🔒 **Auto-redaction** — Protect sensitive fields in log output
+- 📊 **Log levels** — Control verbosity per logger or globally
+- 🔍 **Correlation IDs** — Track requests across services
+- 🌐 **OpenTelemetry** — Optional integration for any OTel-compatible backend
+- 🌍 **Cross-runtime** — Works in Node.js, browsers, and edge runtimes
 
 ## Installation
 
@@ -28,508 +18,276 @@ A flexible logging solution for Eventuras with two separate utilities:
 pnpm add @eventuras/logger
 ```
 
-## Logger (Production Logging)
+## Quick Start
 
-Use `Logger` for all production logging with structured data, context, and levels.
-
-### Static Methods (One-off logs)
+### Scoped Logger (recommended)
 
 ```typescript
-import { Logger } from '@eventuras/logger';
+import { Logger } from "@eventuras/logger";
 
-// Simple logs
-Logger.info('Server started');
-Logger.warn('Memory usage high');
-Logger.error({ error: new Error('Failed') }, 'Database connection failed');
-```
-
-### Scoped Logger (Recommended for components/modules)
-
-```typescript
-import { Logger } from '@eventuras/logger';
-
-const logger = Logger.create({ namespace: 'CollectionEditor' });
-
-logger.info('Updating collection...');
-logger.info('Collection saved successfully');
-logger.error({ error: err }, 'Failed to save collection');
-```
-
-## Advanced Usage
-
-### Context Fields
-
-Add persistent fields to all logs from a logger instance:
-
-```typescript
 const logger = Logger.create({
-  namespace: 'API',
-  context: {
-    userId: user.id,
-    collectionId: collection.id,
-  },
+  namespace: "web:admin:events",
+  context: { module: "EventEditor" },
 });
 
-logger.info('Event added', { eventId: 123 });
-// Logs: { namespace: 'API', userId: 42, collectionId: 99, eventId: 123, msg: 'Event added' }
+logger.info({ eventId: 42 }, "Event updated");
+logger.error({ error }, "Failed to save event");
 ```
 
-### Correlation IDs (Request Tracking)
-
-Track requests across your microservices:
+### Static Methods (one-off logs)
 
 ```typescript
-const logger = Logger.create({
-  namespace: 'EventsController',
-  correlationId: req.headers['x-correlation-id'],
-  context: { userId: req.user.id },
-});
+import { Logger } from "@eventuras/logger";
 
-logger.info('Processing request');
-// Logs include correlationId for easy trace lookup
-```
-
-### Log Levels
-
-Control verbosity per logger instance:
-
-```typescript
-const logger = Logger.create({
-  namespace: 'DebugComponent',
-  level: 'debug', // Only log debug and above (debug, info, warn, error, fatal)
-});
-
-logger.trace('Very detailed'); // Won't log (below debug level)
-logger.debug('Debugging info'); // Will log
-logger.info('Important event'); // Will log
-```
-
-## Global Configuration
-
-Configure the logger once at application startup:
-
-```typescript
-import { Logger } from '@eventuras/logger';
-
-// In your app initialization (e.g., app.ts or layout.tsx)
-Logger.configure({
-  prettyPrint: process.env.NODE_ENV === 'development',
-  level: process.env.LOG_LEVEL || 'info',
-  redact: ['password', 'token', 'apiKey', 'authorization', 'secret'],
-  destination: process.env.LOG_FILE, // Optional file output
-});
-```
-
-## Environment Variables
-
-### Development (Browser)
-
-Enable namespace filtering in the browser console:
-
-```javascript
-localStorage.debug = 'eventuras:*'; // All logs
-localStorage.debug = 'eventuras:auth*'; // Only auth logs
-localStorage.debug = 'eventuras:CollectionEditor'; // Specific namespace
-```
-
-### Server (Node.js)
-
-```bash
-# Enable all Eventuras logs
-DEBUG=eventuras:*
-
-# Enable specific namespaces
-DEBUG=eventuras:auth*,eventuras:api*
-
-# Set global log level
-LOG_LEVEL=debug
-
-# Write logs to file
-LOG_FILE=/var/log/eventuras.log
+Logger.info("Server started");
+Logger.warn({ memoryUsage: "85%" }, "Memory usage high");
+Logger.error({ error }, "Unhandled exception");
 ```
 
 ## Log Levels
 
 From most to least verbose:
 
-- `trace` (10) - Most detailed, for fine-grained debugging
-- `debug` (20) - Debugging information
-- `info` (30) - General informational messages (default)
-- `warn` (40) - Warning messages
-- `error` (50) - Error messages
-- `fatal` (60) - Critical errors that may cause shutdown
+| Level   | Value | Use case                     |
+| ------- | ----- | ---------------------------- |
+| `trace` | 10    | Fine-grained debugging       |
+| `debug` | 20    | Development debugging        |
+| `info`  | 30    | General events **(default)** |
+| `warn`  | 40    | Warnings                     |
+| `error` | 50    | Errors                       |
+| `fatal` | 60    | Critical/shutdown errors     |
 
-## Security: Auto-Redaction
+## Configuration
 
-Sensitive fields are automatically redacted in production:
-
-```typescript
-logger.info({
-  username: 'john',
-  password: 'secret123', // Will be logged as '[REDACTED]'
-  apiKey: 'key_123', // Will be logged as '[REDACTED]'
-});
-```
-
-Default redacted paths:
-- `password`
-- `token`
-- `apiKey`
-- `authorization`
-- `secret`
-
-Add custom redaction patterns via `Logger.configure()`.
-
-## Examples
-
-### React Component
+Configure the logger once at application startup:
 
 ```typescript
-'use client';
-import { Logger } from '@eventuras/logger';
-import { useEffect } from 'react';
+import { Logger } from "@eventuras/logger";
 
-const CollectionEditor = ({ collection }) => {
-  const logger = Logger.create({
-    namespace: 'CollectionEditor',
-    context: { collectionId: collection.id },
-  });
-
-  useEffect(() => {
-    logger.info('Component mounted');
-    return () => logger.info('Component unmounted');
-  }, []);
-
-  const handleSave = async () => {
-    try {
-      logger.info('Saving collection...');
-      await saveCollection(collection);
-      logger.info('Collection saved successfully');
-    } catch (error) {
-      logger.error({ error }, 'Failed to save collection');
-    }
-  };
-
-  return <button onClick={handleSave}>Save</button>;
-};
-```
-
-### API Route Handler
-
-```typescript
-import { Logger } from '@eventuras/logger';
-
-export async function POST(req: Request) {
-  const logger = Logger.create({
-    namespace: 'EventsAPI',
-    correlationId: req.headers.get('x-correlation-id') || crypto.randomUUID(),
-    context: { endpoint: '/api/events' },
-  });
-
-  try {
-    logger.info('Received event creation request');
-    const data = await req.json();
-    logger.debug({ eventData: data }, 'Parsed request body');
-
-    const result = await createEvent(data);
-    logger.info({ eventId: result.id }, 'Event created successfully');
-
-    return Response.json(result);
-  } catch (error) {
-    logger.error({ error }, 'Failed to create event');
-    return Response.json({ error: 'Internal server error' }, { status: 500 });
-  }
-}
-```
-
-## TypeScript
-
-All types are exported:
-
-```typescript
-import type { LoggerOptions, LogLevel, LoggerConfig } from '@eventuras/logger';
-```
-
----
-
-## Debug (Development Debugging)
-
-Use `Debug` for development-only debugging with namespace filtering. This is completely separate from Logger and uses debug-js.
-
-### Basic Usage
-
-```typescript
-import { Debug } from '@eventuras/logger';
-
-// Create a debug instance for a namespace
-const debug = Debug.create('CollectionEditor');
-
-debug('Loading collection...');
-debug('Collection loaded:', collection);
-debug('User action:', { action: 'save', userId: 123 });
-```
-
-### Quick Debug Calls
-
-```typescript
-import { Debug } from '@eventuras/logger';
-
-// One-off debug without creating an instance
-Debug.log('API', 'Request received:', req);
-Debug.log('EventHandler', 'Processing event:', event);
-```
-
-### Enabling Debug Output
-
-#### In Node.js (Server)
-
-```bash
-# Enable all Eventuras debug output
-DEBUG=eventuras:* node app.js
-
-# Enable specific namespaces
-DEBUG=eventuras:auth*,eventuras:api* node app.js
-
-# Enable specific namespace only
-DEBUG=eventuras:CollectionEditor node app.js
-```
-
-#### In Browser
-
-```javascript
-// In browser console
-localStorage.debug = 'eventuras:*'; // All namespaces
-localStorage.debug = 'eventuras:auth*'; // Auth namespaces only
-localStorage.debug = 'eventuras:CollectionEditor'; // Specific namespace
-
-// Then refresh the page
-```
-
-### Programmatic Control
-
-```typescript
-import { Debug } from '@eventuras/logger';
-
-// Enable debug output
-Debug.enable('eventuras:*');
-
-// Disable debug output
-Debug.disable();
-
-// Check if a namespace is enabled
-if (Debug.isEnabled('CollectionEditor')) {
-  console.log('CollectionEditor debugging is active');
-}
-```
-
-### When to Use Debug vs Logger
-
-**Use Debug when:**
-- 🐛 Debugging during development
-- 🔍 Need to trace code execution flow
-- 💡 Want to toggle output with DEBUG env var
-- 🚫 Don't need logs in production
-
-**Use Logger when:**
-- 📊 Production logging
-- 📝 Need structured data
-- 🔒 Need security (redaction)
-- 📈 Monitoring and analytics
-- 🔍 Correlation IDs and context
-
-### Example: Using Both Together
-
-```typescript
-import { Logger, Debug } from '@eventuras/logger';
-
-const logger = Logger.create({ 
-  namespace: 'CollectionEditor',
-  context: { collectionId: 123 }
-});
-const debug = Debug.create('CollectionEditor');
-
-async function saveCollection(data: CollectionDto) {
-  // Use Debug for development tracing
-  debug('saveCollection called with:', data);
-  
-  try {
-    // Use Logger for production-worthy logs
-    logger.info('Saving collection');
-    
-    debug('Validating data...');
-    validateData(data);
-    
-    debug('Calling API...');
-    const result = await api.save(data);
-    
-    logger.info({ collectionId: result.id }, 'Collection saved successfully');
-    return result;
-  } catch (error) {
-    debug('Error occurred:', error);
-    logger.error({ error }, 'Failed to save collection');
-    throw error;
-  }
-}
-```
-
-In development with `DEBUG=eventuras:*`, you'll see both debug traces and logger output.  
-In production, only Logger output is captured (Debug is silent unless explicitly enabled).
-
----
-
-## OpenTelemetry Integration (Optional)
-
-Send logs to any OpenTelemetry-compatible backend (Sentry, Grafana, Jaeger, etc.) without vendor lock-in.
-
-### Installation
-
-Install the required OpenTelemetry packages as peer dependencies:
-
-```bash
-pnpm add @opentelemetry/api @opentelemetry/api-logs @opentelemetry/sdk-logs @opentelemetry/instrumentation-pino @opentelemetry/exporter-logs-otlp-http
-```
-
-### Basic Setup
-
-In your application's instrumentation or entry point (e.g., `instrumentation.ts` or `sentry.server.config.ts`):
-
-```typescript
-import { setupOpenTelemetryLogger } from '@eventuras/logger/opentelemetry';
-import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
-
-// Set up OpenTelemetry logger once at startup
-setupOpenTelemetryLogger({
-  logRecordProcessor: new BatchLogRecordProcessor(
-    new OTLPLogExporter({
-      url: process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
-      headers: {
-        'x-sentry-auth': `sentry sentry_key=${process.env.SENTRY_KEY}`
-      }
-    })
-  )
+Logger.configure({
+  level: "debug",
+  prettyPrint: process.env.NODE_ENV === "development",
+  redact: ["password", "token", "apiKey", "authorization", "secret"],
+  destination: "/var/log/app.log", // Optional file output
 });
 ```
 
 ### Environment Variables
 
 ```bash
-# Required: OTLP endpoint URL
-OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://[org].ingest.sentry.io/api/[project]/integration/otlp/v1/logs
-
-# Required: Authentication header
-OTEL_EXPORTER_OTLP_LOGS_HEADERS=x-sentry-auth=sentry sentry_key=YOUR_KEY_HERE
-
-# Optional: Service name (defaults to 'eventuras')
-OTEL_SERVICE_NAME=historia
+LOG_LEVEL=debug       # Set global log level
+NODE_ENV=development  # Enables pretty printing
 ```
 
-### Using with Sentry
+## Transports
 
-Example setup for sending logs to Sentry via OTLP:
+The library uses a pluggable transport system. A transport implements the `LogTransport` interface:
 
 ```typescript
-// sentry.server.config.ts
-import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import * as Sentry from '@sentry/nextjs';
-
-import { setupOpenTelemetryLogger } from '@eventuras/logger/opentelemetry';
-
-// Initialize Sentry
-Sentry.init({
-  dsn: process.env.SENTRY_DSN,
-  tracesSampleRate: 1.0,
-});
-
-// Set up OpenTelemetry logger integration
-const otlpLogsEndpoint = process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT;
-const otlpLogsHeaders = process.env.OTEL_EXPORTER_OTLP_LOGS_HEADERS;
-
-if (otlpLogsEndpoint && otlpLogsHeaders) {
-  const headers: Record<string, string> = {};
-  otlpLogsHeaders.split(',').forEach((header) => {
-    const [key, value] = header.split('=');
-    if (key && value) {
-      headers[key.trim()] = value.trim();
-    }
-  });
-
-  setupOpenTelemetryLogger({
-    logRecordProcessor: new BatchLogRecordProcessor(
-      new OTLPLogExporter({
-        url: otlpLogsEndpoint,
-        headers,
-      })
-    ),
-  });
+interface LogTransport {
+  log(level: LogLevel, data: Record<string, unknown>, msg?: string): void;
+  child(bindings: Record<string, unknown>): LogTransport;
+  flush?(): Promise<void>;
+  shutdown?(): Promise<void>;
 }
 ```
 
-### Features
+### PinoTransport (default)
 
-- **Vendor-neutral**: Works with any OpenTelemetry-compatible backend
-- **Server-side only**: Automatically detects browser environment and skips initialization
-- **Lazy loading**: OpenTelemetry packages are optional peer dependencies
-- **Graceful degradation**: Works without OTel packages installed (logs warning and continues)
-- **Zero configuration**: Uses environment variables by default
+[Pino](https://getpino.io) is included as a dependency and used automatically. No configuration needed for most use cases.
+
+```typescript
+import { Logger, PinoTransport } from "@eventuras/logger";
+
+// Explicit Pino configuration
+Logger.configure({
+  transport: new PinoTransport({
+    level: "debug",
+    prettyPrint: true,
+    redact: ["password", "secret"],
+  }),
+});
+```
+
+### ConsoleTransport
+
+A lightweight transport using native `console` methods. Useful for browsers, edge runtimes, and testing:
+
+```typescript
+import { Logger, ConsoleTransport } from "@eventuras/logger";
+
+Logger.configure({
+  transport: new ConsoleTransport(),
+});
+```
+
+### Custom Transport
+
+Implement the `LogTransport` interface for any logging backend:
+
+```typescript
+import type { LogTransport, LogLevel } from "@eventuras/logger";
+
+class DatadogTransport implements LogTransport {
+  log(level: LogLevel, data: Record<string, unknown>, msg?: string) {
+    // Send to Datadog, Winston, Bunyan, or any backend
+  }
+
+  child(bindings: Record<string, unknown>): LogTransport {
+    // Return a new transport with merged bindings
+    return new DatadogTransport({ ...this.config, bindings });
+  }
+}
+
+Logger.configure({ transport: new DatadogTransport() });
+```
+
+## Auto-Redaction
+
+Sensitive fields are automatically redacted:
+
+```typescript
+logger.info(
+  {
+    username: "john",
+    password: "secret123", // → '[REDACTED]'
+    apiKey: "key_123", // → '[REDACTED]'
+  },
+  "User login",
+);
+```
+
+Default redacted paths: `password`, `token`, `apiKey`, `authorization`, `secret`.
+
+Configure additional paths via `Logger.configure({ redact: [...] })`.
+
+## HTTP Header Redaction
+
+Utility for redacting sensitive HTTP headers:
+
+```typescript
+import { redactHeaders } from "@eventuras/logger";
+
+const safe = redactHeaders(request.headers);
+logger.info({ headers: safe }, "Incoming request");
+```
+
+Redacts `authorization`, `cookie`, `set-cookie`, `x-api-key`, `x-auth-token`, and `proxy-authorization`.
+
+## OpenTelemetry Integration
+
+Send logs to any OTel-compatible backend (Sentry, Grafana, Jaeger, etc.) without vendor lock-in.
+
+### Install OTel Packages
+
+```bash
+pnpm add @opentelemetry/api @opentelemetry/api-logs @opentelemetry/sdk-logs \
+  @opentelemetry/instrumentation-pino @opentelemetry/exporter-logs-otlp-http
+```
+
+These are optional peer dependencies — the library works fine without them.
+
+### Setup
+
+```typescript
+import { setupOpenTelemetryLogger } from "@eventuras/logger/opentelemetry";
+import { OTLPLogExporter } from "@opentelemetry/exporter-logs-otlp-http";
+import { BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";
+
+setupOpenTelemetryLogger({
+  serviceName: "my-app",
+  logRecordProcessor: new BatchLogRecordProcessor(
+    new OTLPLogExporter({
+      url: process.env.OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
+    }),
+  ),
+});
+```
 
 ### Shutdown
 
-For clean shutdown (e.g., on process termination):
-
 ```typescript
-import { shutdownOpenTelemetryLogger } from '@eventuras/logger/opentelemetry';
+import { shutdownOpenTelemetryLogger } from "@eventuras/logger/opentelemetry";
 
-process.on('SIGTERM', async () => {
+process.on("SIGTERM", async () => {
   await shutdownOpenTelemetryLogger();
   process.exit(0);
 });
 ```
 
-### Advanced: Custom Logger Provider
+### Environment Variables
 
-```typescript
-import { setupOpenTelemetryLogger } from '@eventuras/logger/opentelemetry';
-import { LoggerProvider } from '@opentelemetry/sdk-logs';
-import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
-import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
-
-const loggerProvider = new LoggerProvider();
-const processor = new BatchLogRecordProcessor(new OTLPLogExporter());
-
-setupOpenTelemetryLogger({
-  loggerProvider,
-  logRecordProcessor: processor,
-});
+```bash
+OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://...
+OTEL_EXPORTER_OTLP_LOGS_HEADERS=x-api-key=YOUR_KEY
+OTEL_SERVICE_NAME=my-app
 ```
 
-### Disabling OpenTelemetry
+## Examples
+
+### API Route Handler
 
 ```typescript
-// Disable programmatically
-setupOpenTelemetryLogger({ enabled: false });
+import { Logger } from "@eventuras/logger";
 
-// Or don't call setupOpenTelemetryLogger at all
+export async function POST(req: Request) {
+  const logger = Logger.create({
+    namespace: "events-api",
+    correlationId: req.headers.get("x-correlation-id") || crypto.randomUUID(),
+  });
+
+  try {
+    const data = await req.json();
+    logger.info("Creating event");
+
+    const result = await createEvent(data);
+    logger.info({ eventId: result.id }, "Event created");
+
+    return Response.json(result);
+  } catch (error) {
+    logger.error({ error }, "Failed to create event");
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}
 ```
 
----
-
-## Migration from Old API
-
-**Before:**
+### Server Action
 
 ```typescript
-Logger.info({ namespace: 'CollectionEditor' }, 'Removing event');
-Logger.error({ namespace: 'CollectionEditor' }, 'Failed');
-```
+"use server";
 
-**After:**
+import { Logger } from "@eventuras/logger";
+
+const logger = Logger.create({ namespace: "web:admin:collections" });
+
+export async function updateCollection(data: CollectionDto) {
+  logger.info({ collectionId: data.id }, "Updating collection");
+
+  try {
+    const result = await api.put(data);
+    logger.info({ collectionId: data.id }, "Collection updated");
+    return { success: true, data: result };
+  } catch (error) {
+    logger.error({ error, collectionId: data.id }, "Failed to update");
+    return { success: false, error: "Update failed" };
+  }
+}
+```
 
 ## TypeScript
 
 All types are exported:
 
 ```typescript
-import type { LoggerOptions, LogLevel, LoggerConfig } from '@eventuras/logger';
+import type {
+  LogTransport,
+  LogLevel,
+  LoggerOptions,
+  LoggerConfig,
+  ErrorLoggerOptions,
+} from "@eventuras/logger";
 ```
+
+## License
+
+MIT

--- a/libs/logger/package.json
+++ b/libs/logger/package.json
@@ -39,7 +39,8 @@
   "scripts": {
     "build": "vite build",
     "dev": "vite build --watch",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "pino": "^10.3.1"
@@ -50,7 +51,8 @@
     "@opentelemetry/api-logs": "^0.214.0",
     "@opentelemetry/instrumentation-pino": "^0.60.0",
     "@opentelemetry/sdk-logs": "^0.214.0",
-    "vite": "^8.0.3"
+    "vite": "^8.0.3",
+    "vitest": "^4.1.4"
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",

--- a/libs/logger/package.json
+++ b/libs/logger/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@eventuras/logger",
   "version": "0.6.0",
-  "private": "true",
-  "description": "Logger utility for eventuras",
+  "description": "Structured logging with Pino and optional OpenTelemetry integration",
+  "keywords": [
+    "logger",
+    "logging",
+    "structured-logging",
+    "pino",
+    "opentelemetry",
+    "otel"
+  ],
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/logger#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/logger"
+  },
+  "license": "Apache-2.0",
   "type": "module",
   "exports": {
     ".": {
@@ -25,14 +42,37 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@opentelemetry/api": "^1.9.1",
-    "@opentelemetry/api-logs": "^0.214.0",
-    "@opentelemetry/instrumentation-pino": "^0.60.0",
-    "@opentelemetry/sdk-logs": "^0.214.0",
     "pino": "^10.3.1"
   },
   "devDependencies": {
     "@eventuras/vite-config": "workspace:*",
+    "@opentelemetry/api": "^1.9.1",
+    "@opentelemetry/api-logs": "^0.214.0",
+    "@opentelemetry/instrumentation-pino": "^0.60.0",
+    "@opentelemetry/sdk-logs": "^0.214.0",
     "vite": "^8.0.3"
+  },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": ">=0.200.0",
+    "@opentelemetry/instrumentation-pino": ">=0.50.0",
+    "@opentelemetry/sdk-logs": ">=0.200.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    },
+    "@opentelemetry/api-logs": {
+      "optional": true
+    },
+    "@opentelemetry/instrumentation-pino": {
+      "optional": true
+    },
+    "@opentelemetry/sdk-logs": {
+      "optional": true
+    }
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/libs/logger/package.json
+++ b/libs/logger/package.json
@@ -26,6 +26,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "import": "./dist/node.js"
+    },
     "./opentelemetry": {
       "types": "./dist/opentelemetry.d.ts",
       "import": "./dist/opentelemetry.js"

--- a/libs/logger/src/Logger.test.ts
+++ b/libs/logger/src/Logger.test.ts
@@ -89,6 +89,30 @@ describe('Logger', () => {
       expect(mockTransport.calls[0]!.level).toBe('trace');
     });
 
+    it('Logger.info() accepts a plain string message', () => {
+      Logger.info('simple message');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('info');
+      expect(mockTransport.calls[0]!.data.msg).toEqual(['simple message']);
+    });
+
+    it('Logger.error() accepts a plain string message', () => {
+      Logger.error('something broke');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('error');
+      expect(mockTransport.calls[0]!.data.msg).toEqual(['something broke']);
+    });
+
+    it('Logger.warn() accepts string with extra arguments', () => {
+      Logger.warn('warning:', 'extra info', 42);
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('warn');
+      expect(mockTransport.calls[0]!.data.msg).toEqual(['warning:', 'extra info', 42]);
+    });
+
     it('includes correlationId in log data', () => {
       Logger.info({ correlationId: 'abc-123' }, 'correlated');
 

--- a/libs/logger/src/Logger.test.ts
+++ b/libs/logger/src/Logger.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Logger } from './Logger.js';
+import { ConsoleTransport } from './transports/console.js';
+import { PinoTransport } from './transports/pino.js';
+import type { LogTransport } from './types.js';
+
+/**
+ * Creates a mock LogTransport that records all calls for assertions.
+ */
+function createMockTransport(): LogTransport & { calls: Array<{ level: string; data: Record<string, unknown>; msg?: string; }>; } {
+  const calls: Array<{ level: string; data: Record<string, unknown>; msg?: string; }> = [];
+  const transport: LogTransport & { calls: typeof calls; } = {
+    calls,
+    log(level, data, msg) {
+      calls.push({ level, data, msg });
+    },
+    child(bindings) {
+      const childCalls = calls;
+      return {
+        log(level, data, msg) {
+          childCalls.push({ level, data: { ...bindings, ...data }, msg });
+        },
+        child(innerBindings) {
+          return transport.child({ ...bindings, ...innerBindings });
+        },
+      };
+    },
+  };
+  return transport;
+}
+
+describe('Logger', () => {
+  let mockTransport: ReturnType<typeof createMockTransport>;
+
+  beforeEach(() => {
+    mockTransport = createMockTransport();
+    Logger.configure({ transport: mockTransport });
+  });
+
+  afterEach(() => {
+    // Reset to default PinoTransport
+    Logger.configure({ transport: new PinoTransport() });
+  });
+
+  describe('static methods', () => {
+    it('Logger.info() logs at info level', () => {
+      Logger.info({ namespace: 'test' }, 'hello');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('info');
+      expect(mockTransport.calls[0]!.data).toMatchObject({ namespace: 'test' });
+    });
+
+    it('Logger.debug() logs at debug level', () => {
+      Logger.debug({ namespace: 'test' }, 'debug msg');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('debug');
+    });
+
+    it('Logger.warn() logs at warn level', () => {
+      Logger.warn({}, 'warning');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('warn');
+    });
+
+    it('Logger.error() logs at error level with error info', () => {
+      const err = new Error('test error');
+      Logger.error({ error: err, namespace: 'test' }, 'failed');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('error');
+      expect(mockTransport.calls[0]!.data).toHaveProperty('error');
+      expect(mockTransport.calls[0]!.data).toHaveProperty('namespace', 'test');
+    });
+
+    it('Logger.fatal() logs at fatal level', () => {
+      Logger.fatal({ error: new Error('fatal') }, 'crash');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('fatal');
+    });
+
+    it('Logger.trace() logs at trace level', () => {
+      Logger.trace({ namespace: 'verbose' }, 'trace msg');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('trace');
+    });
+
+    it('includes correlationId in log data', () => {
+      Logger.info({ correlationId: 'abc-123' }, 'correlated');
+
+      expect(mockTransport.calls[0]!.data).toHaveProperty('correlationId', 'abc-123');
+    });
+
+    it('includes context fields in log data', () => {
+      Logger.info({ context: { userId: 42, role: 'admin' } }, 'ctx');
+
+      expect(mockTransport.calls[0]!.data).toMatchObject({ userId: 42, role: 'admin' });
+    });
+
+    it('skips developerOnly logs when not in development', () => {
+      // NODE_ENV is not 'development' in test
+      Logger.info({ developerOnly: true }, 'should not appear');
+
+      expect(mockTransport.calls).toHaveLength(0);
+    });
+  });
+
+  describe('Logger.create() instance methods', () => {
+    it('creates a scoped logger with namespace', () => {
+      const logger = Logger.create({ namespace: 'MyModule' });
+      logger.info('hello from module');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.data).toHaveProperty('namespace', 'MyModule');
+    });
+
+    it('creates a scoped logger with context', () => {
+      const logger = Logger.create({
+        namespace: 'API',
+        context: { service: 'users' },
+      });
+      logger.info({ requestId: '123' }, 'request processed');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.data).toMatchObject({
+        namespace: 'API',
+        service: 'users',
+        requestId: '123',
+      });
+    });
+
+    it('instance info logs with string only', () => {
+      const logger = Logger.create({ namespace: 'test' });
+      logger.info('just a message');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('info');
+    });
+
+    it('instance debug/warn/trace work', () => {
+      const logger = Logger.create({ namespace: 'test' });
+      logger.debug('d');
+      logger.warn('w');
+      logger.trace('t');
+
+      expect(mockTransport.calls).toHaveLength(3);
+      expect(mockTransport.calls.map(c => c.level)).toEqual(['debug', 'warn', 'trace']);
+    });
+
+    it('instance error with Error object', () => {
+      const logger = Logger.create({ namespace: 'test' });
+      const err = new Error('boom');
+      logger.error(err, 'Something broke');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('error');
+      expect(mockTransport.calls[0]!.data).toHaveProperty('error', err);
+    });
+
+    it('instance error with string only', () => {
+      const logger = Logger.create({ namespace: 'test' });
+      logger.error('simple error');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('error');
+    });
+
+    it('instance error with data object and message', () => {
+      const logger = Logger.create({ namespace: 'test' });
+      logger.error({ code: 'NOT_FOUND' }, 'Resource missing');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.data).toMatchObject({
+        namespace: 'test',
+        code: 'NOT_FOUND',
+      });
+    });
+
+    it('instance fatal works like error', () => {
+      const logger = Logger.create({ namespace: 'test' });
+      logger.fatal(new Error('critical'), 'System down');
+
+      expect(mockTransport.calls).toHaveLength(1);
+      expect(mockTransport.calls[0]!.level).toBe('fatal');
+    });
+
+    it('logger without options uses root transport', () => {
+      const logger = Logger.create();
+      logger.info('no options');
+
+      expect(mockTransport.calls).toHaveLength(1);
+    });
+  });
+
+  describe('configure()', () => {
+    it('switches to ConsoleTransport', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => { });
+      Logger.configure({ transport: new ConsoleTransport() });
+
+      Logger.info({ namespace: 'test' }, 'console log');
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('getTransport() returns the active transport', () => {
+      const transport = Logger.getTransport();
+      expect(transport).toBe(mockTransport);
+    });
+
+    it('getPinoInstance() throws when not using PinoTransport', () => {
+      expect(() => Logger.getPinoInstance()).toThrow('getPinoInstance() requires PinoTransport');
+    });
+
+    it('getPinoInstance() works with PinoTransport', () => {
+      Logger.configure({ transport: new PinoTransport() });
+      expect(() => Logger.getPinoInstance()).not.toThrow();
+      expect(Logger.getPinoInstance()).toBeDefined();
+    });
+  });
+});

--- a/libs/logger/src/Logger.test.ts
+++ b/libs/logger/src/Logger.test.ts
@@ -221,5 +221,15 @@ describe('Logger', () => {
       expect(() => Logger.getPinoInstance()).not.toThrow();
       expect(Logger.getPinoInstance()).toBeDefined();
     });
+
+    it('preserves custom transport when reconfiguring other options', () => {
+      const custom = createMockTransport();
+      Logger.configure({ transport: custom });
+      expect(Logger.getTransport()).toBe(custom);
+
+      // Reconfigure level without specifying transport — should keep custom
+      Logger.configure({ level: 'debug' });
+      expect(Logger.getTransport()).toBe(custom);
+    });
   });
 });

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -45,9 +45,11 @@ function getEnv(key: string): string | undefined {
 }
 
 function createDefaultTransport(config: LoggerConfig): LogTransport {
+  const isDev = getEnv('NODE_ENV') === 'development';
   return new PinoTransport({
     level: config.level ?? (getEnv('LOG_LEVEL') as LogLevel | undefined) ?? 'info',
     redact: config.redact ?? DEFAULT_REDACT,
+    prettyPrint: config.prettyPrint ?? isDev,
     destination: config.destination,
   });
 }
@@ -219,22 +221,30 @@ export class Logger {
     }
   }
 
+  /** Log at `trace` level. Pass a string or `{ data }` with an optional message. */
   trace(data?: Record<string, unknown> | string, msg?: string): void {
     this.logInstance('trace', data, msg);
   }
 
+  /** Log at `debug` level. */
   debug(data?: Record<string, unknown> | string, msg?: string): void {
     this.logInstance('debug', data, msg);
   }
 
+  /** Log at `info` level. */
   info(data?: Record<string, unknown> | string, msg?: string): void {
     this.logInstance('info', data, msg);
   }
 
+  /** Log at `warn` level. */
   warn(data?: Record<string, unknown> | string, msg?: string): void {
     this.logInstance('warn', data, msg);
   }
 
+  /**
+   * Log at `error` level. Accepts an `Error` instance, a data object, or a plain string.
+   * Error instances are serialized automatically.
+   */
   error(errorOrData?: unknown, msg?: string): void {
     const transport = this.childTransport ?? Logger.transport;
     if (typeof errorOrData === 'string') {
@@ -248,6 +258,9 @@ export class Logger {
     }
   }
 
+  /**
+   * Log at `fatal` level. Same signature as `error()` but signals a critical/shutdown failure.
+   */
   fatal(errorOrData?: unknown, msg?: string): void {
     const transport = this.childTransport ?? Logger.transport;
     if (typeof errorOrData === 'string') {

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -1,141 +1,130 @@
 /**
- * Production logger using Pino.
+ * Structured logger with pluggable transports.
  *
- * This logger is optimized for production use with structured logging, context fields,
- * correlation IDs, auto-redaction, and configurable log levels.
+ * Uses a `LogTransport` abstraction so the logging backend can be swapped
+ * without changing application code. Ships with PinoTransport (default,
+ * production-grade) and ConsoleTransport (browser/testing).
  *
- * For external integrations (e.g., Sentry), use the @eventuras/logger-sentry package.
- * For development debugging, use the Debug utility instead.
- *
- * Standard log levels (Pino):
- * fatal: 60
- * error: 50
- * warn: 40
- * info: 30
- * debug: 20
- * trace: 10
+ * Standard log levels:
+ * fatal: 60 | error: 50 | warn: 40 | info: 30 | debug: 20 | trace: 10
  *
  * @example
- * // Static usage for one-off logs
+ * // Scoped logger (recommended pattern)
+ * const logger = Logger.create({
+ *   namespace: 'CollectionEditor',
+ *   context: { collectionId: 123 },
+ * });
+ * logger.info('Event added', { eventId: 456 });
+ *
+ * @example
+ * // Static one-off logs
  * Logger.info('Simple message');
  * Logger.error({ error: err }, 'Something failed');
  *
  * @example
- * // Scoped logger with context
- * const logger = Logger.create({
- *   namespace: 'CollectionEditor',
- *   context: { collectionId: 123 }
- * });
- * logger.info('Event added', { eventId: 456 });
- * // Logs: { namespace: 'CollectionEditor', collectionId: 123, eventId: 456, msg: 'Event added' }
+ * // Custom transport
+ * import { ConsoleTransport } from '@eventuras/logger';
+ * Logger.configure({ transport: new ConsoleTransport() });
  */
-import pino, { type Logger as PinoLogger } from 'pino';
+import type {
+  ErrorLoggerOptions,
+  LoggerConfig,
+  LoggerOptions,
+  LogLevel,
+  LogTransport,
+} from './types';
+import { PinoTransport } from './transports/pino';
 
-export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+const DEFAULT_REDACT = ['password', 'token', 'apiKey', 'authorization', 'secret'];
 
-export type LoggerOptions = {
-  /** If true, only logs in development mode */
-  developerOnly?: boolean;
-  /** Namespace for filtering logs (e.g., 'CollectionEditor') */
-  namespace?: string;
-  /** Minimum log level for this logger instance */
-  level?: LogLevel;
-  /** Persistent context fields to include in all logs */
-  context?: Record<string, unknown>;
-  /** Correlation ID for request tracking */
-  correlationId?: string;
-};
+function getEnv(key: string): string | undefined {
+  if (typeof globalThis !== 'undefined' && typeof (globalThis as Record<string, unknown>).process === 'object') {
+    return (globalThis as unknown as { process: { env: Record<string, string | undefined>; }; }).process.env[key];
+  }
+  return undefined;
+}
 
-export type ErrorLoggerOptions = LoggerOptions & {
-  error?: unknown;
-};
-
-export type LoggerConfig = {
-  /** Global minimum log level */
-  level?: LogLevel;
-  /** Paths to redact from logs (e.g., ['password', 'token']) */
-  redact?: string[];
-  /** Optional file path for log output */
-  destination?: string;
-};
+function createDefaultTransport(config: LoggerConfig): LogTransport {
+  return new PinoTransport({
+    level: config.level ?? (getEnv('LOG_LEVEL') as LogLevel | undefined) ?? 'info',
+    redact: config.redact ?? DEFAULT_REDACT,
+    destination: config.destination,
+  });
+}
 
 export class Logger {
-  private static pinoLogger: PinoLogger;
-  private static config: LoggerConfig = {
-    level: (process.env.LOG_LEVEL as LogLevel) || 'info',
-    redact: ['password', 'token', 'apiKey', 'authorization', 'secret'],
-  };
+  private static transport: LogTransport;
+  private static config: LoggerConfig = {};
 
   // Instance properties for scoped logger
   private options: LoggerOptions;
-  private childLogger?: PinoLogger;
+  private childTransport?: LogTransport;
 
   static {
-    // Initialize Pino logger with configuration
-    Logger.pinoLogger = Logger.createPinoInstance();
+    Logger.transport = createDefaultTransport(Logger.config);
   }
 
   private constructor(options: LoggerOptions = {}) {
     this.options = options;
 
-    // Create child logger with context if provided
     if (options.context || options.correlationId || options.namespace) {
       const bindings: Record<string, unknown> = {
         ...(options.namespace && { namespace: options.namespace }),
         ...(options.correlationId && { correlationId: options.correlationId }),
         ...(options.context || {}),
       };
-      this.childLogger = Logger.pinoLogger.child(bindings);
-
-      // Set level if specified
-      if (options.level) {
-        this.childLogger.level = options.level;
-      }
+      this.childTransport = Logger.transport.child(bindings);
     }
-  }
-
-  private static createPinoInstance(): PinoLogger {
-    const options: pino.LoggerOptions = {
-      level: Logger.config.level || 'info',
-      redact: {
-        paths: Logger.config.redact || [],
-        censor: '[REDACTED]',
-      },
-    };
-
-    // File destination if specified
-    if (Logger.config.destination) {
-      return pino(options, pino.destination(Logger.config.destination));
-    }
-
-    // Use standard JSON logging - works well with all log aggregation services
-    return pino(options);
   }
 
   /**
-   * Configure global logger settings. Call this once at application startup.
+   * Configure global logger settings. Call once at application startup.
+   *
+   * Supply a custom `transport` to replace the default Pino backend,
+   * or omit it to keep PinoTransport with the provided options.
    *
    * @example
-   * Logger.configure({
-   *   level: 'debug',
-   *   redact: ['password', 'apiKey'],
-   * });
+   * Logger.configure({ level: 'debug', redact: ['password', 'apiKey'] });
+   *
+   * @example
+   * import { ConsoleTransport } from '@eventuras/logger';
+   * Logger.configure({ transport: new ConsoleTransport() });
    */
   static configure(config: Partial<LoggerConfig>): void {
     Logger.config = { ...Logger.config, ...config };
-    Logger.pinoLogger = Logger.createPinoInstance();
+    Logger.transport = config.transport ?? createDefaultTransport(Logger.config);
+    // Re-bind static convenience methods to the new transport
+    Logger.rebindStaticMethods();
   }
 
   /**
-   * Get the internal Pino instance for advanced use cases or external integrations.
-   * For example, @eventuras/logger-sentry uses this to connect Sentry transport.
+   * Get the active transport for advanced integrations.
    *
-   * @example
-   * import { initializeSentryLogger } from '@eventuras/logger-sentry';
-   * initializeSentryLogger(); // Uses Logger.getPinoInstance() internally
+   * If you need access to the underlying Pino instance (e.g. for OTel
+   * instrumentation), check `transport instanceof PinoTransport` and
+   * access `.pino` on it.
    */
-  static getPinoInstance(): PinoLogger {
-    return Logger.pinoLogger;
+  static getTransport(): LogTransport {
+    return Logger.transport;
+  }
+
+  /**
+   * @deprecated Use `Logger.getTransport()` instead. If you need the raw
+   * Pino instance, cast the transport: `(Logger.getTransport() as PinoTransport).pino`
+   */
+  static getPinoInstance(): import('pino').Logger {
+    if (Logger.transport instanceof PinoTransport) {
+      return Logger.transport.pino;
+    }
+    throw new Error(
+      'getPinoInstance() requires PinoTransport. Use Logger.getTransport() for the active transport.',
+    );
+  }
+
+  // --- Static convenience methods ---
+
+  private static isDevelopment(): boolean {
+    return getEnv('NODE_ENV') === 'development';
   }
 
   private static formatError(error: unknown): string {
@@ -145,226 +134,130 @@ export class Logger {
     return String(error);
   }
 
-  private static wrapLogger(pinoFunction: (obj: any, msg?: string | undefined) => void) {
-    return (
-      options: LoggerOptions = { developerOnly: false, namespace: '' },
-      ...msg: any | any[]
-    ) => {
-      if (options.developerOnly && process.env.NODE_ENV !== 'development') {
-        return;
-      }
-
-      const logData: Record<string, unknown> = {
-        ...(options.namespace && { namespace: options.namespace }),
-        ...(options.correlationId && { correlationId: options.correlationId }),
-        ...(options.context || {}),
-      };
-
-      pinoFunction({ ...logData, msg: msg });
+  private static buildLogData(options: LoggerOptions): Record<string, unknown> {
+    return {
+      ...(options.namespace && { namespace: options.namespace }),
+      ...(options.correlationId && { correlationId: options.correlationId }),
+      ...(options.context || {}),
     };
   }
 
-  private static wrapErrorLogger(pinoFunction: (obj: any, msg?: string | undefined) => void) {
-    return (
-      options: ErrorLoggerOptions = { developerOnly: false, namespace: '' },
-      ...msg: any | any[]
-    ) => {
-      if (options.developerOnly && process.env.NODE_ENV !== 'development') {
-        return;
-      }
-
-      const errorInfo = options.error ? { error: Logger.formatError(options.error) } : {};
-
-      const logData: Record<string, unknown> = {
-        ...(options.namespace && { namespace: options.namespace }),
-        ...(options.correlationId && { correlationId: options.correlationId }),
-        ...(options.context || {}),
-        ...errorInfo,
-      };
-
-      pinoFunction({ ...logData, msg: msg });
-    };
+  private static staticLog(
+    level: LogLevel,
+    options: LoggerOptions,
+    ...msg: unknown[]
+  ): void {
+    if (options.developerOnly && !Logger.isDevelopment()) return;
+    const data = Logger.buildLogData(options);
+    Logger.transport.log(level, { ...data, msg });
   }
 
-  static info = Logger.wrapLogger(
-    Logger.pinoLogger.info.bind(Logger.pinoLogger),
-  ).bind(Logger);
+  private static staticErrorLog(
+    level: LogLevel,
+    options: ErrorLoggerOptions,
+    ...msg: unknown[]
+  ): void {
+    if (options.developerOnly && !Logger.isDevelopment()) return;
+    const errorInfo = options.error ? { error: Logger.formatError(options.error) } : {};
+    const data = { ...Logger.buildLogData(options), ...errorInfo };
+    Logger.transport.log(level, { ...data, msg });
+  }
 
-  static debug = Logger.wrapLogger(
-    Logger.pinoLogger.debug.bind(Logger.pinoLogger),
-  ).bind(Logger);
+  static info(options: LoggerOptions, ...msg: unknown[]): void {
+    Logger.staticLog('info', options, ...msg);
+  }
+  static debug(options: LoggerOptions, ...msg: unknown[]): void {
+    Logger.staticLog('debug', options, ...msg);
+  }
+  static trace(options: LoggerOptions, ...msg: unknown[]): void {
+    Logger.staticLog('trace', options, ...msg);
+  }
+  static warn(options: LoggerOptions, ...msg: unknown[]): void {
+    Logger.staticLog('warn', options, ...msg);
+  }
+  static error(options: ErrorLoggerOptions, ...msg: unknown[]): void {
+    Logger.staticErrorLog('error', options, ...msg);
+  }
+  static fatal(options: ErrorLoggerOptions, ...msg: unknown[]): void {
+    Logger.staticErrorLog('fatal', options, ...msg);
+  }
 
-  static trace = Logger.wrapLogger(
-    Logger.pinoLogger.trace.bind(Logger.pinoLogger),
-  ).bind(Logger);
-
-  static warn = Logger.wrapLogger(
-    Logger.pinoLogger.warn.bind(Logger.pinoLogger),
-  ).bind(Logger);
-
-  static error = Logger.wrapErrorLogger(
-    Logger.pinoLogger.error.bind(Logger.pinoLogger),
-  ).bind(Logger);
-
-  static fatal = Logger.wrapErrorLogger(
-    Logger.pinoLogger.fatal.bind(Logger.pinoLogger),
-  ).bind(Logger);
+  private static rebindStaticMethods(): void {
+    // No-op — static methods now delegate through Logger.transport directly
+    // so rebinding is not needed. Kept for API compatibility.
+  }
 
   /**
    * Create a scoped logger instance with predefined options.
-   * Use this when you have multiple log calls in the same component/module.
    *
    * @example
-   * // Basic scoped logger
    * const logger = Logger.create({ namespace: 'CollectionEditor' });
    * logger.info('Something happened');
    *
    * @example
-   * // With context fields
    * const logger = Logger.create({
    *   namespace: 'API',
-   *   context: { userId: 123, collectionId: 456 },
-   *   correlationId: req.headers['x-correlation-id']
+   *   context: { userId: 123 },
+   *   correlationId: req.headers['x-correlation-id'],
    * });
-   * logger.info('Event added', { eventId: 789 });
-   * // Logs: { namespace: 'API', userId: 123, collectionId: 456, correlationId: 'abc', eventId: 789, msg: 'Event added' }
-   *
-   * @example
-   * // With custom log level
-   * const logger = Logger.create({
-   *   namespace: 'Eventuras:ConvertoApi',
-   *   level: 'debug'
-   * });
+   * logger.info({ eventId: 789 }, 'Event added');
    */
   static create(options: LoggerOptions = {}): Logger {
     return new Logger(options);
   }
 
-  // Instance methods that merge instance options with call-time options
+  // --- Instance methods ---
 
-  /**
-   * Log at trace level (most verbose)
-   */
+  private logInstance(level: LogLevel, data?: Record<string, unknown> | string, msg?: string): void {
+    const transport = this.childTransport ?? Logger.transport;
+    if (typeof data === 'string') {
+      transport.log(level, {}, data);
+    } else if (msg) {
+      transport.log(level, data ?? {}, msg);
+    } else {
+      transport.log(level, data ?? {});
+    }
+  }
+
   trace(data?: Record<string, unknown> | string, msg?: string): void {
-    if (this.childLogger) {
-      if (typeof data === 'string') {
-        this.childLogger.trace(data);
-      } else if (msg) {
-        this.childLogger.trace(data, msg);
-      } else {
-        this.childLogger.trace(data);
-      }
-    } else {
-      Logger.trace(this.options, data, msg);
-    }
+    this.logInstance('trace', data, msg);
   }
 
-  /**
-   * Log at debug level
-   */
   debug(data?: Record<string, unknown> | string, msg?: string): void {
-    if (this.childLogger) {
-      if (typeof data === 'string') {
-        this.childLogger.debug(data);
-      } else if (msg) {
-        this.childLogger.debug(data, msg);
-      } else {
-        this.childLogger.debug(data);
-      }
-    } else {
-      Logger.debug(this.options, data, msg);
-    }
+    this.logInstance('debug', data, msg);
   }
 
-  /**
-   * Log at info level
-   */
   info(data?: Record<string, unknown> | string, msg?: string): void {
-    if (this.childLogger) {
-      if (typeof data === 'string') {
-        this.childLogger.info(data);
-      } else if (msg) {
-        this.childLogger.info(data, msg);
-      } else {
-        this.childLogger.info(data);
-      }
-    } else {
-      Logger.info(this.options, data, msg);
-    }
+    this.logInstance('info', data, msg);
   }
 
-  /**
-   * Log at warn level
-   */
   warn(data?: Record<string, unknown> | string, msg?: string): void {
-    if (this.childLogger) {
-      if (typeof data === 'string') {
-        this.childLogger.warn(data);
-      } else if (msg) {
-        this.childLogger.warn(data, msg);
-      } else {
-        this.childLogger.warn(data);
-      }
-    } else {
-      Logger.warn(this.options, data, msg);
-    }
+    this.logInstance('warn', data, msg);
   }
 
-  /**
-   * Log at error level
-   */
   error(errorOrData?: unknown, msg?: string): void {
-    if (this.childLogger) {
-      // Support: logger.error('message') and logger.error({ error }, 'message')
-      if (typeof errorOrData === 'string') {
-        this.childLogger.error(errorOrData);
-      } else if (errorOrData instanceof Error) {
-        if (msg) {
-          this.childLogger.error({ error: errorOrData }, msg);
-        } else {
-          this.childLogger.error({ error: errorOrData });
-        }
-      } else if (msg) {
-        this.childLogger.error(errorOrData, msg);
-      } else {
-        this.childLogger.error(errorOrData);
-      }
+    const transport = this.childTransport ?? Logger.transport;
+    if (typeof errorOrData === 'string') {
+      transport.log('error', {}, errorOrData);
+    } else if (errorOrData instanceof Error) {
+      transport.log('error', { error: errorOrData }, msg);
+    } else if (msg) {
+      transport.log('error', (errorOrData as Record<string, unknown>) ?? {}, msg);
     } else {
-      // Fallback to static method
-      if (typeof errorOrData === 'object' && errorOrData !== null && 'error' in errorOrData) {
-        Logger.error({ ...this.options, ...(errorOrData as ErrorLoggerOptions) }, msg);
-      } else {
-        Logger.error(this.options, errorOrData, msg);
-      }
+      transport.log('error', (errorOrData as Record<string, unknown>) ?? {});
     }
   }
 
-  /**
-   * Log at fatal level (highest severity)
-   */
   fatal(errorOrData?: unknown, msg?: string): void {
-    if (this.childLogger) {
-      // Support: logger.fatal('message') and logger.fatal({ error }, 'message')
-      if (typeof errorOrData === 'string') {
-        this.childLogger.fatal(errorOrData);
-      } else if (errorOrData instanceof Error) {
-        if (msg) {
-          this.childLogger.fatal({ error: errorOrData }, msg);
-        } else {
-          this.childLogger.fatal({ error: errorOrData });
-        }
-      } else if (msg) {
-        this.childLogger.fatal(errorOrData, msg);
-      } else {
-        this.childLogger.fatal(errorOrData);
-      }
+    const transport = this.childTransport ?? Logger.transport;
+    if (typeof errorOrData === 'string') {
+      transport.log('fatal', {}, errorOrData);
+    } else if (errorOrData instanceof Error) {
+      transport.log('fatal', { error: errorOrData }, msg);
+    } else if (msg) {
+      transport.log('fatal', (errorOrData as Record<string, unknown>) ?? {}, msg);
     } else {
-      // Fallback to static method
-      if (typeof errorOrData === 'object' && errorOrData !== null && 'error' in errorOrData) {
-        Logger.fatal({ ...this.options, ...(errorOrData as ErrorLoggerOptions) }, msg);
-      } else {
-        Logger.fatal(this.options, errorOrData, msg);
-      }
+      transport.log('fatal', (errorOrData as Record<string, unknown>) ?? {});
     }
   }
 }

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -34,6 +34,7 @@ import type {
   LogTransport,
 } from './types';
 import { PinoTransport } from './transports/pino';
+import { ConsoleTransport } from './transports/console';
 
 const DEFAULT_REDACT = ['password', 'token', 'apiKey', 'authorization', 'secret'];
 
@@ -44,7 +45,21 @@ function getEnv(key: string): string | undefined {
   return undefined;
 }
 
+/** Detect Node.js runtime (vs browser / edge). */
+function isNodeRuntime(): boolean {
+  try {
+    return typeof process !== 'undefined' && typeof process.versions?.node === 'string';
+  } catch {
+    return false;
+  }
+}
+
 function createDefaultTransport(config: LoggerConfig): LogTransport {
+  // In non-Node environments (browser, edge), fall back to ConsoleTransport
+  if (!isNodeRuntime()) {
+    return new ConsoleTransport();
+  }
+
   return new PinoTransport({
     level: config.level ?? (getEnv('LOG_LEVEL') as LogLevel | undefined) ?? 'info',
     redact: config.redact ?? DEFAULT_REDACT,

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -93,7 +93,7 @@ export class Logger {
    */
   static configure(config: Partial<LoggerConfig>): void {
     Logger.config = { ...Logger.config, ...config };
-    Logger.transport = config.transport ?? createDefaultTransport(Logger.config);
+    Logger.transport = Logger.config.transport ?? createDefaultTransport(Logger.config);
     // Re-bind static convenience methods to the new transport
     Logger.rebindStaticMethods();
   }

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -124,6 +124,20 @@ export class Logger {
 
   // --- Static convenience methods ---
 
+  /**
+   * Normalize arguments for static log methods.
+   * Supports both `Logger.info('msg')` and `Logger.info({ namespace: 'x' }, 'msg')`.
+   */
+  private static normalizeArgs(
+    optionsOrMsg: LoggerOptions | string,
+    rest: unknown[],
+  ): [LoggerOptions, unknown[]] {
+    if (typeof optionsOrMsg === 'string') {
+      return [{}, [optionsOrMsg, ...rest]];
+    }
+    return [optionsOrMsg, rest];
+  }
+
   private static isDevelopment(): boolean {
     return getEnv('NODE_ENV') === 'development';
   }
@@ -164,23 +178,58 @@ export class Logger {
     Logger.transport.log(level, { ...data, msg });
   }
 
-  static info(options: LoggerOptions, ...msg: unknown[]): void {
-    Logger.staticLog('info', options, ...msg);
+  /** Log at info level with options and message(s). */
+  static info(options: LoggerOptions, ...msg: unknown[]): void;
+  /** Log at info level with just a message string. */
+  static info(msg: string, ...args: unknown[]): void;
+  static info(optionsOrMsg: LoggerOptions | string, ...msg: unknown[]): void {
+    const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
+    Logger.staticLog('info', options, ...messages);
   }
-  static debug(options: LoggerOptions, ...msg: unknown[]): void {
-    Logger.staticLog('debug', options, ...msg);
+
+  /** Log at debug level with options and message(s). */
+  static debug(options: LoggerOptions, ...msg: unknown[]): void;
+  /** Log at debug level with just a message string. */
+  static debug(msg: string, ...args: unknown[]): void;
+  static debug(optionsOrMsg: LoggerOptions | string, ...msg: unknown[]): void {
+    const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
+    Logger.staticLog('debug', options, ...messages);
   }
-  static trace(options: LoggerOptions, ...msg: unknown[]): void {
-    Logger.staticLog('trace', options, ...msg);
+
+  /** Log at trace level with options and message(s). */
+  static trace(options: LoggerOptions, ...msg: unknown[]): void;
+  /** Log at trace level with just a message string. */
+  static trace(msg: string, ...args: unknown[]): void;
+  static trace(optionsOrMsg: LoggerOptions | string, ...msg: unknown[]): void {
+    const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
+    Logger.staticLog('trace', options, ...messages);
   }
-  static warn(options: LoggerOptions, ...msg: unknown[]): void {
-    Logger.staticLog('warn', options, ...msg);
+
+  /** Log at warn level with options and message(s). */
+  static warn(options: LoggerOptions, ...msg: unknown[]): void;
+  /** Log at warn level with just a message string. */
+  static warn(msg: string, ...args: unknown[]): void;
+  static warn(optionsOrMsg: LoggerOptions | string, ...msg: unknown[]): void {
+    const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
+    Logger.staticLog('warn', options, ...messages);
   }
-  static error(options: ErrorLoggerOptions, ...msg: unknown[]): void {
-    Logger.staticErrorLog('error', options, ...msg);
+
+  /** Log at error level with options and message(s). */
+  static error(options: ErrorLoggerOptions, ...msg: unknown[]): void;
+  /** Log at error level with just a message string. */
+  static error(msg: string, ...args: unknown[]): void;
+  static error(optionsOrMsg: ErrorLoggerOptions | string, ...msg: unknown[]): void {
+    const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
+    Logger.staticErrorLog('error', options, ...messages);
   }
-  static fatal(options: ErrorLoggerOptions, ...msg: unknown[]): void {
-    Logger.staticErrorLog('fatal', options, ...msg);
+
+  /** Log at fatal level with options and message(s). */
+  static fatal(options: ErrorLoggerOptions, ...msg: unknown[]): void;
+  /** Log at fatal level with just a message string. */
+  static fatal(msg: string, ...args: unknown[]): void;
+  static fatal(optionsOrMsg: ErrorLoggerOptions | string, ...msg: unknown[]): void {
+    const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
+    Logger.staticErrorLog('fatal', options, ...messages);
   }
 
   private static rebindStaticMethods(): void {

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -45,11 +45,10 @@ function getEnv(key: string): string | undefined {
 }
 
 function createDefaultTransport(config: LoggerConfig): LogTransport {
-  const isDev = getEnv('NODE_ENV') === 'development';
   return new PinoTransport({
     level: config.level ?? (getEnv('LOG_LEVEL') as LogLevel | undefined) ?? 'info',
     redact: config.redact ?? DEFAULT_REDACT,
-    prettyPrint: config.prettyPrint ?? isDev,
+    prettyPrint: config.prettyPrint ?? getEnv('NODE_ENV') === 'development',
     destination: config.destination,
   });
 }

--- a/libs/logger/src/httpLogger.test.ts
+++ b/libs/logger/src/httpLogger.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { redactHeaders } from './httpLogger.js';
+
+describe('redactHeaders', () => {
+  const SENSITIVE = ['authorization', 'cookie', 'set-cookie', 'x-api-key', 'x-auth-token', 'proxy-authorization'];
+
+  describe('with Record<string, unknown> input', () => {
+    it('redacts sensitive headers', () => {
+      const result = redactHeaders({
+        Authorization: 'Bearer secret-token',
+        'Content-Type': 'application/json',
+        Cookie: 'session=abc',
+      });
+
+      expect(result['Authorization']).toBe('[REDACTED]');
+      expect(result['Content-Type']).toBe('application/json');
+      expect(result['Cookie']).toBe('[REDACTED]');
+    });
+
+    it('is case-insensitive', () => {
+      const result = redactHeaders({
+        AUTHORIZATION: 'Bearer token',
+        'x-api-key': 'key123',
+        'X-AUTH-TOKEN': 'token456',
+      });
+
+      expect(result['AUTHORIZATION']).toBe('[REDACTED]');
+      expect(result['x-api-key']).toBe('[REDACTED]');
+      expect(result['X-AUTH-TOKEN']).toBe('[REDACTED]');
+    });
+
+    it('passes through non-sensitive headers', () => {
+      const result = redactHeaders({
+        'Content-Type': 'text/html',
+        'Accept': 'application/json',
+        'X-Request-Id': 'abc-123',
+      });
+
+      expect(result['Content-Type']).toBe('text/html');
+      expect(result['Accept']).toBe('application/json');
+      expect(result['X-Request-Id']).toBe('abc-123');
+    });
+
+    it('converts non-string values to strings', () => {
+      const result = redactHeaders({
+        'X-Count': 42,
+        'X-Flag': true,
+      });
+
+      expect(result['X-Count']).toBe('42');
+      expect(result['X-Flag']).toBe('true');
+    });
+
+    it('handles empty input', () => {
+      const result = redactHeaders({});
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('with Headers input', () => {
+    it('redacts sensitive headers', () => {
+      const headers = new Headers();
+      headers.set('authorization', 'Bearer token');
+      headers.set('content-type', 'application/json');
+
+      const result = redactHeaders(headers);
+
+      expect(result['authorization']).toBe('[REDACTED]');
+      expect(result['content-type']).toBe('application/json');
+    });
+
+    it('handles all sensitive headers', () => {
+      const headers = new Headers();
+      for (const name of SENSITIVE) {
+        headers.set(name, 'secret-value');
+      }
+      headers.set('accept', 'text/plain');
+
+      const result = redactHeaders(headers);
+
+      for (const name of SENSITIVE) {
+        expect(result[name]).toBe('[REDACTED]');
+      }
+      expect(result['accept']).toBe('text/plain');
+    });
+  });
+
+  describe('with array input', () => {
+    it('redacts sensitive headers', () => {
+      const headers: [string, string][] = [
+        ['Authorization', 'Bearer token'],
+        ['Content-Type', 'application/json'],
+        ['X-Api-Key', 'secret'],
+      ];
+
+      const result = redactHeaders(headers);
+
+      expect(result['Authorization']).toBe('[REDACTED]');
+      expect(result['Content-Type']).toBe('application/json');
+      expect(result['X-Api-Key']).toBe('[REDACTED]');
+    });
+
+    it('handles empty array', () => {
+      const result = redactHeaders([]);
+      expect(result).toEqual({});
+    });
+  });
+
+  it('redacts all known sensitive headers', () => {
+    const input: Record<string, string> = {};
+    for (const name of SENSITIVE) {
+      input[name] = 'secret';
+    }
+    input['safe-header'] = 'visible';
+
+    const result = redactHeaders(input);
+
+    for (const name of SENSITIVE) {
+      expect(result[name]).toBe('[REDACTED]');
+    }
+    expect(result['safe-header']).toBe('visible');
+  });
+});

--- a/libs/logger/src/index.ts
+++ b/libs/logger/src/index.ts
@@ -8,9 +8,9 @@ export type { LoggerOptions, ErrorLoggerOptions, LoggerConfig, LogLevel, LogTran
 export { PinoTransport, type PinoTransportOptions } from './transports/pino';
 export { ConsoleTransport } from './transports/console';
 
-// Pretty-print formatter (Node.js only)
-export { formatLogLine, createPrettyStream } from './transports/pretty';
-
 // HTTP logging utility — header redaction
 export { redactHeaders } from './httpLogger';
+
+// Node-only exports (formatLogLine, createPrettyStream) are available via
+// '@eventuras/logger/node' to avoid pulling node:stream into browser bundles.
 

--- a/libs/logger/src/index.ts
+++ b/libs/logger/src/index.ts
@@ -8,6 +8,9 @@ export type { LoggerOptions, ErrorLoggerOptions, LoggerConfig, LogLevel, LogTran
 export { PinoTransport, type PinoTransportOptions } from './transports/pino';
 export { ConsoleTransport } from './transports/console';
 
+// Pretty-print formatter (Node.js only)
+export { formatLogLine, createPrettyStream } from './transports/pretty';
+
 // HTTP logging utility — header redaction
 export { redactHeaders } from './httpLogger';
 

--- a/libs/logger/src/index.ts
+++ b/libs/logger/src/index.ts
@@ -1,7 +1,13 @@
-// Logger is for production logging (Pino)
+// Core Logger
 export { Logger } from './Logger';
-export type { LoggerOptions, ErrorLoggerOptions, LoggerConfig, LogLevel } from './Logger';
 
-// HTTP logging utility - header redaction
+// Types — re-export from canonical source
+export type { LoggerOptions, ErrorLoggerOptions, LoggerConfig, LogLevel, LogTransport } from './types';
+
+// Transports
+export { PinoTransport, type PinoTransportOptions } from './transports/pino';
+export { ConsoleTransport } from './transports/console';
+
+// HTTP logging utility — header redaction
 export { redactHeaders } from './httpLogger';
 

--- a/libs/logger/src/node.ts
+++ b/libs/logger/src/node.ts
@@ -1,0 +1,11 @@
+/**
+ * Node.js-only exports for @eventuras/logger.
+ *
+ * These utilities depend on `node:stream` and must not be imported in browser
+ * or edge runtime environments. Import from the root entry point
+ * (`@eventuras/logger`) for the browser-safe API.
+ *
+ * @example
+ * import { createPrettyStream, formatLogLine } from '@eventuras/logger/node';
+ */
+export { formatLogLine, createPrettyStream } from './transports/pretty';

--- a/libs/logger/src/opentelemetry.ts
+++ b/libs/logger/src/opentelemetry.ts
@@ -10,7 +10,7 @@
  *
  * @example
  * // In your app's instrumentation.ts or main entry point
- * import { setupOpenTelemetryLogger } from '@eventuras/logger';
+ * import { setupOpenTelemetryLogger } from '@eventuras/logger/opentelemetry';
  * import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
  * import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
  *
@@ -31,6 +31,32 @@
  * logger.error({ error: err }, 'Something failed'); // Sent to OpenTelemetry backend
  */
 
+/**
+ * Minimal interface for an OpenTelemetry LogRecordProcessor.
+ * Compatible with `@opentelemetry/sdk-logs` `LogRecordProcessor`.
+ * Defined locally to avoid requiring OTel types at compile time.
+ */
+export interface LogRecordProcessor {
+  shutdown(): Promise<void>;
+  forceFlush(): Promise<void>;
+}
+
+/**
+ * Minimal interface for an OpenTelemetry LoggerProvider.
+ * Compatible with `@opentelemetry/sdk-logs` `LoggerProvider`.
+ */
+export interface OTelLoggerProvider {
+  addLogRecordProcessor(processor: LogRecordProcessor): void;
+  shutdown(): Promise<void>;
+  forceFlush?(): Promise<void>;
+}
+
+/** Internal interface for Pino instrumentation */
+interface PinoInstrumentationInstance {
+  enable(): void;
+  disable(): void;
+}
+
 // Lazy load OpenTelemetry packages to handle optional peer dependencies
 async function loadOpenTelemetry() {
   try {
@@ -47,22 +73,26 @@ async function loadOpenTelemetry() {
   }
 }
 
-export type LogRecordProcessor = any;
-
 /**
  * Options for OpenTelemetry logger integration
  */
 export type OpenTelemetryLoggerOptions = {
   /**
-   * Log record processor (e.g., BatchLogRecordProcessor with an exporter)
-   * If not provided, logs will only be instrumented but not exported
+   * Log record processor (e.g., BatchLogRecordProcessor with an exporter).
+   * If not provided, logs will only be instrumented but not exported.
    */
-  logRecordProcessor?: any;
+  logRecordProcessor?: LogRecordProcessor;
 
   /**
    * Logger provider instance. If not provided, a new one will be created.
    */
-  loggerProvider?: any;
+  loggerProvider?: OTelLoggerProvider;
+
+  /**
+   * Service name to attach to log records.
+   * Defaults to the `OTEL_SERVICE_NAME` environment variable, or `'unknown-service'`.
+   */
+  serviceName?: string;
 
   /**
    * Whether to enable the integration. Default: true
@@ -70,8 +100,8 @@ export type OpenTelemetryLoggerOptions = {
   enabled?: boolean;
 };
 
-let pinoInstrumentation: any | null = null;
-let loggerProvider: any | null = null;
+let pinoInstrumentation: PinoInstrumentationInstance | null = null;
+let loggerProvider: OTelLoggerProvider | null = null;
 
 /**
  * Set up OpenTelemetry integration for Pino logger.
@@ -127,7 +157,12 @@ export async function setupOpenTelemetryLogger(
     return;
   }
 
-  const { logRecordProcessor, loggerProvider: providedLoggerProvider, enabled = true } = options;
+  const {
+    logRecordProcessor,
+    loggerProvider: providedLoggerProvider,
+    serviceName,
+    enabled = true,
+  } = options;
 
   if (!enabled) {
     console.log('[logger] OpenTelemetry integration disabled');
@@ -152,21 +187,25 @@ export async function setupOpenTelemetryLogger(
   }
 
   // Create or use provided logger provider
-  loggerProvider = providedLoggerProvider ?? new LoggerProvider();
+  loggerProvider = (providedLoggerProvider ?? new LoggerProvider()) as OTelLoggerProvider;
 
   // Register log record processor if provided
-  if (logRecordProcessor) {
+  if (logRecordProcessor && loggerProvider) {
     loggerProvider.addLogRecordProcessor(logRecordProcessor);
   }
 
+  // Resolve service name from option, env var, or fallback
+  const resolvedServiceName =
+    serviceName ??
+    (typeof process !== 'undefined' ? process.env?.OTEL_SERVICE_NAME : undefined) ??
+    'unknown-service';
+
   // Enable Pino instrumentation to bridge Pino logs to OpenTelemetry
   pinoInstrumentation = new PinoInstrumentation({
-    logHook: (_span: any, record: any) => {
-      // Optionally modify log records here before they're sent to OTel
-      // For now, pass through as-is
-      record['service.name'] = process.env.OTEL_SERVICE_NAME || 'eventuras';
+    logHook: (_span: unknown, record: Record<string, unknown>) => {
+      record['service.name'] = resolvedServiceName;
     },
-  });
+  }) as PinoInstrumentationInstance;
 
   pinoInstrumentation.enable();
 
@@ -209,7 +248,7 @@ export async function shutdownOpenTelemetryLogger(): Promise<void> {
  * Get the active LoggerProvider instance, if any.
  * Useful for advanced use cases or debugging.
  */
-export function getLoggerProvider(): any | null {
+export function getLoggerProvider(): OTelLoggerProvider | null {
   // Return null if in browser environment
   if (typeof window !== 'undefined') {
     return null;

--- a/libs/logger/src/transports/console.test.ts
+++ b/libs/logger/src/transports/console.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConsoleTransport } from './console.js';
+import type { LogLevel } from '../types.js';
+
+describe('ConsoleTransport', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps log levels to correct console methods', () => {
+    const transport = new ConsoleTransport();
+    const mapping: Record<string, keyof Console> = {
+      trace: 'debug',
+      debug: 'debug',
+      info: 'log',
+      warn: 'warn',
+      error: 'error',
+      fatal: 'error',
+    };
+
+    for (const [level, method] of Object.entries(mapping)) {
+      const spy = vi.spyOn(console, method as 'log').mockImplementation(() => { });
+      transport.log(level as LogLevel, {}, `test ${level}`);
+      expect(spy).toHaveBeenCalledWith(`[${level}]`, `test ${level}`);
+      spy.mockRestore();
+    }
+  });
+
+  it('logs message with data', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const transport = new ConsoleTransport();
+
+    transport.log('info', { userId: 42 }, 'User logged in');
+
+    expect(spy).toHaveBeenCalledWith('[info]', 'User logged in', { userId: 42 });
+  });
+
+  it('logs data without message', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const transport = new ConsoleTransport();
+
+    transport.log('info', { userId: 42 });
+
+    expect(spy).toHaveBeenCalledWith('[info]', { userId: 42 });
+  });
+
+  it('does not log when data is empty and no message', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const transport = new ConsoleTransport();
+
+    transport.log('info', {});
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('creates child transport with merged bindings', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const transport = new ConsoleTransport();
+    const child = transport.child({ namespace: 'test' });
+
+    child.log('info', { extra: true }, 'hello');
+
+    expect(spy).toHaveBeenCalledWith('[info]', 'hello', { namespace: 'test', extra: true });
+  });
+
+  it('chains child bindings', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => { });
+    const transport = new ConsoleTransport();
+    const child = transport.child({ a: 1 }).child({ b: 2 });
+
+    child.log('info', { c: 3 }, 'chained');
+
+    expect(spy).toHaveBeenCalledWith('[info]', 'chained', { a: 1, b: 2, c: 3 });
+  });
+});

--- a/libs/logger/src/transports/console.ts
+++ b/libs/logger/src/transports/console.ts
@@ -1,0 +1,42 @@
+/**
+ * Console-based transport for browser environments and testing.
+ *
+ * Uses `console.log/warn/error` — no dependencies, works everywhere.
+ * Useful as a lightweight fallback when Pino is not available or desired.
+ */
+import type { LogLevel, LogTransport } from '../types';
+
+const LEVEL_TO_CONSOLE: Record<LogLevel, 'log' | 'warn' | 'error' | 'debug'> = {
+  trace: 'debug',
+  debug: 'debug',
+  info: 'log',
+  warn: 'warn',
+  error: 'error',
+  fatal: 'error',
+};
+
+export class ConsoleTransport implements LogTransport {
+  private bindings: Record<string, unknown>;
+
+  constructor(bindings?: Record<string, unknown>) {
+    this.bindings = bindings ?? {};
+  }
+
+  log(level: LogLevel, data: Record<string, unknown>, msg?: string): void {
+    const method = LEVEL_TO_CONSOLE[level];
+    const merged = { ...this.bindings, ...data };
+    const hasData = Object.keys(merged).length > 0;
+
+    if (msg && hasData) {
+      console[method](`[${level}]`, msg, merged);
+    } else if (msg) {
+      console[method](`[${level}]`, msg);
+    } else if (hasData) {
+      console[method](`[${level}]`, merged);
+    }
+  }
+
+  child(bindings: Record<string, unknown>): LogTransport {
+    return new ConsoleTransport({ ...this.bindings, ...bindings });
+  }
+}

--- a/libs/logger/src/transports/console.ts
+++ b/libs/logger/src/transports/console.ts
@@ -18,10 +18,12 @@ const LEVEL_TO_CONSOLE: Record<LogLevel, 'log' | 'warn' | 'error' | 'debug'> = {
 export class ConsoleTransport implements LogTransport {
   private bindings: Record<string, unknown>;
 
+  /** Create a ConsoleTransport with optional pre-bound context fields. */
   constructor(bindings?: Record<string, unknown>) {
     this.bindings = bindings ?? {};
   }
 
+  /** Write a log entry to the appropriate `console` method. */
   log(level: LogLevel, data: Record<string, unknown>, msg?: string): void {
     const method = LEVEL_TO_CONSOLE[level];
     const merged = { ...this.bindings, ...data };
@@ -36,6 +38,7 @@ export class ConsoleTransport implements LogTransport {
     }
   }
 
+  /** Return a new ConsoleTransport with the given bindings merged in. */
   child(bindings: Record<string, unknown>): LogTransport {
     return new ConsoleTransport({ ...this.bindings, ...bindings });
   }

--- a/libs/logger/src/transports/pino.test.ts
+++ b/libs/logger/src/transports/pino.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { PinoTransport } from './pino.js';
+
+describe('PinoTransport', () => {
+  it('creates with default options', () => {
+    const transport = new PinoTransport();
+    expect(transport.pino).toBeDefined();
+    expect(transport.pino.level).toBe('info');
+  });
+
+  it('respects custom log level', () => {
+    const transport = new PinoTransport({ level: 'debug' });
+    expect(transport.pino.level).toBe('debug');
+  });
+
+  it('logs at the specified level', () => {
+    const transport = new PinoTransport({ level: 'trace' });
+    // Pino won't throw when we call log methods
+    expect(() => {
+      transport.log('info', { key: 'value' }, 'test message');
+      transport.log('error', { err: 'something' });
+      transport.log('trace', {}, 'trace message');
+    }).not.toThrow();
+  });
+
+  it('creates a child transport with bindings', () => {
+    const transport = new PinoTransport();
+    const child = transport.child({ namespace: 'test' });
+
+    expect(child).toBeDefined();
+    // Child should also implement LogTransport
+    expect(child.log).toBeTypeOf('function');
+    expect(child.child).toBeTypeOf('function');
+  });
+
+  it('child transport chains bindings', () => {
+    const transport = new PinoTransport();
+    const child = transport.child({ a: 1 }).child({ b: 2 });
+
+    expect(() => {
+      child.log('info', {}, 'nested child');
+    }).not.toThrow();
+  });
+
+  it('flush does not throw', async () => {
+    const transport = new PinoTransport();
+    await expect(transport.flush()).resolves.toBeUndefined();
+  });
+
+  it('accepts raw pinoOptions', () => {
+    const transport = new PinoTransport({
+      pinoOptions: { name: 'my-app' },
+    });
+    // Pino stores the name in bindings
+    expect(transport.pino).toBeDefined();
+  });
+
+  it('configures redaction', () => {
+    const transport = new PinoTransport({
+      redact: ['password', 'secret'],
+    });
+    // Pino should be configured — just verify it doesn't error
+    expect(() => {
+      transport.log('info', { password: 'hunter2', ok: true }, 'redact test');
+    }).not.toThrow();
+  });
+});

--- a/libs/logger/src/transports/pino.ts
+++ b/libs/logger/src/transports/pino.ts
@@ -1,0 +1,80 @@
+/**
+ * Pino-based transport — the default production backend.
+ *
+ * Wraps a Pino logger instance to satisfy the `LogTransport` interface,
+ * keeping Pino as an implementation detail that consumers never interact with directly.
+ */
+import pino, { type Logger as PinoLogger, type LoggerOptions as PinoLoggerOptions } from 'pino';
+import type { LogLevel, LogTransport } from '../types';
+
+/** Options for creating a PinoTransport. */
+export type PinoTransportOptions = {
+  /** Minimum log level. Defaults to `'info'`. */
+  level?: LogLevel;
+  /** Field paths to redact from output. */
+  redact?: string[];
+  /** File path destination (omit for stdout). */
+  destination?: string;
+  /** Raw Pino options for advanced tuning (merged after built-in defaults). */
+  pinoOptions?: PinoLoggerOptions;
+};
+
+export class PinoTransport implements LogTransport {
+  /** The underlying Pino instance. Exposed for advanced integrations only. */
+  readonly pino: PinoLogger;
+
+  constructor(options: PinoTransportOptions = {}) {
+    const pinoOpts: PinoLoggerOptions = {
+      level: options.level ?? 'info',
+      ...(options.redact && {
+        redact: { paths: options.redact, censor: '[REDACTED]' },
+      }),
+      ...options.pinoOptions,
+    };
+
+    this.pino = options.destination
+      ? pino(pinoOpts, pino.destination(options.destination))
+      : pino(pinoOpts);
+  }
+
+  log(level: LogLevel, data: Record<string, unknown>, msg?: string): void {
+    if (msg) {
+      this.pino[level](data, msg);
+    } else {
+      this.pino[level](data);
+    }
+  }
+
+  child(bindings: Record<string, unknown>): LogTransport {
+    const childPino = this.pino.child(bindings);
+    return new PinoChildTransport(childPino);
+  }
+
+  async flush(): Promise<void> {
+    this.pino.flush();
+  }
+}
+
+/**
+ * Lightweight wrapper for a Pino child logger.
+ * Created by `PinoTransport.child()` — not intended for direct use.
+ */
+class PinoChildTransport implements LogTransport {
+  constructor(private readonly pinoChild: PinoLogger) { }
+
+  log(level: LogLevel, data: Record<string, unknown>, msg?: string): void {
+    if (msg) {
+      this.pinoChild[level](data, msg);
+    } else {
+      this.pinoChild[level](data);
+    }
+  }
+
+  child(bindings: Record<string, unknown>): LogTransport {
+    return new PinoChildTransport(this.pinoChild.child(bindings));
+  }
+
+  async flush(): Promise<void> {
+    this.pinoChild.flush();
+  }
+}

--- a/libs/logger/src/transports/pino.ts
+++ b/libs/logger/src/transports/pino.ts
@@ -13,6 +13,8 @@ export type PinoTransportOptions = {
   level?: LogLevel;
   /** Field paths to redact from output. */
   redact?: string[];
+  /** Enable pretty-printed, human-readable output. */
+  prettyPrint?: boolean;
   /** File path destination (omit for stdout). */
   destination?: string;
   /** Raw Pino options for advanced tuning (merged after built-in defaults). */
@@ -28,6 +30,9 @@ export class PinoTransport implements LogTransport {
       level: options.level ?? 'info',
       ...(options.redact && {
         redact: { paths: options.redact, censor: '[REDACTED]' },
+      }),
+      ...(options.prettyPrint && {
+        transport: { target: 'pino-pretty', options: { colorize: true } },
       }),
       ...options.pinoOptions,
     };

--- a/libs/logger/src/transports/pino.ts
+++ b/libs/logger/src/transports/pino.ts
@@ -6,6 +6,7 @@
  */
 import pino, { type Logger as PinoLogger, type LoggerOptions as PinoLoggerOptions } from 'pino';
 import type { LogLevel, LogTransport } from '../types';
+import { createPrettyStream } from './pretty';
 
 /** Options for creating a PinoTransport. */
 export type PinoTransportOptions = {
@@ -31,15 +32,16 @@ export class PinoTransport implements LogTransport {
       ...(options.redact && {
         redact: { paths: options.redact, censor: '[REDACTED]' },
       }),
-      ...(options.prettyPrint && {
-        transport: { target: 'pino-pretty', options: { colorize: true } },
-      }),
       ...options.pinoOptions,
     };
 
-    this.pino = options.destination
-      ? pino(pinoOpts, pino.destination(options.destination))
-      : pino(pinoOpts);
+    if (options.prettyPrint) {
+      this.pino = pino(pinoOpts, createPrettyStream());
+    } else if (options.destination) {
+      this.pino = pino(pinoOpts, pino.destination(options.destination));
+    } else {
+      this.pino = pino(pinoOpts);
+    }
   }
 
   log(level: LogLevel, data: Record<string, unknown>, msg?: string): void {

--- a/libs/logger/src/transports/pino.ts
+++ b/libs/logger/src/transports/pino.ts
@@ -29,6 +29,12 @@ export class PinoTransport implements LogTransport {
   constructor(options: PinoTransportOptions = {}) {
     const pinoOpts: PinoLoggerOptions = {
       level: options.level ?? 'info',
+      // ISO timestamps for Loki/Grafana compatibility
+      timestamp: pino.stdTimeFunctions.isoTime,
+      // Output level as string label — avoids numeric mapping in log pipelines
+      formatters: {
+        level: (label) => ({ level: label }),
+      },
       ...(options.redact && {
         redact: { paths: options.redact, censor: '[REDACTED]' },
       }),

--- a/libs/logger/src/transports/pretty.test.ts
+++ b/libs/logger/src/transports/pretty.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { formatLogLine } from './pretty.js';
+
+describe('formatLogLine', () => {
+  it('formats an info log with message', () => {
+    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'hello world' });
+    const result = formatLogLine(json);
+    expect(result).toContain('INFO');
+    expect(result).toContain('hello world');
+    expect(result).toContain('→');
+  });
+
+  it('formats an error log with red coloring', () => {
+    const json = JSON.stringify({ level: 50, time: Date.now(), msg: 'something broke' });
+    const result = formatLogLine(json);
+    expect(result).toContain('ERROR');
+    expect(result).toContain('\x1b[31m'); // red
+    expect(result).toContain('something broke');
+  });
+
+  it('includes namespace in output', () => {
+    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'test', ns: 'web:auth' });
+    const result = formatLogLine(json);
+    expect(result).toContain('(web:auth)');
+  });
+
+  it('includes extra data fields', () => {
+    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'req', userId: 42, path: '/api' });
+    const result = formatLogLine(json);
+    expect(result).toContain('userId');
+    expect(result).toContain('42');
+  });
+
+  it('excludes internal pino keys from data', () => {
+    const json = JSON.stringify({ level: 30, time: 123, pid: 1, hostname: 'test', msg: 'hi' });
+    const result = formatLogLine(json);
+    expect(result).not.toContain('"pid"');
+    expect(result).not.toContain('"hostname"');
+  });
+
+  it('returns original string for non-JSON input', () => {
+    expect(formatLogLine('not json')).toBe('not json');
+  });
+
+  it('returns empty string for blank input', () => {
+    expect(formatLogLine('')).toBe('');
+    expect(formatLogLine('  ')).toBe('');
+  });
+
+  it('handles all log levels', () => {
+    const levels = [
+      { num: 10, label: 'TRACE' },
+      { num: 20, label: 'DEBUG' },
+      { num: 30, label: 'INFO' },
+      { num: 40, label: 'WARN' },
+      { num: 50, label: 'ERROR' },
+      { num: 60, label: 'FATAL' },
+    ];
+    for (const { num, label } of levels) {
+      const json = JSON.stringify({ level: num, time: Date.now(), msg: 'test' });
+      expect(formatLogLine(json)).toContain(label);
+    }
+  });
+});

--- a/libs/logger/src/transports/pretty.test.ts
+++ b/libs/logger/src/transports/pretty.test.ts
@@ -44,6 +44,14 @@ describe('formatLogLine', () => {
     expect(result).toContain('(web:auth)');
   });
 
+  it('includes namespace from Logger-style "namespace" field', () => {
+    const json = JSON.stringify({ level: 'info', time: '2026-04-11T19:00:00.000Z', msg: 'test', namespace: 'web:admin:events' });
+    const result = formatLogLine(json);
+    expect(result).toContain('(web:admin:events)');
+    // namespace should not appear in extra data
+    expect(result).not.toContain('"namespace"');
+  });
+
   it('includes extra data fields', () => {
     const json = JSON.stringify({ level: 'info', time: '2026-04-11T19:00:00.000Z', msg: 'req', userId: 42, path: '/api' });
     const result = formatLogLine(json);

--- a/libs/logger/src/transports/pretty.test.ts
+++ b/libs/logger/src/transports/pretty.test.ts
@@ -2,37 +2,57 @@ import { describe, it, expect } from 'vitest';
 import { formatLogLine } from './pretty.js';
 
 describe('formatLogLine', () => {
-  it('formats an info log with message', () => {
-    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'hello world' });
+  it('formats a string-level info log (default format)', () => {
+    const json = JSON.stringify({ level: 'info', time: '2026-04-11T19:00:00.000Z', msg: 'hello world' });
     const result = formatLogLine(json);
     expect(result).toContain('INFO');
     expect(result).toContain('hello world');
     expect(result).toContain('→');
   });
 
-  it('formats an error log with red coloring', () => {
-    const json = JSON.stringify({ level: 50, time: Date.now(), msg: 'something broke' });
+  it('formats a string-level error log with red coloring', () => {
+    const json = JSON.stringify({ level: 'error', time: '2026-04-11T19:00:00.000Z', msg: 'something broke' });
     const result = formatLogLine(json);
     expect(result).toContain('ERROR');
     expect(result).toContain('\x1b[31m'); // red
     expect(result).toContain('something broke');
   });
 
+  it('handles numeric levels for backwards compatibility', () => {
+    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'numeric level' });
+    const result = formatLogLine(json);
+    expect(result).toContain('INFO');
+    expect(result).toContain('numeric level');
+  });
+
+  it('handles ISO timestamp strings', () => {
+    const json = JSON.stringify({ level: 'info', time: '2026-04-11T12:34:56.789Z', msg: 'test' });
+    const result = formatLogLine(json);
+    // Should contain a formatted time (exact value depends on locale/TZ)
+    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('handles numeric timestamps', () => {
+    const json = JSON.stringify({ level: 'info', time: 1712851200000, msg: 'test' });
+    const result = formatLogLine(json);
+    expect(result).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+
   it('includes namespace in output', () => {
-    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'test', ns: 'web:auth' });
+    const json = JSON.stringify({ level: 'info', time: '2026-04-11T19:00:00.000Z', msg: 'test', ns: 'web:auth' });
     const result = formatLogLine(json);
     expect(result).toContain('(web:auth)');
   });
 
   it('includes extra data fields', () => {
-    const json = JSON.stringify({ level: 30, time: Date.now(), msg: 'req', userId: 42, path: '/api' });
+    const json = JSON.stringify({ level: 'info', time: '2026-04-11T19:00:00.000Z', msg: 'req', userId: 42, path: '/api' });
     const result = formatLogLine(json);
     expect(result).toContain('userId');
     expect(result).toContain('42');
   });
 
   it('excludes internal pino keys from data', () => {
-    const json = JSON.stringify({ level: 30, time: 123, pid: 1, hostname: 'test', msg: 'hi' });
+    const json = JSON.stringify({ level: 'info', time: '2026-04-11T19:00:00.000Z', pid: 1, hostname: 'test', msg: 'hi' });
     const result = formatLogLine(json);
     expect(result).not.toContain('"pid"');
     expect(result).not.toContain('"hostname"');
@@ -47,7 +67,15 @@ describe('formatLogLine', () => {
     expect(formatLogLine('  ')).toBe('');
   });
 
-  it('handles all log levels', () => {
+  it('handles all string log levels', () => {
+    const levels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
+    for (const level of levels) {
+      const json = JSON.stringify({ level, time: '2026-04-11T19:00:00.000Z', msg: 'test' });
+      expect(formatLogLine(json)).toContain(level.toUpperCase());
+    }
+  });
+
+  it('handles all numeric log levels', () => {
     const levels = [
       { num: 10, label: 'TRACE' },
       { num: 20, label: 'DEBUG' },

--- a/libs/logger/src/transports/pretty.ts
+++ b/libs/logger/src/transports/pretty.ts
@@ -21,7 +21,7 @@ const ANSI = {
   gray: '\x1b[90m',
 } as const;
 
-const LEVEL_CONFIG: Record<number, { label: string; color: string; }> = {
+const LEVEL_BY_NUMBER: Record<number, { label: string; color: string; }> = {
   10: { label: 'TRACE', color: ANSI.gray },
   20: { label: 'DEBUG', color: ANSI.cyan },
   30: { label: 'INFO ', color: ANSI.green },
@@ -30,14 +30,30 @@ const LEVEL_CONFIG: Record<number, { label: string; color: string; }> = {
   60: { label: 'FATAL', color: `${ANSI.bold}${ANSI.red}` },
 };
 
+const LEVEL_BY_NAME: Record<string, { label: string; color: string; }> = {
+  trace: { label: 'TRACE', color: ANSI.gray },
+  debug: { label: 'DEBUG', color: ANSI.cyan },
+  info:  { label: 'INFO ', color: ANSI.green },
+  warn:  { label: 'WARN ', color: ANSI.yellow },
+  error: { label: 'ERROR', color: ANSI.red },
+  fatal: { label: 'FATAL', color: `${ANSI.bold}${ANSI.red}` },
+};
+
 /** Keys excluded from the "extra data" output. */
 const INTERNAL_KEYS = new Set([
   'level', 'time', 'pid', 'hostname', 'msg', 'name', 'ns',
 ]);
 
-function formatTime(epoch: number): string {
-  const d = new Date(epoch);
-  return d.toLocaleTimeString('en-GB', { hour12: false });
+function formatTime(time: unknown): string {
+  if (typeof time === 'string') {
+    // ISO string — extract time portion
+    const d = new Date(time);
+    return isNaN(d.getTime()) ? '' : d.toLocaleTimeString('en-GB', { hour12: false });
+  }
+  if (typeof time === 'number') {
+    return new Date(time).toLocaleTimeString('en-GB', { hour12: false });
+  }
+  return new Date().toLocaleTimeString('en-GB', { hour12: false });
 }
 
 function formatData(obj: Record<string, unknown>): string {
@@ -71,9 +87,11 @@ export function formatLogLine(line: string): string {
     return trimmed;
   }
 
-  const level = obj.level as number;
-  const config = LEVEL_CONFIG[level] ?? { label: `L${level}`, color: ANSI.gray };
-  const time = formatTime((obj.time as number) ?? Date.now());
+  const level = obj.level;
+  const config = typeof level === 'string'
+    ? LEVEL_BY_NAME[level] ?? { label: level.toUpperCase().padEnd(5), color: ANSI.gray }
+    : LEVEL_BY_NUMBER[level as number] ?? { label: `L${level}`, color: ANSI.gray };
+  const time = formatTime(obj.time);
   const msg = (obj.msg as string) ?? '';
   const ns = (obj.ns as string) || (obj.name as string) || '';
 

--- a/libs/logger/src/transports/pretty.ts
+++ b/libs/logger/src/transports/pretty.ts
@@ -1,0 +1,104 @@
+/**
+ * Lightweight pretty-print formatter for development.
+ * Zero external dependencies — uses ANSI colors and simple formatting.
+ *
+ * Produces output like:
+ *   12:34:56 INFO  (web:auth) → User logged in
+ *   12:34:56 ERROR (web:auth) → Failed to authenticate { error: "invalid token" }
+ */
+
+import { Writable } from 'node:stream';
+
+const ANSI = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  bold: '\x1b[1m',
+  red: '\x1b[31m',
+  yellow: '\x1b[33m',
+  green: '\x1b[32m',
+  cyan: '\x1b[36m',
+  magenta: '\x1b[35m',
+  gray: '\x1b[90m',
+} as const;
+
+const LEVEL_CONFIG: Record<number, { label: string; color: string; }> = {
+  10: { label: 'TRACE', color: ANSI.gray },
+  20: { label: 'DEBUG', color: ANSI.cyan },
+  30: { label: 'INFO ', color: ANSI.green },
+  40: { label: 'WARN ', color: ANSI.yellow },
+  50: { label: 'ERROR', color: ANSI.red },
+  60: { label: 'FATAL', color: `${ANSI.bold}${ANSI.red}` },
+};
+
+/** Keys excluded from the "extra data" output. */
+const INTERNAL_KEYS = new Set([
+  'level', 'time', 'pid', 'hostname', 'msg', 'name', 'ns',
+]);
+
+function formatTime(epoch: number): string {
+  const d = new Date(epoch);
+  return d.toLocaleTimeString('en-GB', { hour12: false });
+}
+
+function formatData(obj: Record<string, unknown>): string {
+  const filtered: Record<string, unknown> = {};
+  let hasKeys = false;
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (!INTERNAL_KEYS.has(key)) {
+      filtered[key] = value;
+      hasKeys = true;
+    }
+  }
+
+  if (!hasKeys) return '';
+  return ` ${ANSI.dim}${JSON.stringify(filtered)}${ANSI.reset}`;
+}
+
+/**
+ * Format a Pino JSON log line into a human-readable string.
+ * @param line Raw JSON string from Pino
+ * @returns Formatted string, or the original line if parsing fails
+ */
+export function formatLogLine(line: string): string {
+  const trimmed = line.trim();
+  if (!trimmed) return '';
+
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    return trimmed;
+  }
+
+  const level = obj.level as number;
+  const config = LEVEL_CONFIG[level] ?? { label: `L${level}`, color: ANSI.gray };
+  const time = formatTime((obj.time as number) ?? Date.now());
+  const msg = (obj.msg as string) ?? '';
+  const ns = (obj.ns as string) || (obj.name as string) || '';
+
+  const nsTag = ns ? ` ${ANSI.magenta}(${ns})${ANSI.reset}` : '';
+  const arrow = `${ANSI.dim}→${ANSI.reset}`;
+  const data = formatData(obj);
+
+  return `${ANSI.dim}${time}${ANSI.reset} ${config.color}${config.label}${ANSI.reset}${nsTag} ${arrow} ${msg}${data}`;
+}
+
+/**
+ * Creates a Node.js writable stream that formats Pino JSON output.
+ * Used as the destination for PinoTransport when prettyPrint is enabled.
+ */
+export function createPrettyStream(): NodeJS.WritableStream {
+  return new Writable({
+    write(chunk: Buffer, _encoding: string, callback: () => void) {
+      const lines = chunk.toString().split('\n');
+      for (const line of lines) {
+        const formatted = formatLogLine(line);
+        if (formatted) {
+          process.stdout.write(formatted + '\n');
+        }
+      }
+      callback();
+    },
+  });
+}

--- a/libs/logger/src/transports/pretty.ts
+++ b/libs/logger/src/transports/pretty.ts
@@ -41,7 +41,7 @@ const LEVEL_BY_NAME: Record<string, { label: string; color: string; }> = {
 
 /** Keys excluded from the "extra data" output. */
 const INTERNAL_KEYS = new Set([
-  'level', 'time', 'pid', 'hostname', 'msg', 'name', 'ns',
+  'level', 'time', 'pid', 'hostname', 'msg', 'name', 'ns', 'namespace',
 ]);
 
 function formatTime(time: unknown): string {
@@ -93,7 +93,7 @@ export function formatLogLine(line: string): string {
     : LEVEL_BY_NUMBER[level as number] ?? { label: `L${level}`, color: ANSI.gray };
   const time = formatTime(obj.time);
   const msg = (obj.msg as string) ?? '';
-  const ns = (obj.ns as string) || (obj.name as string) || '';
+  const ns = (obj.namespace as string) || (obj.ns as string) || (obj.name as string) || '';
 
   const nsTag = ns ? ` ${ANSI.magenta}(${ns})${ANSI.reset}` : '';
   const arrow = `${ANSI.dim}→${ANSI.reset}`;

--- a/libs/logger/src/types.ts
+++ b/libs/logger/src/types.ts
@@ -60,7 +60,7 @@ export type LoggerConfig = {
   level?: LogLevel;
   /** Field paths to redact from log output (e.g., ['password', 'token']). */
   redact?: string[];
-  /** Enable pretty-printed output in development (Pino only). */
+  /** Enable pretty-printed output (auto-enabled in development). */
   prettyPrint?: boolean;
   /** Optional file path for log output (Pino only). */
   destination?: string;

--- a/libs/logger/src/types.ts
+++ b/libs/logger/src/types.ts
@@ -1,0 +1,65 @@
+/**
+ * Core type definitions for @eventuras/logger.
+ *
+ * The `LogTransport` interface is the primary extension point — implement it
+ * to send logs to any backend (Pino, Winston, console, a test spy, etc.).
+ */
+
+/** Standard log levels ordered by severity (lowest → highest). */
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+/**
+ * Pluggable transport interface for log output.
+ *
+ * Implement this to send structured log data to any backend.
+ * The library ships with `PinoTransport` (default) and `ConsoleTransport`.
+ *
+ * @example
+ * // Custom transport
+ * const myTransport: LogTransport = {
+ *   log(level, data, msg) { fetch('/logs', { body: JSON.stringify({ level, ...data, msg }) }); },
+ *   child(bindings) { return { ...myTransport, log(l, d, m) { myTransport.log(l, { ...bindings, ...d }, m); } }; },
+ * };
+ */
+export interface LogTransport {
+  /** Write a log entry at the given level. */
+  log(level: LogLevel, data: Record<string, unknown>, msg?: string): void;
+
+  /** Create a child transport with additional bound fields. */
+  child(bindings: Record<string, unknown>): LogTransport;
+
+  /** Flush any buffered log entries. */
+  flush?(): Promise<void>;
+
+  /** Graceful shutdown — flush and release resources. */
+  shutdown?(): Promise<void>;
+}
+
+/** Options for creating a scoped Logger instance. */
+export type LoggerOptions = {
+  /** If true, only logs in development mode. */
+  developerOnly?: boolean;
+  /** Namespace for filtering logs (e.g., 'web:admin:events'). */
+  namespace?: string;
+  /** Minimum log level for this logger instance. */
+  level?: LogLevel;
+  /** Persistent context fields included in every log entry. */
+  context?: Record<string, unknown>;
+  /** Correlation ID for request tracing. */
+  correlationId?: string;
+};
+
+/** Extended options for error/fatal log methods. */
+export type ErrorLoggerOptions = LoggerOptions & {
+  error?: unknown;
+};
+
+/** Global logger configuration. */
+export type LoggerConfig = {
+  /** Global minimum log level. */
+  level?: LogLevel;
+  /** Field paths to redact from log output (e.g., ['password', 'token']). */
+  redact?: string[];
+  /** Custom transport implementation. Defaults to PinoTransport. */
+  transport?: LogTransport;
+};

--- a/libs/logger/src/types.ts
+++ b/libs/logger/src/types.ts
@@ -60,6 +60,8 @@ export type LoggerConfig = {
   level?: LogLevel;
   /** Field paths to redact from log output (e.g., ['password', 'token']). */
   redact?: string[];
+  /** Enable pretty-printed output in development (Pino only). */
+  prettyPrint?: boolean;
   /** Optional file path for log output (Pino only). */
   destination?: string;
   /** Custom transport implementation. Defaults to PinoTransport. */

--- a/libs/logger/src/types.ts
+++ b/libs/logger/src/types.ts
@@ -60,6 +60,8 @@ export type LoggerConfig = {
   level?: LogLevel;
   /** Field paths to redact from log output (e.g., ['password', 'token']). */
   redact?: string[];
+  /** Optional file path for log output (Pino only). */
+  destination?: string;
   /** Custom transport implementation. Defaults to PinoTransport. */
   transport?: LogTransport;
 };

--- a/libs/logger/vite.config.ts
+++ b/libs/logger/vite.config.ts
@@ -3,6 +3,7 @@ import { defineVanillaLibConfig } from '@eventuras/vite-config/vanilla-lib';
 export default defineVanillaLibConfig({
   entry: {
     index: 'src/index.ts',
+    node: 'src/node.ts',
     opentelemetry: 'src/opentelemetry.ts',
   },
 });

--- a/libs/logger/vitest.config.ts
+++ b/libs/logger/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      exclude: [
+        'node_modules/',
+        'dist/',
+        '**/*.d.ts',
+        '**/*.config.*',
+      ],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1160,6 +1160,9 @@ importers:
       vite:
         specifier: ^8.0.3
         version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   libs/lustro-search:
     dependencies:
@@ -1490,7 +1493,7 @@ importers:
         version: 10.3.4(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@storybook/addon-vitest':
         specifier: ^10.3.4
-        version: 10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2))(@vitest/runner@4.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)
+        version: 10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2))(@vitest/runner@4.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)
       '@storybook/react-vite':
         specifier: ^10.3.4
         version: 10.3.4(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rollup@4.60.1)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(webpack@5.104.1(esbuild@0.27.7))
@@ -7687,8 +7690,22 @@ packages:
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
   '@vitest/mocker@4.1.2':
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -7704,17 +7721,29 @@ packages:
   '@vitest/pretty-format@4.1.2':
     resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
   '@vitest/runner@4.1.2':
     resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
   '@vitest/snapshot@4.1.2':
     resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
   '@vitest/spy@4.1.2':
     resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
 
   '@vitest/ui@4.1.2':
     resolution: {integrity: sha512-/irhyeAcKS2u6Zokagf9tqZJ0t8S6kMZq4ZG9BHZv7I+fkRrYfQX4w7geYeC2r6obThz39PDxvXQzZX+qXqGeg==}
@@ -7726,6 +7755,9 @@ packages:
 
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@vladfrangu/async_event_emitter@2.4.7':
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
@@ -13441,6 +13473,47 @@ packages:
       jsdom:
         optional: true
 
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -14324,7 +14397,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14396,7 +14469,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -15144,7 +15217,7 @@ snapshots:
   '@eslint/config-array@0.23.4':
     dependencies:
       '@eslint/object-schema': 3.0.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -15183,7 +15256,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -15826,7 +15899,7 @@ snapshots:
 
   '@koa/router@15.4.0(koa@3.2.0)':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       koa: 3.2.0
       koa-compose: 4.1.0
@@ -16313,7 +16386,7 @@ snapshots:
       semver: 7.7.4
       string-width: 4.2.3
       supports-color: 8.1.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       widest-line: 3.1.0
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
@@ -16335,7 +16408,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.4
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       npm: 10.9.8
       npm-package-arg: 11.0.3
       npm-run-path: 5.3.0
@@ -16351,7 +16424,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.4
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-call: 5.3.0
       lodash: 4.18.1
       registry-auth-token: 5.1.1
@@ -16364,7 +16437,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.4
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20566,7 +20639,7 @@ snapshots:
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2))(@vitest/runner@4.1.2)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)':
+  '@storybook/addon-vitest@10.3.4(@vitest/browser-playwright@4.1.2)(@vitest/browser@4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2))(@vitest/runner@4.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vitest@4.1.2)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -20574,7 +20647,7 @@ snapshots:
     optionalDependencies:
       '@vitest/browser': 4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2)
       '@vitest/browser-playwright': 4.1.2(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2)
-      '@vitest/runner': 4.1.2
+      '@vitest/runner': 4.1.4
       vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(@vitest/browser-playwright@4.1.2)(@vitest/ui@4.1.2)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     transitivePeerDependencies:
       - react
@@ -20882,7 +20955,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21189,7 +21262,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.0(jiti@2.6.1)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -21201,7 +21274,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.0(jiti@2.6.1)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -21211,7 +21284,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -21220,7 +21293,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -21248,7 +21321,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -21260,7 +21333,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -21277,7 +21350,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -21292,7 +21365,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
@@ -21502,6 +21575,15 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
   '@vitest/mocker@4.1.2(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
@@ -21518,6 +21600,14 @@ snapshots:
     optionalDependencies:
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  '@vitest/mocker@4.1.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
@@ -21526,9 +21616,18 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
   '@vitest/runner@4.1.2':
     dependencies:
       '@vitest/utils': 4.1.2
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.2':
@@ -21538,11 +21637,20 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
 
   '@vitest/spy@4.1.2': {}
+
+  '@vitest/spy@4.1.4': {}
 
   '@vitest/ui@4.1.2(vitest@4.1.2)':
     dependencies:
@@ -21564,6 +21672,12 @@ snapshots:
   '@vitest/utils@4.1.2':
     dependencies:
       '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -21752,7 +21866,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22044,7 +22158,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -22958,7 +23072,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
@@ -23150,7 +23264,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.0(jiti@2.6.1)
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
@@ -23165,7 +23279,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.2.0(jiti@2.6.1)
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
@@ -23272,7 +23386,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.50.2
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 10.2.0(jiti@2.6.1)
       espree: 10.4.0
@@ -23484,7 +23598,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -23591,7 +23705,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -23764,7 +23878,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -23916,7 +24030,7 @@ snapshots:
   gel@2.2.0:
     dependencies:
       '@petamoriken/float16': 3.9.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       env-paths: 3.0.0
       semver: 7.7.4
       shell-quote: 1.8.3
@@ -24346,7 +24460,7 @@ snapshots:
   http-call@5.3.0:
     dependencies:
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -24380,14 +24494,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24796,7 +24910,7 @@ snapshots:
 
   json-schema-resolver@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-uri: 3.1.0
       rfdc: 1.4.1
     transitivePeerDependencies:
@@ -24812,7 +24926,7 @@ snapshots:
       lodash: 4.18.1
       minimist: 1.2.8
       prettier: 3.8.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   json-schema-to-zod@2.6.1: {}
 
@@ -25552,7 +25666,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -25645,7 +25759,7 @@ snapshots:
   mqtt-packet@6.10.0:
     dependencies:
       bl: 4.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       process-nextick-args: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -25654,7 +25768,7 @@ snapshots:
     dependencies:
       commist: 1.1.0
       concat-stream: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       duplexify: 4.1.3
       help-me: 3.0.0
       inherits: 2.0.4
@@ -25874,7 +25988,7 @@ snapshots:
 
   number-allocator@1.0.14:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       js-sdsl: 4.3.0
     transitivePeerDependencies:
       - supports-color
@@ -25953,7 +26067,7 @@ snapshots:
       ansis: 3.17.0
       async-retry: 1.3.3
       change-case: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       ejs: 3.1.10
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
@@ -25976,7 +26090,7 @@ snapshots:
     dependencies:
       '@koa/cors': 5.0.0
       '@koa/router': 15.4.0(koa@3.2.0)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eta: 4.5.1
       jose: 6.2.2
       jsesc: 3.1.0
@@ -27066,7 +27180,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -27173,7 +27287,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -27259,7 +27373,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -27468,7 +27582,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.4
       sort-object-keys: 1.1.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   source-map-js@1.2.1: {}
 
@@ -27711,7 +27825,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
   supports-color@5.5.0:
@@ -27957,7 +28071,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -28302,7 +28416,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@6.0.2)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -28413,6 +28527,36 @@ snapshots:
       '@types/node': 25.5.0
       '@vitest/browser-playwright': 4.1.2(playwright@1.59.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.2)
       '@vitest/ui': 4.1.2(vitest@4.1.2)
+      happy-dom: 20.8.9
+      jsdom: 29.0.1
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.5.0
       happy-dom: 20.8.9
       jsdom: 29.0.1
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1138,6 +1138,13 @@ importers:
 
   libs/logger:
     dependencies:
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+    devDependencies:
+      '@eventuras/vite-config':
+        specifier: workspace:*
+        version: link:../vite-config
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
@@ -1150,13 +1157,6 @@ importers:
       '@opentelemetry/sdk-logs':
         specifier: ^0.214.0
         version: 0.214.0(@opentelemetry/api@1.9.1)
-      pino:
-        specifier: ^10.3.1
-        version: 10.3.1
-    devDependencies:
-      '@eventuras/vite-config':
-        specifier: workspace:*
-        version: link:../vite-config
       vite:
         specifier: ^8.0.3
         version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.5.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
This PR refactors @eventuras/logger into a transport-based architecture (Pino + console + custom transports), improves OpenTelemetry typing/configurability, and adds a Vitest test suite + updated package metadata/docs for publishing.