### PR TITLE
ci: use pnpm publish to rewrite workspace protocol in published packages

### DIFF
--- a/.github/workflows/datatable-publish.yml
+++ b/.github/workflows/datatable-publish.yml
@@ -48,6 +48,4 @@ jobs:
         run: pnpm --filter @eventuras/datatable build
 
       - name: Publish to npm
-        run: |
-          cd libs/datatable
-          npm publish --access public --provenance
+        run: pnpm --filter @eventuras/datatable publish --access public --provenance --no-git-checks

--- a/.github/workflows/fides-auth-next-publish.yml
+++ b/.github/workflows/fides-auth-next-publish.yml
@@ -48,6 +48,4 @@ jobs:
         run: pnpm --filter @eventuras/fides-auth-next build
 
       - name: Publish to npm
-        run: |
-          cd libs/fides-auth-next
-          npm publish --access public --provenance
+        run: pnpm --filter @eventuras/fides-auth-next publish --access public --provenance --no-git-checks

--- a/.github/workflows/fides-auth-publish.yml
+++ b/.github/workflows/fides-auth-publish.yml
@@ -48,6 +48,4 @@ jobs:
         run: pnpm --filter @eventuras/fides-auth build
 
       - name: Publish to npm
-        run: |
-          cd libs/fides-auth
-          npm publish --access public --provenance
+        run: pnpm --filter @eventuras/fides-auth publish --access public --provenance --no-git-checks

--- a/.github/workflows/logger-publish.yml
+++ b/.github/workflows/logger-publish.yml
@@ -48,6 +48,4 @@ jobs:
         run: pnpm --filter @eventuras/logger build
 
       - name: Publish to npm
-        run: |
-          cd libs/logger
-          npm publish --access public --provenance
+        run: pnpm --filter @eventuras/logger publish --access public --provenance --no-git-checks

--- a/.github/workflows/ratio-release.yml
+++ b/.github/workflows/ratio-release.yml
@@ -48,6 +48,4 @@ jobs:
         run: pnpm --filter @eventuras/ratio-ui build
 
       - name: Publish to npm
-        run: |
-          cd libs/ratio-ui
-          npm publish --access public --provenance
+        run: pnpm --filter @eventuras/ratio-ui publish --access public --provenance --no-git-checks

--- a/.github/workflows/scribo-publish.yml
+++ b/.github/workflows/scribo-publish.yml
@@ -48,6 +48,4 @@ jobs:
         run: pnpm --filter @eventuras/scribo build
 
       - name: Publish to npm
-        run: |
-          cd libs/scribo
-          npm publish --access public --provenance
+        run: pnpm --filter @eventuras/scribo publish --access public --provenance --no-git-checks


### PR DESCRIPTION
## Summary

- Replaces `npm publish` with `pnpm --filter <pkg> publish` in all six package publish workflows (`ratio-release`, `logger-publish`, `datatable-publish`, `scribo-publish`, `fides-auth-publish`, `fides-auth-next-publish`).
- `npm publish` leaves `workspace:*` literal in the published manifest. `pnpm publish` rewrites it to the resolved version.

## Why

`@eventuras/ratio-ui@1.0.0` on npm currently ships with `"@eventuras/logger": "workspace:*"` in `dependencies`, which makes the package uninstallable for any consumer outside this repo. Same risk applies to `@eventuras/datatable` (depends on `ratio-ui`) and `@eventuras/fides-auth-next` (depends on `fides-auth` and `logger`).

## Follow-up (not in this PR)

- Release `@eventuras/ratio-ui@1.0.3` once merged so a fixed version exists on npm.
- Consider `npm deprecate @eventuras/ratio-ui@1.0.0` with a pointer to the fixed version.

## Test plan

- [ ] Tag `@eventuras/ratio-ui@1.0.3` after merge and confirm the published manifest has a resolved version (e.g. `^0.7.0`) instead of `workspace:*`.
- [ ] `npm view @eventuras/ratio-ui@1.0.3 dependencies` shows no `workspace:` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)