### PR TITLE
fix(ratio-ui): use border token for Card default variant

### DIFF
--- a/.changeset/card-default-border-token.md
+++ b/.changeset/card-default-border-token.md
@@ -1,0 +1,9 @@
+---
+"@eventuras/ratio-ui": patch
+---
+
+fix(card): use `border-border-1` token for the default variant's border
+so custom `border` and `borderColor` props override cleanly in both
+light and dark mode. The previous hardcoded `border-gray-200/50` +
+`dark:border-gray-700/50` meant dark mode kept the gray color even when
+the consumer supplied a colored border.

--- a/libs/ratio-ui/src/core/Card/Card.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.tsx
@@ -38,7 +38,7 @@ export const Card: React.FC<CardProps> = ({
   const hoverClasses = hoverEffect ? 'hover:bg-card-hover transition-colors duration-200' : '';
 
   const variantStyles = {
-    default: 'bg-card border-2 border-gray-200/50 shadow-xs dark:border-gray-700/50',
+    default: 'bg-card border-2 border-border-1 shadow-xs',
     wide: 'bg-card mx-auto min-h-[33vh]',
     outline: 'border border-border-1 bg-transparent',
     transparent: 'bg-transparent',


### PR DESCRIPTION
## Summary

The `default` variant of `<Card>` hardcoded `border-gray-200/50 dark:border-gray-700/50`. Because `buildBorderClasses` never emits `dark:border-*`, consumer-supplied `border`/`borderColor` props only partially overrode the default — dark mode kept the hardcoded gray even when a colored border was requested.

Switch the default to `border-border-1`, the same token already used by the `outline` variant. The token resolves light/dark values via CSS variables in `theme.css`, so prop-driven classes now override cleanly via `twMerge` in both modes. `border-2` is retained (2px is the design choice).

## Test plan

- [ ] Visual: verify Card stories render with the same default 2px border in light mode.
- [ ] Visual: verify dark mode now shows the token-based border color.
- [ ] Pass `borderColor="primary"` and confirm both light and dark borders pick up the primary color without leaking gray.

🤖 Generated with [Claude Code](https://claude.com/claude-code)