### PR TITLE
fix(web): correct public directory path in Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -98,7 +98,7 @@ ENV HOSTNAME="0.0.0.0"
 RUN addgroup --system --gid 1001 nodejs \
   && adduser --system --uid 1001 --gid 1001 nextjs
 
-COPY --from=builder --chown=nextjs:nodejs --chmod=755 /app/apps/web/public ./public
+COPY --from=builder --chown=nextjs:nodejs --chmod=755 /app/apps/web/public ./apps/web/public
 COPY --from=builder --chown=nextjs:nodejs --chmod=755 /app/apps/web/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs --chmod=755 /app/apps/web/.next/static ./apps/web/.next/static
 


### PR DESCRIPTION
Fixes the runtime container layout for the Next.js standalone build by copying the public directory into the path expected by apps/web/server.js (produced under .next/standalone in this monorepo structure).