### PR TITLE
refactor(logger): architecture cleanup pass

### DIFF
--- a/.changeset/logger-cleanup.md
+++ b/.changeset/logger-cleanup.md
@@ -1,0 +1,30 @@
+---
+"@eventuras/logger": minor
+---
+
+Logger hygiene pass:
+
+- **BREAKING:** `prettyPrint` options on `PinoTransport` and
+  `LoggerConfig` are removed, and the default transport no longer
+  auto-enables pretty output based on `NODE_ENV`. Importing the main
+  entry no longer pulls `node:stream` into browser/edge bundles. For
+  pretty dev output, call `configureNodeLogger` from
+  `@eventuras/logger/node`:
+
+  ```ts
+  import { configureNodeLogger } from '@eventuras/logger/node';
+  configureNodeLogger({ prettyPrint: process.env.NODE_ENV === 'development' });
+  ```
+
+- `PinoTransport` gains a `destinationStream?: NodeJS.WritableStream`
+  option to replace the removed `prettyPrint` convenience.
+- OpenTelemetry setup now dogfoods `Logger` for its own diagnostics
+  instead of writing `console.log` / `console.warn` directly.
+- OTel peer-dep ranges capped below `1.0.0` to prevent silent breaks
+  when the packages eventually leave pre-1.0.
+- `getPinoInstance()` is now flagged for removal in `1.0`.
+- Default redact behavior is documented: `fast-redact` matches exact
+  field paths, not arbitrary nested occurrences.
+- Internal no-op `rebindStaticMethods` removed.
+- README now calls out `Logger.create()` as the preferred pattern for
+  everything beyond bootstrap logs.

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -66,17 +66,30 @@ import { Logger } from "@eventuras/logger";
 
 Logger.configure({
   level: "debug",
-  prettyPrint: process.env.NODE_ENV === "development",
   redact: ["password", "token", "apiKey", "authorization", "secret"],
   destination: "/var/log/app.log", // Optional file output
+});
+```
+
+### Pretty dev output (Node only)
+
+Pretty-printing depends on `node:stream`, so it lives in the `/node`
+subpath to keep the main entry browser/edge-safe. Call it from your
+server bootstrap:
+
+```typescript
+import { configureNodeLogger } from "@eventuras/logger/node";
+
+configureNodeLogger({
+  level: "debug",
+  prettyPrint: process.env.NODE_ENV === "development",
 });
 ```
 
 ### Environment Variables
 
 ```bash
-LOG_LEVEL=debug       # Set global log level
-NODE_ENV=development  # Enables pretty printing
+LOG_LEVEL=debug       # Set global log level (picked up by the default PinoTransport)
 ```
 
 ## Transports
@@ -242,7 +255,7 @@ process.on("SIGTERM", async () => {
 });
 ```
 
-### Environment Variables
+### OTel Environment Variables
 
 ```bash
 OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://...
@@ -317,11 +330,11 @@ import type {
 
 ## Subpath Exports
 
-| Import path                       | Contents                                                        | Environment |
-| --------------------------------- | --------------------------------------------------------------- | ----------- |
-| `@eventuras/logger`               | Logger, types, PinoTransport, ConsoleTransport, httpLogger      | Universal   |
-| `@eventuras/logger/node`          | `formatLogLine`, `createPrettyStream` (depends on `node:stream`) | Node.js     |
-| `@eventuras/logger/opentelemetry` | `setupOpenTelemetryLogger`, `shutdownOpenTelemetryLogger`        | Node.js     |
+| Import path | Contents | Environment |
+| --- | --- | --- |
+| `@eventuras/logger` | `Logger`, types, `PinoTransport`, `ConsoleTransport`, `redactHeaders` | Universal |
+| `@eventuras/logger/node` | `configureNodeLogger`, `createPrettyStream`, `formatLogLine` | Node.js |
+| `@eventuras/logger/opentelemetry` | `setupOpenTelemetryLogger`, `shutdownOpenTelemetryLogger` | Node.js |
 
 ### Node-only Pretty-print Utilities
 

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -20,7 +20,12 @@ pnpm add @eventuras/logger
 
 ## Quick Start
 
-### Scoped Logger (recommended)
+### Scoped Logger (preferred)
+
+Create a `Logger` instance per module so every log entry carries the
+module's namespace and any persistent context — it's the pattern we
+use everywhere in Eventuras, and it makes filtering by module in Loki
+/ Grafana trivial.
 
 ```typescript
 import { Logger } from "@eventuras/logger";
