### PR TITLE
fix(web): handle checkAuth rejection in LoginSuccessHandler

### DIFF
--- a/.changeset/login-success-handler-cleanup.md
+++ b/.changeset/login-success-handler-cleanup.md
@@ -1,0 +1,16 @@
+---
+"@eventuras/web": patch
+---
+
+`LoginSuccessHandler` cleanup:
+
+- Wrap the immediate `checkAuth()` call so a rejection logs at error
+  level instead of becoming an unhandled promise rejection.
+- Drop the per-page-load debug log when the `?login=success` parameter
+  isn't present — the silent path is the common case and the noise
+  showed up everywhere when debug filters were on.
+- Use a single `URL` object for both reading and cleaning the query
+  parameter.
+- Document why the `hasChecked` ref exists (StrictMode dev double-fire)
+  and replace the dated `useSearchParams` comment with the actual
+  reason (avoiding a Suspense boundary in the layout).

--- a/apps/web/src/components/auth/LoginSuccessHandler.tsx
+++ b/apps/web/src/components/auth/LoginSuccessHandler.tsx
@@ -24,31 +24,30 @@ const logger = Logger.create({
  * Place this component in the root layout so it runs on every page load.
  */
 export function LoginSuccessHandler() {
+  // Guards against React StrictMode's intentional double-effect-invocation in
+  // dev. Without it, checkAuth would fire twice on the success redirect.
   const hasChecked = useRef(false);
 
   useEffect(() => {
-    // Only run once per page load
     if (hasChecked.current) return;
     hasChecked.current = true;
 
-    // Read query params directly from window.location (more reliable than useSearchParams during hydration)
-    const urlParams = new URLSearchParams(window.location.search);
-    const loginSuccess = urlParams.get('login') === 'success';
+    // Read directly from window.location to keep this component a single
+    // 'use client' island — using next/navigation's useSearchParams would
+    // pull a Suspense boundary into the layout for no real benefit.
+    const url = new URL(window.location.href);
+    if (url.searchParams.get('login') !== 'success') return;
 
-    if (loginSuccess) {
-      logger.info('Login success detected via query param, triggering immediate auth check');
+    logger.info('Login success detected via query param, triggering immediate auth check');
 
-      // Trigger immediate check to update store
-      checkAuth(authStore, getAuthStatus);
+    checkAuth(authStore, getAuthStatus).catch((error: unknown) => {
+      logger.error({ error }, 'Immediate auth check failed after login redirect');
+    });
 
-      // Clean up the URL (remove query param) without triggering navigation
-      const url = new URL(window.location.href);
-      url.searchParams.delete('login');
-      window.history.replaceState({}, '', url.toString());
-    } else {
-      logger.debug('No login success parameter found, skipping immediate check');
-    }
+    // Clean up the URL without triggering navigation.
+    url.searchParams.delete('login');
+    window.history.replaceState({}, '', url.toString());
   }, []);
 
-  return null; // This component renders nothing
+  return null;
 }


### PR DESCRIPTION
## Summary

Five small fixes to [LoginSuccessHandler.tsx](apps/web/src/components/auth/LoginSuccessHandler.tsx):

1. **Catch the `checkAuth` promise.** It's `async` ([store.ts:245](libs/fides-auth-next/src/store/store.ts#L245)) but was called fire-and-forget, so a rejection became an unhandled promise rejection instead of a logged error.
2. **Drop the per-page-load `debug` log.** The else-branch logged "no login success parameter found" on every navigation when the component lives in the root layout — noisy when debug filters are on.
3. **Reuse a single `URL` object** for reading the query parameter and writing the cleaned URL.
4. **Document the `hasChecked` ref.** It's there to survive React StrictMode's intentional dev double-fire — without a comment it looked like cargo-cult code next to the empty deps array.
5. **Refresh the `useSearchParams` comment.** The original "more reliable during hydration" framing was outdated; the real reason is keeping this a single `'use client'` island without dragging in a Suspense boundary.

## Test plan

- [x] `pnpm tsc --noEmit` clean.
- [ ] Trigger an OAuth login flow in dev and confirm the success-redirect still updates the auth store immediately.
- [ ] Force `getAuthStatus` to throw and confirm the rejection now produces a structured error log instead of an unhandled promise rejection in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)