### PR TITLE
refactor(fides-auth): default ConsoleLogger emits structured JSON

### DIFF
--- a/.changeset/fides-auth-default-jsonl-logger.md
+++ b/.changeset/fides-auth-default-jsonl-logger.md
@@ -1,0 +1,21 @@
+---
+"@eventuras/fides-auth": minor
+---
+
+The default `ConsoleLogger` now emits newline-delimited JSON instead of
+bracket-prefixed text. Output stays interoperable with Loki / Grafana /
+Datadog out of the box even when the consuming app hasn't called
+`configureLogger()` to wire in `@eventuras/logger` or pino.
+
+Each entry includes `level`, ISO `time`, `namespace`, persistent context
+fields, optional `msg`, and the data object (with `Error` instances
+serialized to `{ name, message, stack }`):
+
+```json
+{"level":"info","time":"2026-04-15T19:40:57.300Z","namespace":"fides-auth:oauth","msg":"PKCE parameters generated"}
+```
+
+Apps that still want pretty bracketed output during development should
+plug in their own logger via `configureLogger()` — e.g. wire in
+`@eventuras/logger` and let `configureNodeLogger` from
+`@eventuras/logger/node` handle dev pretty-print.

--- a/libs/fides-auth/README.md
+++ b/libs/fides-auth/README.md
@@ -231,15 +231,22 @@ import {
 
 ### Pluggable Logging (`/logger`)
 
-The library uses console logging by default. Plug in your preferred logger at startup:
+The library writes newline-delimited JSON to `console.<level>` by default — interoperable with Loki, Grafana, Datadog, and other log shippers without any setup. Plug in a richer logger at startup if you want OpenTelemetry, redaction, or shared formatting with the rest of your app:
 
 ```typescript
 import { configureLogger } from "@eventuras/fides-auth/logger";
 
-// Example: plug in pino
+// Example: plug in @eventuras/logger
+import { Logger } from "@eventuras/logger";
+configureLogger({
+  create(options) {
+    return Logger.create(options);
+  },
+});
+
+// Or plug in pino directly
 import pino from "pino";
 const pinoInstance = pino();
-
 configureLogger({
   create({ namespace, context }) {
     return pinoInstance.child({ namespace, ...context });
@@ -248,6 +255,12 @@ configureLogger({
 ```
 
 Any object implementing `{ debug, info, warn, error }` works — pino, winston, bunyan, or your own.
+
+The default JSONL output looks like:
+
+```json
+{"level":"info","time":"2026-04-15T19:40:57.300Z","namespace":"fides-auth:oauth","msg":"PKCE parameters generated"}
+```
 
 ### Vipps Login Provider (`/providers/vipps`)
 

--- a/libs/fides-auth/src/logger.test.ts
+++ b/libs/fides-auth/src/logger.test.ts
@@ -91,6 +91,56 @@ describe('default console logger (structured JSON)', () => {
     spy.mockRestore();
   });
 
+  it('protects reserved keys (level, time, namespace) from caller overrides', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => { });
+    const logger = createLogger({
+      namespace: 'auth',
+      context: { time: 'context-clobber-attempt', user: 'alice' },
+    });
+
+    logger.info(
+      { level: 'fatal', namespace: 'fake', requestId: 'r1' },
+      'still original',
+    );
+
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry.level).toBe('info');
+    expect(entry.namespace).toBe('auth');
+    expect(typeof entry.time).toBe('string');
+    expect(entry.time).not.toBe('context-clobber-attempt');
+    // Caller fields that don't collide are preserved.
+    expect(entry.user).toBe('alice');
+    expect(entry.requestId).toBe('r1');
+    expect(entry.msg).toBe('still original');
+    spy.mockRestore();
+  });
+
+  it('skips empty calls without emitting a log line', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => { });
+    const logger = createLogger({ namespace: 'auth' });
+
+    logger.info();
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('survives circular and BigInt values without throwing', () => {
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => { });
+    const logger = createLogger({ namespace: 'auth' });
+
+    const circular: Record<string, unknown> = { name: 'self' };
+    circular.self = circular;
+
+    expect(() => logger.info({ circular, count: 9007199254740993n }, 'edge cases')).not.toThrow();
+
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry.msg).toBe('edge cases');
+    expect(entry.circular).toMatchObject({ name: 'self', self: '[Circular]' });
+    expect(entry.count).toBe('9007199254740993');
+    spy.mockRestore();
+  });
+
   it('each log level delegates to the matching console method', () => {
     const spyDebug = vi.spyOn(console, 'debug').mockImplementation(() => { });
     const spyInfo = vi.spyOn(console, 'info').mockImplementation(() => { });

--- a/libs/fides-auth/src/logger.test.ts
+++ b/libs/fides-auth/src/logger.test.ts
@@ -17,7 +17,7 @@ import {
 // Default console logger
 // ────────────────────────────────────────────
 
-describe('default console logger', () => {
+describe('default console logger (structured JSON)', () => {
   it('creates a logger without any configuration', () => {
     const logger = createLogger({ namespace: 'test' });
     expect(logger).toBeDefined();
@@ -27,27 +27,40 @@ describe('default console logger', () => {
     expect(typeof logger.error).toBe('function');
   });
 
-  it('logs a string message to console.info', () => {
+  it('logs a string message as a JSON line to console.info', () => {
     const spy = vi.spyOn(console, 'info').mockImplementation(() => { });
     const logger = createLogger({ namespace: 'my-app' });
 
     logger.info('hello world');
 
-    expect(spy).toHaveBeenCalledWith('[my-app]', 'hello world');
+    expect(spy).toHaveBeenCalledOnce();
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry).toMatchObject({
+      level: 'info',
+      namespace: 'my-app',
+      msg: 'hello world',
+    });
+    expect(typeof entry.time).toBe('string');
     spy.mockRestore();
   });
 
-  it('logs a context object + message to console.warn', () => {
+  it('merges context object with the message in a single JSON entry', () => {
     const spy = vi.spyOn(console, 'warn').mockImplementation(() => { });
     const logger = createLogger({ namespace: 'auth' });
 
     logger.warn({ userId: 42 }, 'Rate limited');
 
-    expect(spy).toHaveBeenCalledWith('[auth]', 'Rate limited', { userId: 42 });
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry).toMatchObject({
+      level: 'warn',
+      namespace: 'auth',
+      msg: 'Rate limited',
+      userId: 42,
+    });
     spy.mockRestore();
   });
 
-  it('includes persistent context in the prefix', () => {
+  it('includes persistent context fields in every entry', () => {
     const spy = vi.spyOn(console, 'debug').mockImplementation(() => { });
     const logger = createLogger({
       namespace: 'auth:session',
@@ -56,14 +69,29 @@ describe('default console logger', () => {
 
     logger.debug('checking session');
 
-    expect(spy).toHaveBeenCalledWith(
-      '[auth:session] {"module":"validator"}',
-      'checking session',
-    );
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry).toMatchObject({
+      level: 'debug',
+      namespace: 'auth:session',
+      module: 'validator',
+      msg: 'checking session',
+    });
     spy.mockRestore();
   });
 
-  it('each log level delegates to the correct console method', () => {
+  it('serializes Error instances on the error field', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => { });
+    const logger = createLogger({ namespace: 'auth' });
+
+    logger.error({ error: new Error('boom') }, 'request failed');
+
+    const entry = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(entry.error).toMatchObject({ name: 'Error', message: 'boom' });
+    expect(typeof entry.error.stack).toBe('string');
+    spy.mockRestore();
+  });
+
+  it('each log level delegates to the matching console method', () => {
     const spyDebug = vi.spyOn(console, 'debug').mockImplementation(() => { });
     const spyInfo = vi.spyOn(console, 'info').mockImplementation(() => { });
     const spyWarn = vi.spyOn(console, 'warn').mockImplementation(() => { });
@@ -246,23 +274,29 @@ describe('lazy proxy — configureLogger after createLogger', () => {
 });
 
 /**
- * Helper: replicate the default ConsoleLogger to reset configureLogger
- * in afterEach. This avoids importing the private ConsoleLogger class.
+ * Helper: replicate the default JSONL ConsoleLogger so the suites that
+ * `configureLogger()` mid-test can reset back to the default behavior in
+ * afterEach without importing the private ConsoleLogger class.
  */
 function createDefaultConsoleLogger(
   namespace: string,
   context?: Record<string, unknown>,
 ): FidesLogger {
-  const contextStr = context && Object.keys(context).length > 0
-    ? ` ${JSON.stringify(context)}`
-    : '';
-  const prefix = `[${namespace}]${contextStr}`;
-
   const log = (method: 'debug' | 'info' | 'warn' | 'error') =>
     (data?: Record<string, unknown> | string, msg?: string) => {
-      if (typeof data === 'string') console[method](prefix, data);
-      else if (msg) console[method](prefix, msg, data);
-      else if (data) console[method](prefix, data);
+      const entry: Record<string, unknown> = {
+        level: method,
+        time: new Date().toISOString(),
+        namespace,
+        ...context,
+      };
+      if (typeof data === 'string') {
+        entry.msg = data;
+      } else {
+        if (msg !== undefined) entry.msg = msg;
+        if (data) Object.assign(entry, data);
+      }
+      console[method](JSON.stringify(entry));
     };
 
   return {

--- a/libs/fides-auth/src/logger.ts
+++ b/libs/fides-auth/src/logger.ts
@@ -89,15 +89,28 @@ function serializeError(value: unknown): unknown {
   return value;
 }
 
+/** Field names the logger reserves so callers can't accidentally clobber them. */
+const RESERVED_KEYS = new Set(['level', 'time', 'namespace']);
+
 function safeStringify(record: Record<string, unknown>): string {
+  const seen = new WeakSet<object>();
   try {
-    return JSON.stringify(record, (_key, value) =>
-      value instanceof Error ? serializeError(value) : value,
-    );
+    return JSON.stringify(record, (_key, value) => {
+      if (value instanceof Error) return serializeError(value);
+      if (typeof value === 'bigint') return value.toString();
+      if (typeof value === 'object' && value !== null) {
+        if (seen.has(value)) return '[Circular]';
+        seen.add(value);
+      }
+      return value;
+    });
   } catch {
-    // Circular or otherwise non-serializable — fall back to a marker entry.
+    // Last-resort fallback: drop the original record entirely so a single
+    // non-serializable payload can't take down the caller's request path.
     return JSON.stringify({
-      ...record,
+      level: record.level,
+      time: record.time,
+      namespace: record.namespace,
       msg: typeof record.msg === 'string' ? record.msg : '[unserializable log entry]',
       _serializeError: true,
     });
@@ -116,18 +129,34 @@ class ConsoleLogger implements FidesLogger {
     data?: Record<string, unknown> | string,
     msg?: string,
   ): void {
+    // Skip noisy empty entries — match the pre-JSON ConsoleLogger, which
+    // dropped calls with no data and no message.
+    if (data === undefined && msg === undefined) return;
+
+    // Reserved keys are set first so they appear at the front of the JSON
+    // output. User-supplied fields are filtered against RESERVED_KEYS so
+    // they can't clobber level/time/namespace.
     const entry: Record<string, unknown> = {
       level,
       time: new Date().toISOString(),
       namespace: this.namespace,
-      ...this.context,
     };
+
+    if (this.context) {
+      for (const [key, value] of Object.entries(this.context)) {
+        if (!RESERVED_KEYS.has(key)) entry[key] = value;
+      }
+    }
 
     if (typeof data === 'string') {
       entry.msg = data;
     } else {
       if (msg !== undefined) entry.msg = msg;
-      if (data) Object.assign(entry, data);
+      if (data) {
+        for (const [key, value] of Object.entries(data)) {
+          if (!RESERVED_KEYS.has(key)) entry[key] = value;
+        }
+      }
     }
 
     if (entry.error !== undefined) {

--- a/libs/fides-auth/src/logger.ts
+++ b/libs/fides-auth/src/logger.ts
@@ -1,14 +1,17 @@
 /**
  * Pluggable logger for fides-auth.
  *
- * By default, uses a console-based logger. Users can provide their own
- * implementation (pino, winston, etc.) via `configureLogger()`.
+ * The default writes newline-delimited JSON to `console.<level>` so output
+ * is interoperable with Loki / Grafana / Datadog out of the box, even when
+ * the consumer hasn't wired in a structured logger. Users can plug their
+ * own backend (pino, winston, @eventuras/logger, ...) via `configureLogger()`.
  *
  * @example
- * // Use default console logger (no setup needed)
+ * // Use default JSONL console logger (no setup needed)
  * import { createLogger } from '@eventuras/fides-auth/logger';
  * const logger = createLogger({ namespace: 'my-app:auth' });
  * logger.info('Authentication successful');
+ * // → {"level":"info","time":"…","namespace":"my-app:auth","msg":"Authentication successful"}
  *
  * @example
  * // Plug in pino
@@ -62,57 +65,92 @@ export interface FidesLoggerFactory {
 }
 
 /**
- * Console-based logger implementation.
- * Used as the default when no custom logger factory is configured.
+ * Console-based logger implementation that emits newline-delimited JSON.
+ *
+ * Used as the default when no custom logger factory is configured. JSONL
+ * keeps fides-auth's output interoperable with log shippers (Loki, Grafana,
+ * Datadog, etc.) even when the consuming app hasn't wired in a structured
+ * logger via `configureLogger()`. Each entry preserves the original
+ * `console.<level>` call so browser devtools and CI log filters still work.
+ *
+ * Output shape (example):
+ *
+ *   {"level":"info","time":"2026-04-15T19:40:57.300Z","namespace":"fides-auth:oauth","msg":"PKCE parameters generated","codeChallenge":"…"}
+ *
+ * Errors in the `data` field are serialized to `{ name, message, stack }`
+ * so they survive `JSON.stringify`.
  */
-class ConsoleLogger implements FidesLogger {
-  private readonly prefix: string;
+type ConsoleMethod = 'debug' | 'info' | 'warn' | 'error';
 
-  constructor(namespace: string, context?: Record<string, unknown>) {
-    const contextStr = context && Object.keys(context).length > 0
-      ? ` ${JSON.stringify(context)}`
-      : '';
-    this.prefix = `[${namespace}]${contextStr}`;
+function serializeError(value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  return value;
+}
+
+function safeStringify(record: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(record, (_key, value) =>
+      value instanceof Error ? serializeError(value) : value,
+    );
+  } catch {
+    // Circular or otherwise non-serializable — fall back to a marker entry.
+    return JSON.stringify({
+      ...record,
+      msg: typeof record.msg === 'string' ? record.msg : '[unserializable log entry]',
+      _serializeError: true,
+    });
+  }
+}
+
+class ConsoleLogger implements FidesLogger {
+  constructor(
+    private readonly namespace: string,
+    private readonly context?: Record<string, unknown>,
+  ) { }
+
+  private write(
+    method: ConsoleMethod,
+    level: 'debug' | 'info' | 'warn' | 'error',
+    data?: Record<string, unknown> | string,
+    msg?: string,
+  ): void {
+    const entry: Record<string, unknown> = {
+      level,
+      time: new Date().toISOString(),
+      namespace: this.namespace,
+      ...this.context,
+    };
+
+    if (typeof data === 'string') {
+      entry.msg = data;
+    } else {
+      if (msg !== undefined) entry.msg = msg;
+      if (data) Object.assign(entry, data);
+    }
+
+    if (entry.error !== undefined) {
+      entry.error = serializeError(entry.error);
+    }
+
+    console[method](safeStringify(entry));
   }
 
   debug(data?: Record<string, unknown> | string, msg?: string): void {
-    if (typeof data === 'string') {
-      console.debug(this.prefix, data);
-    } else if (msg) {
-      console.debug(this.prefix, msg, data);
-    } else if (data) {
-      console.debug(this.prefix, data);
-    }
+    this.write('debug', 'debug', data, msg);
   }
 
   info(data?: Record<string, unknown> | string, msg?: string): void {
-    if (typeof data === 'string') {
-      console.info(this.prefix, data);
-    } else if (msg) {
-      console.info(this.prefix, msg, data);
-    } else if (data) {
-      console.info(this.prefix, data);
-    }
+    this.write('info', 'info', data, msg);
   }
 
   warn(data?: Record<string, unknown> | string, msg?: string): void {
-    if (typeof data === 'string') {
-      console.warn(this.prefix, data);
-    } else if (msg) {
-      console.warn(this.prefix, msg, data);
-    } else if (data) {
-      console.warn(this.prefix, data);
-    }
+    this.write('warn', 'warn', data, msg);
   }
 
   error(data?: Record<string, unknown> | string, msg?: string): void {
-    if (typeof data === 'string') {
-      console.error(this.prefix, data);
-    } else if (msg) {
-      console.error(this.prefix, msg, data);
-    } else if (data) {
-      console.error(this.prefix, data);
-    }
+    this.write('error', 'error', data, msg);
   }
 }
 


### PR DESCRIPTION
## Summary

Switch fides-auth's fallback `ConsoleLogger` from bracket-prefixed text (`[fides-auth:oauth] PKCE parameters generated {...}`) to newline-delimited JSON. Output is now interoperable with Loki / Grafana / Datadog out of the box, even when the consuming app hasn't wired in a structured logger via `configureLogger()`.

Today only `apps/web` calls `configureAuthLogger` ([apps/web/src/auth/authStore.ts:17](apps/web/src/auth/authStore.ts#L17)). Every other consumer — `apps/idem-admin`, `libs/payload-vipps-auth`, e2e tests, and any external user of fides-auth — has been silently shipping prefix-string logs that are hard to filter and parse.

## New default output

```json
{"level":"info","time":"2026-04-15T19:40:57.300Z","namespace":"fides-auth:oauth","msg":"PKCE parameters generated"}
```

Each entry includes `level`, ISO `time`, `namespace`, persistent `context` fields, optional `msg`, and the data object. `Error` instances on `error` are serialized to `{ name, message, stack }` so they survive `JSON.stringify`. The original `console.<level>` call is preserved so browser devtools and CI log filters still work.

## Breaking change

Apps that grep their own logs for the `[namespace] msg` shape will need to switch to JSON parsing. The new shape matches Pino / @eventuras/logger output, so most log pipelines are unchanged.

If you want pretty dev output, plug in `@eventuras/logger`:

```ts
import { configureLogger } from "@eventuras/fides-auth/logger";
import { Logger } from "@eventuras/logger";
configureLogger({ create: (o) => Logger.create(o) });
```

## Test plan

- [x] `pnpm --filter @eventuras/fides-auth test` — 125 tests pass (default-logger suite rewritten to assert on JSON shape).
- [ ] Spot-check fides-auth output in `apps/idem-admin` and `libs/payload-vipps-auth` — verify entries are valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)