@@ -35,6 +40,11 @@ logger.error({ error }, "Failed to save event");
 ```
 
 ### Static Methods (one-off logs)
+
+The static methods are fine for bootstrap code that runs before any
+scoped logger exists (server startup, top-level error handlers,
+scripts). For anything inside a module or request path, prefer
+`Logger.create()` so the output stays namespaced.
 
 ```typescript
 import { Logger } from "@eventuras/logger";

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -161,6 +161,33 @@ Default redacted paths: `password`, `token`, `apiKey`, `authorization`, `secret`
 
 Configure additional paths via `Logger.configure({ redact: [...] })`.
 
+### Nested fields
+
+Redaction uses [Pino's `redact` option](https://getpino.io/#/docs/redaction), which is powered by [fast-redact](https://github.com/davidmarkclements/fast-redact). Paths are **exact field paths** — they don't match nested occurrences by default:
+
+```typescript
+// Only redacts top-level `password`
+Logger.configure({ redact: ["password"] });
+
+logger.info({ password: "x" });          // → [REDACTED]
+logger.info({ user: { password: "x" } }); // → NOT redacted
+```
+
+To redact nested fields, spell out the path or use wildcards:
+
+```typescript
+Logger.configure({
+  redact: [
+    "password",
+    "user.password",
+    "request.headers.authorization",
+    "*.token", // any key named `token` one level deep
+  ],
+});
+```
+
+For HTTP headers specifically, prefer [`redactHeaders`](#http-header-redaction) — it normalizes the object and handles `Headers` instances in addition to plain objects.
+
 ## HTTP Header Redaction
 
 Utility for redacting sensitive HTTP headers:

--- a/libs/logger/package.json
+++ b/libs/logger/package.json
@@ -60,9 +60,9 @@
   },
   "peerDependencies": {
     "@opentelemetry/api": "^1.9.0",
-    "@opentelemetry/api-logs": ">=0.200.0",
-    "@opentelemetry/instrumentation-pino": ">=0.50.0",
-    "@opentelemetry/sdk-logs": ">=0.200.0"
+    "@opentelemetry/api-logs": ">=0.200.0 <1.0.0",
+    "@opentelemetry/instrumentation-pino": ">=0.50.0 <1.0.0",
+    "@opentelemetry/sdk-logs": ">=0.200.0 <1.0.0"
   },
   "peerDependenciesMeta": {
     "@opentelemetry/api": {

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -63,7 +63,6 @@ function createDefaultTransport(config: LoggerConfig): LogTransport {
   return new PinoTransport({
     level: config.level ?? (getEnv('LOG_LEVEL') as LogLevel | undefined) ?? 'info',
     redact: config.redact ?? DEFAULT_REDACT,
-    prettyPrint: config.prettyPrint ?? getEnv('NODE_ENV') === 'development',
     destination: config.destination,
   });
 }

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -109,8 +109,6 @@ export class Logger {
   static configure(config: Partial<LoggerConfig>): void {
     Logger.config = { ...Logger.config, ...config };
     Logger.transport = Logger.config.transport ?? createDefaultTransport(Logger.config);
-    // Re-bind static convenience methods to the new transport
-    Logger.rebindStaticMethods();
   }
 
   /**
@@ -245,11 +243,6 @@ export class Logger {
   static fatal(optionsOrMsg: ErrorLoggerOptions | string, ...msg: unknown[]): void {
     const [options, messages] = Logger.normalizeArgs(optionsOrMsg, msg);
     Logger.staticErrorLog('fatal', options, ...messages);
-  }
-
-  private static rebindStaticMethods(): void {
-    // No-op — static methods now delegate through Logger.transport directly
-    // so rebinding is not needed. Kept for API compatibility.
   }
 
   /**

--- a/libs/logger/src/Logger.ts
+++ b/libs/logger/src/Logger.ts
@@ -123,8 +123,9 @@ export class Logger {
   }
 
   /**
-   * @deprecated Use `Logger.getTransport()` instead. If you need the raw
-   * Pino instance, cast the transport: `(Logger.getTransport() as PinoTransport).pino`
+   * @deprecated Since 0.7 — will be removed in 1.0. Use `Logger.getTransport()`
+   * instead. If you need the raw Pino instance, cast the transport:
+   * `(Logger.getTransport() as PinoTransport).pino`.
    */
   static getPinoInstance(): import('pino').Logger {
     if (Logger.transport instanceof PinoTransport) {

--- a/libs/logger/src/index.ts
+++ b/libs/logger/src/index.ts
@@ -11,6 +11,7 @@ export { ConsoleTransport } from './transports/console';
 // HTTP logging utility — header redaction
 export { redactHeaders } from './httpLogger';
 
-// Node-only exports (formatLogLine, createPrettyStream) are available via
-// '@eventuras/logger/node' to avoid pulling node:stream into browser bundles.
+// Node-only exports (configureNodeLogger, formatLogLine, createPrettyStream)
+// are available via '@eventuras/logger/node' to avoid pulling node:stream
+// into browser bundles.
 

--- a/libs/logger/src/node.ts
+++ b/libs/logger/src/node.ts
@@ -6,6 +6,53 @@
  * (`@eventuras/logger`) for the browser-safe API.
  *
  * @example
+ * // Pretty dev output
+ * import { configureNodeLogger } from '@eventuras/logger/node';
+ * configureNodeLogger({ prettyPrint: process.env.NODE_ENV === 'development' });
+ *
+ * @example
+ * // Lower-level: just the pretty helpers
  * import { createPrettyStream, formatLogLine } from '@eventuras/logger/node';
  */
+import { Logger } from './Logger';
+import { PinoTransport, type PinoTransportOptions } from './transports/pino';
+import { createPrettyStream } from './transports/pretty';
+import type { LoggerConfig } from './types';
+
 export { formatLogLine, createPrettyStream } from './transports/pretty';
+
+/** Options for `configureNodeLogger`. */
+export type NodeLoggerOptions = Omit<LoggerConfig, 'transport'> & {
+  /** Enable human-readable, ANSI-colored output. Off by default. */
+  prettyPrint?: boolean;
+  /** Raw PinoTransport options for advanced tuning. */
+  pinoOptions?: PinoTransportOptions['pinoOptions'];
+};
+
+/**
+ * Configure the global Logger with a Node-side PinoTransport, optionally
+ * wired to a pretty-print stream for development. Keeps the browser/edge
+ * main entry free of `node:stream` imports — call this from a Node-only
+ * bootstrap (e.g. `instrumentation.ts`, `server.ts`).
+ *
+ * @example
+ * // In your server entry point
+ * import { configureNodeLogger } from '@eventuras/logger/node';
+ * configureNodeLogger({
+ *   level: 'debug',
+ *   prettyPrint: process.env.NODE_ENV === 'development',
+ * });
+ */
+export function configureNodeLogger(options: NodeLoggerOptions = {}): void {
+  const { prettyPrint, pinoOptions, ...rest } = options;
+  Logger.configure({
+    ...rest,
+    transport: new PinoTransport({
+      level: rest.level,
+      redact: rest.redact,
+      destination: rest.destination,
+      destinationStream: prettyPrint ? createPrettyStream() : undefined,
+      pinoOptions,
+    }),
+  });
+}

--- a/libs/logger/src/opentelemetry.ts
+++ b/libs/logger/src/opentelemetry.ts
@@ -31,6 +31,8 @@
  * logger.error({ error: err }, 'Something failed'); // Sent to OpenTelemetry backend
  */
 
+import { Logger } from './Logger';
+
 /**
  * Minimal interface for an OpenTelemetry LogRecordProcessor.
  * Compatible with `@opentelemetry/sdk-logs` `LogRecordProcessor`.
@@ -153,7 +155,7 @@ export async function setupOpenTelemetryLogger(
 ): Promise<void> {
   // Check if we're running in a browser environment
   if (typeof window !== 'undefined') {
-    console.warn('[logger] OpenTelemetry integration is server-side only - skipping in browser');
+    Logger.warn({ namespace: 'logger:otel' }, 'OpenTelemetry integration is server-side only, skipping');
     return;
   }
 
@@ -165,7 +167,7 @@ export async function setupOpenTelemetryLogger(
   } = options;
 
   if (!enabled) {
-    console.log('[logger] OpenTelemetry integration disabled');
+    Logger.debug({ namespace: 'logger:otel' }, 'OpenTelemetry integration disabled');
     return;
   }
 
@@ -173,8 +175,10 @@ export async function setupOpenTelemetryLogger(
   const otel = await loadOpenTelemetry();
 
   if (!otel) {
-    console.warn('[logger] OpenTelemetry packages not available - integration disabled');
-    console.warn('[logger] Install @opentelemetry/* packages to enable OpenTelemetry integration');
+    Logger.warn(
+      { namespace: 'logger:otel' },
+      'OpenTelemetry packages not available — integration disabled. Install @opentelemetry/api, @opentelemetry/api-logs, @opentelemetry/instrumentation-pino, and @opentelemetry/sdk-logs to enable.',
+    );
     return;
   }
 
@@ -209,10 +213,10 @@ export async function setupOpenTelemetryLogger(
 
   pinoInstrumentation.enable();
 
-  console.log('[logger] OpenTelemetry integration enabled');
-  if (logRecordProcessor) {
-    console.log('[logger] Log record processor registered');
-  }
+  Logger.info(
+    { namespace: 'logger:otel', context: { hasProcessor: Boolean(logRecordProcessor) } },
+    'OpenTelemetry integration enabled',
+  );
 }
 
 /**
@@ -241,7 +245,7 @@ export async function shutdownOpenTelemetryLogger(): Promise<void> {
     loggerProvider = null;
   }
 
-  console.log('[logger] OpenTelemetry integration shut down');
+  Logger.info({ namespace: 'logger:otel' }, 'OpenTelemetry integration shut down');
 }
 
 /**

--- a/libs/logger/src/transports/pino.ts
+++ b/libs/logger/src/transports/pino.ts
@@ -3,10 +3,13 @@
  *
  * Wraps a Pino logger instance to satisfy the `LogTransport` interface,
  * keeping Pino as an implementation detail that consumers never interact with directly.
+ *
+ * For pretty-printed dev output, see `configureNodeLogger` in
+ * `@eventuras/logger/node` — this module intentionally stays free of
+ * `node:stream` imports so the main entry stays browser/edge-safe.
  */
 import pino, { type Logger as PinoLogger, type LoggerOptions as PinoLoggerOptions } from 'pino';
 import type { LogLevel, LogTransport } from '../types';
-import { createPrettyStream } from './pretty';
 
 /** Options for creating a PinoTransport. */
 export type PinoTransportOptions = {
@@ -14,10 +17,13 @@ export type PinoTransportOptions = {
   level?: LogLevel;
   /** Field paths to redact from output. */
   redact?: string[];
-  /** Enable pretty-printed, human-readable output. */
-  prettyPrint?: boolean;
   /** File path destination (omit for stdout). */
   destination?: string;
+  /**
+   * Writable stream destination (e.g. a pretty-print stream from
+   * `@eventuras/logger/node`). Takes precedence over `destination`.
+   */
+  destinationStream?: NodeJS.WritableStream;
   /** Raw Pino options for advanced tuning (merged after built-in defaults). */
   pinoOptions?: PinoLoggerOptions;
 };
@@ -41,8 +47,8 @@ export class PinoTransport implements LogTransport {
       ...options.pinoOptions,
     };
 
-    if (options.prettyPrint) {
-      this.pino = pino(pinoOpts, createPrettyStream());
+    if (options.destinationStream) {
+      this.pino = pino(pinoOpts, options.destinationStream);
     } else if (options.destination) {
       this.pino = pino(pinoOpts, pino.destination(options.destination));
     } else {

--- a/libs/logger/src/types.ts
+++ b/libs/logger/src/types.ts
@@ -60,10 +60,12 @@ export type LoggerConfig = {
   level?: LogLevel;
   /** Field paths to redact from log output (e.g., ['password', 'token']). */
   redact?: string[];
-  /** Enable pretty-printed output (auto-enabled in development). */
-  prettyPrint?: boolean;
   /** Optional file path for log output (Pino only). */
   destination?: string;
-  /** Custom transport implementation. Defaults to PinoTransport. */
+  /**
+   * Custom transport implementation. Defaults to PinoTransport with JSON
+   * output. For pretty-printed dev output, use `configureNodeLogger`
+   * from `@eventuras/logger/node`.
+   */
   transport?: LogTransport;
 };


### PR DESCRIPTION
## Summary

Seven independent fixes to `@eventuras/logger` based on the review of its architecture and package choices. Each is a separate commit — review commit-by-commit for the easiest read.

1. **Drop no-op `rebindStaticMethods`.** The method only held a stale comment.
2. **Cap OTel peer ranges below `1.0.0`.** The pre-1.0 OTel packages ship breaking changes between minors; open-ended `>=0.200.0` would silently install a future breaking 0.500.
3. **Schedule `getPinoInstance()` removal in 1.0.** Explicit deadline in the JSDoc.
4. **Dogfood `Logger` for OTel setup diagnostics.** Replaces `console.log` / `console.warn` calls in `setupOpenTelemetryLogger` with namespaced `Logger` calls.
5. **Document redact semantics.** `fast-redact` matches exact paths, not arbitrary nested occurrences — consumers expecting `{user.password}` to be redacted by a top-level `password` entry were silently wrong.
6. **Move pretty-stream wiring off the main entry. (BREAKING)** `PinoTransport` no longer imports `./pretty`, so the main entry is free of `node:stream`. Pretty dev output moves to a new `configureNodeLogger` export in `@eventuras/logger/node`.
7. **README nudge toward `Logger.create()`** for everything beyond bootstrap logs, so Loki/Grafana filtering stays useful.

## Breaking change

`prettyPrint` options on `PinoTransport` and `LoggerConfig` are removed, and the default transport no longer auto-enables pretty output from `NODE_ENV`. Migration:

```ts
// Before
Logger.configure({ prettyPrint: process.env.NODE_ENV === 'development' });

// After
import { configureNodeLogger } from '@eventuras/logger/node';
configureNodeLogger({ prettyPrint: process.env.NODE_ENV === 'development' });
```

No consumers inside the monorepo used `prettyPrint` directly — the auto-enable from `NODE_ENV` was the only caller. `historia`'s `setupOpenTelemetryLogger` call is unchanged.

## Test plan

- [x] `pnpm --filter @eventuras/logger test` — 63 tests pass.
- [x] `pnpm --filter @eventuras/logger build` — `dist/node.js` is the only bundle that references `node:stream`.
- [ ] Verify historia server logs still pretty-print in dev after adopting `configureNodeLogger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)