### PR TITLE
feat: publish @eventuras/eslint-config and @eventuras/typescript-config

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -104,6 +104,14 @@ jobs:
                 echo "Triggering npm publish for ratio-ui: ${TAG}"
                 gh workflow run ratio-release.yml -f "tag=${TAG}"
                 ;;
+              @eventuras/eslint-config)
+                echo "Triggering npm publish for eslint-config: ${TAG}"
+                gh workflow run eslint-config-publish.yml -f "tag=${TAG}"
+                ;;
+              @eventuras/typescript-config)
+                echo "Triggering npm publish for typescript-config: ${TAG}"
+                gh workflow run typescript-config-publish.yml -f "tag=${TAG}"
+                ;;
               *)
                 echo "No downstream workflow configured for package ${NAME} with tag ${TAG}"
                 ;;

--- a/.github/workflows/eslint-config-publish.yml
+++ b/.github/workflows/eslint-config-publish.yml
@@ -1,0 +1,50 @@
+name: ESLint Config Publish
+
+on:
+  push:
+    tags:
+      - '@eventuras/eslint-config@*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., @eventuras/eslint-config@1.0.3)'
+        required: true
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Resolve ref
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ref=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --filter @eventuras/eslint-config... --frozen-lockfile
+
+      - name: Publish to npm
+        run: |
+          cd libs/eslint-config
+          npm publish --access public --provenance

--- a/.github/workflows/typescript-config-publish.yml
+++ b/.github/workflows/typescript-config-publish.yml
@@ -1,0 +1,50 @@
+name: TypeScript Config Publish
+
+on:
+  push:
+    tags:
+      - '@eventuras/typescript-config@*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., @eventuras/typescript-config@1.0.0)'
+        required: true
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Resolve ref
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ref=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --filter @eventuras/typescript-config... --frozen-lockfile
+
+      - name: Publish to npm
+        run: |
+          cd libs/typescript-config
+          npm publish --access public --provenance

--- a/libs/eslint-config/package.json
+++ b/libs/eslint-config/package.json
@@ -1,7 +1,17 @@
 {
   "name": "@eventuras/eslint-config",
   "version": "1.0.3",
-  "private": true,
+  "description": "Shared ESLint configurations for Eventuras projects",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/eslint-config#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/eslint-config"
+  },
+  "license": "MIT",
   "type": "module",
   "exports": {
     "./base": "./base.js",
@@ -9,17 +19,32 @@
     "./react-library": "./react-library.js",
     "./rules": "./rules/index.js"
   },
