### PR TITLE
fix(logger): keep Node types out of universal entry, polish docs

### DIFF
--- a/.changeset/logger-followup-pr1314.md
+++ b/.changeset/logger-followup-pr1314.md
@@ -1,0 +1,17 @@
+---
+"@eventuras/logger": patch
+---
+
+Follow-up to the logger cleanup pass:
+
+- `PinoTransportOptions.destinationStream` now uses a structural
+  `PinoDestinationStream` interface instead of `NodeJS.WritableStream`,
+  so the universal main-entry types no longer leak Node types into
+  browser/edge consumers.
+- `LoggerConfig.transport` JSDoc clarifies the runtime-dependent
+  default (`PinoTransport` on Node, `ConsoleTransport` in
+  browser/edge).
+- README cleanup: the `PinoTransport` example no longer references the
+  removed `prettyPrint` option, and the auto-redaction snippets now
+  include the missing `Logger.create()` setup so they're copy-paste
+  runnable.

--- a/libs/logger/README.md
+++ b/libs/logger/README.md
@@ -122,15 +122,19 @@ interface LogTransport {
 ```typescript
 import { Logger, PinoTransport } from "@eventuras/logger";
 
-// Explicit Pino configuration
+// Explicit Pino configuration (JSON output to stdout)
 Logger.configure({
   transport: new PinoTransport({
     level: "debug",
-    prettyPrint: true,
     redact: ["password", "secret"],
   }),
 });
 ```
+
+For pretty-printed dev output, use `configureNodeLogger` from
+`@eventuras/logger/node` (see [Pretty dev output](#pretty-dev-output-node-only))
+— the `prettyPrint` option lives there to keep `node:stream` out of the
+universal main entry.
 
 ### ConsoleTransport
 
@@ -170,6 +174,9 @@ Logger.configure({ transport: new DatadogTransport() });
 Sensitive fields are automatically redacted:
 
 ```typescript
+import { Logger } from "@eventuras/logger";
+const logger = Logger.create({ namespace: "auth" });
+
 logger.info(
   {
     username: "john",
@@ -192,7 +199,8 @@ Redaction uses [Pino's `redact` option](https://getpino.io/#/docs/redaction), wh
 // Only redacts top-level `password`
 Logger.configure({ redact: ["password"] });
 
-logger.info({ password: "x" });          // → [REDACTED]
+const logger = Logger.create({ namespace: "auth" });
+logger.info({ password: "x" });           // → [REDACTED]
 logger.info({ user: { password: "x" } }); // → NOT redacted
 ```
 

--- a/libs/logger/src/transports/pino.ts
+++ b/libs/logger/src/transports/pino.ts
@@ -11,6 +11,16 @@
 import pino, { type Logger as PinoLogger, type LoggerOptions as PinoLoggerOptions } from 'pino';
 import type { LogLevel, LogTransport } from '../types';
 
+/**
+ * Minimal structural type for a Pino destination stream — accepts anything
+ * with a `write` method. Defined locally so this file (re-exported from the
+ * universal `@eventuras/logger` entry) doesn't pull `NodeJS.*` types into
+ * browser/edge consumers that don't ship `@types/node`.
+ */
+export interface PinoDestinationStream {
+  write(chunk: string | Uint8Array): unknown;
+}
+
 /** Options for creating a PinoTransport. */
 export type PinoTransportOptions = {
   /** Minimum log level. Defaults to `'info'`. */
@@ -23,7 +33,7 @@ export type PinoTransportOptions = {
    * Writable stream destination (e.g. a pretty-print stream from
    * `@eventuras/logger/node`). Takes precedence over `destination`.
    */
-  destinationStream?: NodeJS.WritableStream;
+  destinationStream?: PinoDestinationStream;
   /** Raw Pino options for advanced tuning (merged after built-in defaults). */
   pinoOptions?: PinoLoggerOptions;
 };
@@ -48,7 +58,10 @@ export class PinoTransport implements LogTransport {
     };
 
     if (options.destinationStream) {
-      this.pino = pino(pinoOpts, options.destinationStream);
+      // Pino's overload expects a NodeJS.WritableStream; the structural
+      // PinoDestinationStream is a strict subset (only `.write` is read at
+      // runtime), so the cast is safe.
+      this.pino = pino(pinoOpts, options.destinationStream as Parameters<typeof pino>[1]);
     } else if (options.destination) {
       this.pino = pino(pinoOpts, pino.destination(options.destination));
     } else {

--- a/libs/logger/src/types.ts
+++ b/libs/logger/src/types.ts
@@ -63,9 +63,11 @@ export type LoggerConfig = {
   /** Optional file path for log output (Pino only). */
   destination?: string;
   /**
-   * Custom transport implementation. Defaults to PinoTransport with JSON
-   * output. For pretty-printed dev output, use `configureNodeLogger`
-   * from `@eventuras/logger/node`.
+   * Custom transport implementation. The default depends on the runtime:
+   * `PinoTransport` (JSON output) on Node.js, and `ConsoleTransport`
+   * (browser-safe `console.*` calls) in browser/edge runtimes. For
+   * pretty-printed dev output, use `configureNodeLogger` from
+   * `@eventuras/logger/node`.
    */
   transport?: LogTransport;
 };


### PR DESCRIPTION
## Summary

Follow-up on #1314 review.

- `PinoTransportOptions.destinationStream` now uses a local structural `PinoDestinationStream` interface (`{ write(chunk): unknown }`) instead of `NodeJS.WritableStream`. The universal main entry's `.d.ts` no longer drags Node types into browser/edge consumers that don't ship `@types/node`. Pino's runtime contract only reads `.write`, so the structural type is sufficient.
- `LoggerConfig.transport` JSDoc now spells out the runtime-dependent default (`PinoTransport` on Node, `ConsoleTransport` in browser/edge) instead of claiming PinoTransport everywhere.
- README cleanup:
  - The `PinoTransport` example no longer references the removed `prettyPrint` option, and points readers at the `configureNodeLogger` helper for pretty dev output.
  - The auto-redaction snippets now include the missing `Logger.create()` setup so the examples run as written.

## Test plan

- [x] `pnpm --filter @eventuras/logger build` — only `dist/transports/pretty.d.ts` references `NodeJS.*` (it's only re-exported via `/node`).
- [x] `pnpm --filter @eventuras/logger test` — 63 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)