### PR TITLE
fix: include all apps/* in root workspaces field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,16 +4,11 @@
   "private": true,
   "license": "GPL-2.0+",
   "workspaces": [
-    "apps/api",
-    "apps/dev-docs",
-    "apps/historia",
-    "apps/idem-idp",
-    "apps/web",
-    "tests/e2e",
-    "apps/convertoapi",
+    "apps/*",
     "docs",
     "libs/**",
-    "lab/**"
+    "lab/**",
+    "tests/e2e"
   ],
   "scripts": {
     "build": "turbo run build --concurrency 30",


### PR DESCRIPTION
## Summary

The yarn-style `workspaces` array in root `package.json` listed only a subset of apps, while `pnpm-workspace.yaml` used `apps/**`. Changesets resolves the workspace via `@manypkg/get-packages`, which prefers the yarn array, so newer apps (`conductor`, `idem-admin`, `oxo-cli`, `nuntius-homey-app`) were invisible to changesets.

That caused the release CI to fail with:

```
🦋  error Found changeset deps-update-2026-04-15 for package @eventuras/conductor which is not in the workspace
```

Switching to `apps/*` makes the yarn array match `pnpm-workspace.yaml`'s intent and auto-includes future apps.

## Test plan

- [x] `pnpm changeset version` runs successfully locally with all relevant apps bumped.
- [ ] Release workflow succeeds on CI after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)