-  "devDependencies": {
+  "files": [
+    "base.js",
+    "next-js.js",
+    "react-library.js",
+    "rules",
+    "README.md"
+  ],
+  "dependencies": {
     "@eslint/js": "^10.0.1",
     "@next/eslint-plugin-next": "^16.2.3",
-    "eslint": "^10.2.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-only-warn": "^1.2.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-simple-import-sort": "^13.0.0",
     "eslint-plugin-turbo": "^2.9.6",
     "globals": "^17.5.0",
-    "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.2"
+  },
+  "devDependencies": {
+    "eslint": "^10.2.0",
+    "typescript": "^6.0.2"
+  },
+  "peerDependencies": {
+    "eslint": "^10.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/libs/eslint-config/rules/no-direct-event-sdk-import.js
+++ b/libs/eslint-config/rules/no-direct-event-sdk-import.js
@@ -4,8 +4,8 @@
  * Prevents direct imports from '@eventuras/event-sdk' in the apps/web codebase.
  * Requires using wrapper modules that ensure proper client configuration.
  *
- * @see /Users/ole/Kode/eventuras/apps/web/src/lib/eventuras-sdk.ts
- * @see /Users/ole/Kode/eventuras/apps/web/src/lib/eventuras-public-sdk.ts
+ * @see apps/web/src/lib/eventuras-sdk.ts
+ * @see apps/web/src/lib/eventuras-public-sdk.ts
  */
 
 export default {

--- a/libs/typescript-config/README.md
+++ b/libs/typescript-config/README.md
@@ -1,0 +1,30 @@
+# `@eventuras/typescript-config`
+
+Shared TypeScript configurations used across Eventuras projects.
+
+## Presets
+
+| File                  | Use for                                                    |
+| --------------------- | ---------------------------------------------------------- |
+| `base.json`           | Default preset — strict, modern Node/ESM baseline.         |
+| `library.json`        | Libraries that emit declarations and JS.                   |
+| `react-library.json`  | React component libraries (JSX, DOM lib).                  |
+| `nextjs.json`         | Next.js apps.                                              |
+| `node.json`           | Node-only apps and scripts.                                |
+
+## Usage
+
+Install:
+
+```sh
+npm install -D @eventuras/typescript-config
+```
+
+Extend from your `tsconfig.json`:
+
+```json
+{
+  "extends": "@eventuras/typescript-config/base.json",
+  "include": ["src"]
+}
+```

--- a/libs/typescript-config/package.json
+++ b/libs/typescript-config/package.json
@@ -1,8 +1,25 @@
 {
   "name": "@eventuras/typescript-config",
   "version": "1.0.0",
-  "private": true,
+  "description": "Shared TypeScript configurations for Eventuras projects",
+  "homepage": "https://github.com/losol/eventuras/tree/main/libs/typescript-config#readme",
+  "bugs": {
+    "url": "https://github.com/losol/eventuras/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/losol/eventuras.git",
+    "directory": "libs/typescript-config"
+  },
   "license": "MIT",
+  "files": [
+    "base.json",
+    "library.json",
+    "nextjs.json",
+    "node.json",
+    "react-library.json",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -998,16 +998,13 @@ importers:
         version: 6.0.2
 
   libs/eslint-config:
-    devDependencies:
+    dependencies:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.2.0(jiti@2.6.1))
       '@next/eslint-plugin-next':
         specifier: ^16.2.3
         version: 16.2.3
-      eslint:
-        specifier: ^10.2.0
-        version: 10.2.0(jiti@2.6.1)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@10.2.0(jiti@2.6.1))
@@ -1026,12 +1023,16 @@ importers:
       globals:
         specifier: ^17.5.0
         version: 17.5.0
-      typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
       typescript-eslint:
         specifier: ^8.58.2
         version: 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
+    devDependencies:
+      eslint:
+        specifier: ^10.2.0
+        version: 10.2.0(jiti@2.6.1)
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
 
   libs/event-sdk:
     dependencies:
@@ -1090,7 +1091,7 @@ importers:
         version: 3.17.1(react@19.2.5)
       next:
         specifier: ^16.0.0
-        version: 16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(sass@1.77.4)
+        version: 16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -21674,7 +21675,7 @@ snapshots:
       eslint: 10.2.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.2.0(jiti@2.6.1))
@@ -21780,7 +21781,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -21847,7 +21848,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -23317,7 +23318,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -24333,7 +24334,7 @@ snapshots:
       minimist: 1.2.8
       next: 16.2.3(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4)
 
-  next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.5))(react@19.2.5)(sass@1.77.4):
+  next@16.2.1(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sass@1.77.4):
     dependencies:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
@@ -24341,7 +24342,7 @@ snapshots:
       caniuse-lite: 1.0.30001780
       postcss: 8.4.31
       react: 19.2.5
-      react-dom: 19.2.4(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(react@19.2.5)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.1
@@ -25247,11 +25248,6 @@ snapshots:
   react-dom@19.2.4(react@19.2.4):
     dependencies:
       react: 19.2.4
-      scheduler: 0.27.0
-
-  react-dom@19.2.4(react@19.2.5):
-    dependencies:
-      react: 19.2.5
       scheduler: 0.27.0
 
   react-dom@19.2.5(react@19.2.5):


### PR DESCRIPTION
## Summary

Makes the two shared config packages publishable on npm so external repositories (e.g. a standalone Homey app repo) can consume them.

- Removes `"private": true`, adds `repository`/`homepage`/`bugs`/`license` metadata required for provenance.
- Adds explicit `files` lists so npm only includes the config assets.
- Adds `eslint-config-publish.yml` and `typescript-config-publish.yml` following the existing per-package publish workflow pattern.
- Wires both into `_release.yml` so changesets-tagged releases dispatch the right publish workflow.

## Test plan

- [ ] Tag `@eventuras/eslint-config@1.0.3` and `@eventuras/typescript-config@1.0.0`; confirm publish workflows succeed with provenance.
- [ ] Confirm both are installable from npm in a fresh repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)