### PR TITLE
fix(docker): harden Dockerfiles for security hotspots

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,9 +3,9 @@ FROM mcr.microsoft.com/vscode/devcontainers/dotnet:6.0
 # Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="16"
 RUN if [ "${NODE_VERSION}" != "none" ]; then \
-      su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; \
-    fi && \
-    dotnet tool install --global dotnet-ef
+  su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; \
+  fi && \
+  dotnet tool install --global dotnet-ef
 ENV PATH $PATH:/root/.dotnet/tools
 
 # Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
@@ -20,3 +20,5 @@ ENV PATH $PATH:/root/.dotnet/tools
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+
+USER vscode

--- a/apps/conductor/Dockerfile
+++ b/apps/conductor/Dockerfile
@@ -76,11 +76,11 @@ RUN groupadd -r conductor && useradd -r -g conductor conductor
 WORKDIR /app
 
 # Copy built application and production dependencies
-COPY --from=builder --chown=conductor:conductor /app/apps/conductor/dist ./dist
-COPY --from=builder --chown=conductor:conductor /app/apps/conductor/package.json ./package.json
+COPY --from=builder --chown=conductor:conductor --chmod=555 /app/apps/conductor/dist ./dist
+COPY --from=builder --chown=conductor:conductor --chmod=555 /app/apps/conductor/package.json ./package.json
 
 # Copy node_modules (contains production dependencies)
-COPY --from=builder --chown=conductor:conductor /app/node_modules ./node_modules
+COPY --from=builder --chown=conductor:conductor --chmod=555 /app/node_modules ./node_modules
 
 # Create config directory with proper permissions
 RUN mkdir -p /data/config && chown -R conductor:conductor /data/config
@@ -98,7 +98,7 @@ EXPOSE 3333
 
 # Health check using wget (available in alpine)
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3333/health || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:3333/health || exit 1
 
 # Start the application
 CMD ["node", "dist/index.js"]

--- a/apps/idem-idp/Dockerfile
+++ b/apps/idem-idp/Dockerfile
@@ -59,7 +59,7 @@ RUN addgroup --system --gid 1001 nodejs \
     && adduser --system --uid 1001 --ingroup nodejs idem
 
 # Copy built artifacts (dependencies are bundled by tsup)
-COPY --from=build --chown=idem:nodejs /srv/deploy ./
+COPY --from=build --chown=idem:nodejs --chmod=555 /srv/deploy ./
 
 USER idem
 

--- a/apps/idem-idp/Dockerfile
+++ b/apps/idem-idp/Dockerfile
@@ -44,9 +44,9 @@ ARG GIT_SHA=unknown
 
 # OCI labels
 LABEL org.opencontainers.image.title="idem-idp" \
-      org.opencontainers.image.version="${APP_VERSION}" \
-      org.opencontainers.image.revision="${GIT_SHA}" \
-      org.opencontainers.image.source="https://github.com/losol/eventuras"
+    org.opencontainers.image.version="${APP_VERSION}" \
+    org.opencontainers.image.revision="${GIT_SHA}" \
+    org.opencontainers.image.source="https://github.com/losol/eventuras"
 
 # Also expose in env (handy for / and /health)
 ENV NODE_ENV=production \
@@ -54,11 +54,16 @@ ENV NODE_ENV=production \
     GIT_SHA=${GIT_SHA} \
     PORT=3001
 
-# Copy built artifacts (dependencies are bundled by tsup)
-COPY --from=build /srv/deploy ./
+# Create non-root user for security
+RUN addgroup --system --gid 1001 nodejs \
+    && adduser --system --uid 1001 --ingroup nodejs idem
 
