### PR TITLE
ci: dispatch npm publish workflows on release

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -61,7 +61,7 @@ jobs:
               || echo "Failed to create release for ${TAG}"
           done
 
-      - name: Trigger Docker retag for released packages
+      - name: Trigger downstream workflows for released packages
         if: steps.changesets.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -79,6 +79,33 @@ jobs:
               @eventuras/web)
                 echo "Triggering Docker retag for Web: ${TAG}"
                 gh workflow run web-docker.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/fides-auth)
+                echo "Triggering npm publish for fides-auth: ${TAG}"
+                gh workflow run fides-auth-publish.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/fides-auth-next)
+                echo "Triggering npm publish for fides-auth-next: ${TAG}"
+                gh workflow run fides-auth-next-publish.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/logger)
+                echo "Triggering npm publish for logger: ${TAG}"
+                gh workflow run logger-publish.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/datatable)
+                echo "Triggering npm publish for datatable: ${TAG}"
+                gh workflow run datatable-publish.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/scribo)
+                echo "Triggering npm publish for scribo: ${TAG}"
+                gh workflow run scribo-publish.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/ratio-ui)
+                echo "Triggering npm publish for ratio-ui: ${TAG}"
+                gh workflow run ratio-release.yml -f "tag=${TAG}"
+                ;;
+              *)
+                echo "No downstream workflow configured for package ${NAME} with tag ${TAG}"
                 ;;
             esac
           done


### PR DESCRIPTION
## Summary
- Tags pushed by the default `GITHUB_TOKEN` don't fire `on: push: tags` workflows, so `fides-auth-publish.yml`, `fides-auth-next-publish.yml`, `logger-publish.yml`, `datatable-publish.yml`, `scribo-publish.yml` and `ratio-release.yml` have **never run** (`gh run list` shows 0 runs for each).
- Extend the existing `gh workflow run` dispatch in `_release.yml` — already used for Docker retag — to also dispatch each package's publish workflow with the new tag.
- The publish workflows keep their `on: push: tags` trigger intact as a manual/fallback path.

## Test plan
- [ ] Next `workflow_dispatch` of `_release.yml` that tags a library package should trigger the corresponding publish workflow
- [ ] Verify new npm versions appear on the registry after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)