### PR TITLE
fix: add repository metadata to publishable libs for npm provenance

### DIFF
--- a/libs/app-config/package.json
+++ b/libs/app-config/package.json
@@ -8,6 +8,15 @@
     "environment",
     "validation"
   ],
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/app-config#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/app-config"
+  },
   "license": "MIT",
   "type": "module",
   "exports": {

--- a/libs/datatable/package.json
+++ b/libs/datatable/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@eventuras/datatable",
   "version": "0.5.15",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/datatable#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/datatable"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/libs/event-sdk/package.json
+++ b/libs/event-sdk/package.json
@@ -2,6 +2,15 @@
   "name": "@eventuras/event-sdk",
   "version": "3.0.3",
   "description": "Event api sdk",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/event-sdk#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/event-sdk"
+  },
   "license": "GPL-2.0-or-later",
   "author": "Ole Kristian Losvik",
   "type": "module",

--- a/libs/fides-auth-next/package.json
+++ b/libs/fides-auth-next/package.json
@@ -2,6 +2,15 @@
   "name": "@eventuras/fides-auth-next",
   "version": "0.1.7",
   "description": "Next.js bindings for @eventuras/fides-auth",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/fides-auth-next#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/fides-auth-next"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/libs/mailer/package.json
+++ b/libs/mailer/package.json
@@ -2,6 +2,15 @@
   "name": "@eventuras/mailer",
   "version": "0.1.1",
   "description": "Email sending utility for Eventuras applications",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/mailer#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/mailer"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/libs/markdown-plugin-happening/package.json
+++ b/libs/markdown-plugin-happening/package.json
@@ -2,6 +2,15 @@
   "name": "@eventuras/markdown-plugin-happening",
   "version": "4.0.3",
   "description": "Markdown plugins for events and conferences — schedule detection, speaker cards, etc.",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/markdown-plugin-happening#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/markdown-plugin-happening"
+  },
   "license": "MIT",
   "sideEffects": false,
   "type": "module",

--- a/libs/ratio-ui-next/package.json
+++ b/libs/ratio-ui-next/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@eventuras/ratio-ui-next",
   "version": "0.1.16",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/ratio-ui-next#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/ratio-ui-next"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/libs/ratio-ui/package.json
+++ b/libs/ratio-ui/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@eventuras/ratio-ui",
   "version": "1.0.3",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/ratio-ui#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/ratio-ui"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/libs/smartform/package.json
+++ b/libs/smartform/package.json
@@ -1,6 +1,15 @@
 {
   "name": "@eventuras/smartform",
   "version": "0.3.8",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/smartform#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/smartform"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

`npm publish --provenance` verifies that `package.json` `repository.url` matches the repo URL embedded in the Sigstore provenance bundle. Packages without it fail to publish:

\`\`\`
npm error 422 Unprocessable Entity ... "repository.url" is "", expected
to match "https://github.com/losol/eventuras" from provenance
\`\`\`

Adds `homepage`, `bugs`, and `repository` fields to nine non-private libs that were missing them — `app-config`, `datatable`, `event-sdk`, `fides-auth-next`, `mailer`, `markdown-plugin-happening`, `ratio-ui`, `ratio-ui-next`, `smartform` — matching the format used by `logger`, `scribo`, `fides-auth`, `markdown`, and `notitia-templates`.

## Test plan

- [ ] Tag a package (e.g. `@eventuras/ratio-ui@1.0.4`) and confirm the publish workflow succeeds with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)