-# (rest unchanged)
+# Copy built artifacts (dependencies are bundled by tsup)
+COPY --from=build --chown=idem:nodejs /srv/deploy ./
+
+USER idem
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s \
-  CMD wget -qO- http://127.0.0.1:${PORT}/health || exit 1
+    CMD wget -qO- http://127.0.0.1:${PORT}/health || exit 1
 EXPOSE 3001
 CMD ["node", "--enable-source-maps", "dist/main.js"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1079,9 +1079,6 @@ importers:
       '@eventuras/logger':
         specifier: workspace:*
         version: link:../logger
-      '@eventuras/typescript-config':
-        specifier: workspace:*
-        version: link:../typescript-config
       '@xstate/react':
         specifier: ^5.0.0 || ^6.0.0
         version: 6.0.0(@types/react@19.2.14)(react@19.2.4)(xstate@5.30.0)
@@ -1095,6 +1092,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4
     devDependencies:
+      '@eventuras/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
       '@eventuras/vite-config':
         specifier: workspace:*
         version: link:../vite-config
@@ -14394,7 +14394,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -14466,7 +14466,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -15214,7 +15214,7 @@ snapshots:
   '@eslint/config-array@0.23.4':
     dependencies:
       '@eslint/object-schema': 3.0.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
     transitivePeerDependencies:
       - supports-color
@@ -15253,7 +15253,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -15896,7 +15896,7 @@ snapshots:
 
   '@koa/router@15.4.0(koa@3.2.0)':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       koa: 3.2.0
       koa-compose: 4.1.0
@@ -16405,7 +16405,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.4
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       npm: 10.9.8
       npm-package-arg: 11.0.3
       npm-run-path: 5.3.0
@@ -16421,7 +16421,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.4
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-call: 5.3.0
       lodash: 4.18.1
       registry-auth-token: 5.1.1
@@ -16434,7 +16434,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.10.4
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -20952,7 +20952,7 @@ snapshots:
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       token-types: 6.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21259,7 +21259,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0(jiti@2.6.1)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -21271,7 +21271,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0(jiti@2.6.1)
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -21281,7 +21281,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -21290,7 +21290,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -21318,7 +21318,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/typescript-estree': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -21330,7 +21330,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/typescript-estree': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/utils': 8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@6.0.2)
       typescript: 6.0.2
@@ -21347,7 +21347,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.0(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.0
       '@typescript-eslint/visitor-keys': 8.58.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
@@ -21362,7 +21362,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@6.0.2)
       '@typescript-eslint/types': 8.58.1
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.16
@@ -21863,7 +21863,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -22155,7 +22155,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -23069,7 +23069,7 @@ snapshots:
 
   esbuild-register@3.6.0(esbuild@0.25.12):
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
@@ -23261,7 +23261,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0(jiti@2.6.1)
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
@@ -23276,7 +23276,7 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 10.2.0(jiti@2.6.1)
       get-tsconfig: 4.13.7
       is-bun-module: 2.0.0
@@ -23383,7 +23383,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.50.2
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint: 10.2.0(jiti@2.6.1)
       espree: 10.4.0
@@ -23595,7 +23595,7 @@ snapshots:
       '@types/estree': 1.0.8
       ajv: 6.14.0
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -23702,7 +23702,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -23875,7 +23875,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -24027,7 +24027,7 @@ snapshots:
   gel@2.2.0:
     dependencies:
       '@petamoriken/float16': 3.9.3
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       env-paths: 3.0.0
       semver: 7.7.4
       shell-quote: 1.8.3
@@ -24457,7 +24457,7 @@ snapshots:
   http-call@5.3.0:
     dependencies:
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       is-retry-allowed: 1.2.0
       is-stream: 2.0.1
       parse-json: 4.0.0
@@ -24491,14 +24491,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -24907,7 +24907,7 @@ snapshots:
 
   json-schema-resolver@3.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       fast-uri: 3.1.0
       rfdc: 1.4.1
     transitivePeerDependencies:
@@ -25663,7 +25663,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -25756,7 +25756,7 @@ snapshots:
   mqtt-packet@6.10.0:
     dependencies:
       bl: 4.1.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       process-nextick-args: 2.0.1
     transitivePeerDependencies:
       - supports-color
@@ -25765,7 +25765,7 @@ snapshots:
     dependencies:
       commist: 1.1.0
       concat-stream: 2.0.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       duplexify: 4.1.3
       help-me: 3.0.0
       inherits: 2.0.4
@@ -25985,7 +25985,7 @@ snapshots:
 
   number-allocator@1.0.14:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       js-sdsl: 4.3.0
     transitivePeerDependencies:
       - supports-color
@@ -26064,7 +26064,7 @@ snapshots:
       ansis: 3.17.0
       async-retry: 1.3.3
       change-case: 4.1.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       ejs: 3.1.10
       find-yarn-workspace-root: 2.0.0
       fs-extra: 8.1.0
@@ -26087,7 +26087,7 @@ snapshots:
     dependencies:
       '@koa/cors': 5.0.0
       '@koa/router': 15.4.0(koa@3.2.0)
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       eta: 4.5.1
       jose: 6.2.2
       jsesc: 3.1.0
@@ -27177,7 +27177,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -27284,7 +27284,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -27370,7 +27370,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -28068,7 +28068,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -28413,7 +28413,7 @@ snapshots:
       '@volar/typescript': 2.4.28
       '@vue/language-core': 2.2.0(typescript@6.0.2)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21


### PR DESCRIPTION
## SonarCloud Security Hotspot & Reliability Fixes

Addresses security hotspots and reliability issues flagged by SonarCloud.

### 🔒 Security Hotspot Fixes (Docker)
- **idem-idp**: Run container as non-root user `idem`, restrict file permissions (`--chmod=555`)
- **conductor**: Restrict COPY file permissions (`--chmod=555`)
- **devcontainer**: Switch default user from root to `vscode`

### 🔧 Reliability Fixes

**Unsafe sorting (S2871)** — 3 files:
- `commitlint.config.ts`: locale-aware `.sort()` with `localeCompare`
- `scripts/changeset-suggest.ts`: same
- `libs/notitia-templates`: same

**Unsafe type intersection (S4335)** — 1 file:
- `apps/historia/RenderBlocks.tsx`: Replace `any & {...}` with `Record<string, unknown> & {...}`

**Identical sub-expressions (S1764)** — 1 file:
- `apps/historia/Link/index.tsx`: Remove redundant `{label && label}` → `{label}`

**Shadowing built-in names (S2137)** — 5 changes:
- `Form/Error` export → `FieldError` (+ 7 importing files)
- `Form/Number` export → `NumberField` (+ 1 importing file)
- `ratio-ui Error` compound component → `ErrorBlock` (+ 13 importing files across ratio-ui, web, historia)
- `Badge.stories.tsx` Error story → `ErrorStatus`

**CSS issues (S4656, S4649)** — 1 file:
- `libs/scribo/MarkdownEditor.css`: Remove duplicate `display` properties, add generic `cursive` font fallback

### 📦 Other
- Updated `pnpm-lock.yaml` for `fides-auth-next` dependency changes
- Added changeset for affected packages