### PR TITLE
feat(ratio-ui): compound Navbar with Brand + Content slots

### DIFF
--- a/.changeset/navbar-compound-component.md
+++ b/.changeset/navbar-compound-component.md
@@ -1,0 +1,31 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+feat(navbar): compound component API with `Navbar.Brand` and `Navbar.Content`
+
+The Navbar now supports a compound-component pattern for full control
+over brand, navigation, and action zones:
+
+```tsx
+<Navbar sticky>
+  <Navbar.Brand>
+    <Link to="/"><Logo /> Ignis</Link>
+  </Navbar.Brand>
+  <Navbar.Content>
+    <NavLink to="/events">Events</NavLink>
+    <div className="ml-auto flex gap-2">
+      <SearchField />
+      <UserMenu />
+    </div>
+  </Navbar.Content>
+</Navbar>
+```
+
+`Navbar.Brand` is optional — admin bars and secondary navbars can use
+just `Navbar.Content`. Stacking two `<Navbar>` gives a double-navbar
+layout with no additional API.
+
+The previous `title` / `titleHref` / `LinkComponent` props still work
+for backward compatibility but are deprecated in favour of
+`Navbar.Brand`.

--- a/libs/ratio-ui/.storybook/modeDecorator.tsx
+++ b/libs/ratio-ui/.storybook/modeDecorator.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-export const ModeDecorator = (Story: any) => {
+export const ModeDecorator = (Story: any, context: any) => {
+  const noPadding = context?.parameters?.noPadding === true;
   const [isDarkMode, setIsDarkMode] = useState(true);
 
   const toggleMode = () => {
@@ -19,10 +20,10 @@ export const ModeDecorator = (Story: any) => {
         onClick={toggleMode}
         style={{
           position: 'fixed',
-          top: 10,
+          bottom: 10,
           right: 10,
           zIndex: 9999,
-          padding: '8px 12px',
+          padding: '2px 8px',
           backgroundColor: isDarkMode ? '#333' : '#fff',
           color: isDarkMode ? '#fff' : '#333',
           border: '1px solid #ccc',
@@ -37,7 +38,7 @@ export const ModeDecorator = (Story: any) => {
         style={{
           minWidth: '100%',
           backgroundColor: isDarkMode ? '#1a1a1a' : '#ffffff',
-          padding: '2rem',
+          padding: noPadding ? '0' : '2rem',
         }}
       >
         <Story />

--- a/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
@@ -1,38 +1,99 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Navbar, NavbarProps } from './Navbar';
+import { Navbar } from './Navbar';
 
 const meta: Meta<typeof Navbar> = {
   title: 'Core/Navbar',
   component: Navbar,
   tags: ['autodocs'],
+  parameters: {
+    noPadding: true,
+  },
 };
 export default meta;
 type Story = StoryObj<typeof Navbar>;
 
-export const Default: Story = {
-  args: { title: 'Eventuras Inc.' },
+export const BrandAndContent: Story = {
+  render: () => (
+    <Navbar sticky>
+      <Navbar.Brand>
+        <a href="/" className="flex items-center gap-2 text-lg tracking-tight no-underline">
+          <span className="inline-block h-6 w-6 rounded bg-primary-500" />{' '}
+          Eventuras
+        </a>
+      </Navbar.Brand>
+      <Navbar.Content>
+        <a href="/events" className="hover:underline">Events</a>
+        <a href="/about" className="hover:underline">About</a>
+        <div className="ml-auto flex gap-2">
+          <button type="button" className="btn-primary">Sign up</button>
+        </div>
+      </Navbar.Content>
+    </Navbar>
+  ),
 };
 
-/** Dark background + white text */
-export const DarkBg: Story = {
+export const BrandOnly: Story = {
+  render: () => (
+    <Navbar bgColor="bg-slate-900" bgDark>
+      <Navbar.Brand>
+        <a href="/" className="text-lg tracking-tight no-underline text-white">
+          Ignis
+        </a>
+      </Navbar.Brand>
+    </Navbar>
+  ),
+};
+
+export const ContentOnly: Story = {
+  render: () => (
+    <Navbar bgColor="bg-amber-100">
+      <Navbar.Content>
+        <a href="/admin/events" className="hover:underline">Events</a>
+        <a href="/admin/users" className="hover:underline">Users</a>
+        <a href="/admin/settings" className="hover:underline">Settings</a>
+      </Navbar.Content>
+    </Navbar>
+  ),
+};
+
+export const DoubleNavbar: Story = {
+  render: () => (
+    <div>
+      <Navbar sticky bgColor="bg-slate-900" bgDark>
+        <Navbar.Brand>
+          <a href="/" className="text-lg tracking-tight no-underline text-white">Eventuras</a>
+        </Navbar.Brand>
+        <Navbar.Content>
+          <div className="ml-auto">
+            <button type="button" className="text-sm text-white/70 hover:text-white">Sign out</button>
+          </div>
+        </Navbar.Content>
+      </Navbar>
+      <Navbar bgColor="bg-slate-700" className="text-dark">
+        <Navbar.Content>
+          <a href="/admin/events" className="hover:underline">Events</a>
+          <a href="/admin/users" className="hover:underline">Users</a>
+        </Navbar.Content>
+      </Navbar>
+    </div>
+  ),
+};
+
+/** Legacy API — still works, renders identically to the old Navbar. */
+export const LegacyTitle: Story = {
   args: {
     title: 'Eventuras Inc.',
-    bgDark: true,
-    bgColor: 'bg-slate-900',
-  } satisfies NavbarProps,
+    sticky: true,
+  },
 };
 
-/** With right‑side links / buttons */
-export const WithChildren: Story = {
+/** Legacy API with children. */
+export const LegacyWithChildren: Story = {
   render: (args) => (
     <Navbar {...args}>
-      {/* Any React node(s) */}
-      <a href="/about" className="px-3">
-        About
-      </a>
-      <button className="btn-primary ml-2">Sign up</button>
+      <a href="/about" className="px-3">About</a>
+      <button type="button" className="btn-primary ml-2">Sign up</button>
     </Navbar>
   ),
   args: { title: 'Acme Inc.' },
 };
-

--- a/libs/ratio-ui/src/core/Navbar/Navbar.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.tsx
@@ -1,54 +1,100 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
+import { cn } from '../../utils/cn';
 
 export interface NavbarProps {
-  /** Text shown at the left side. */
-  title?: string;
-  /** Optional right‑side content (buttons, links …). */
-  children?: React.ReactNode;
+  children?: ReactNode;
   /** Forces white text for dark backgrounds. */
   bgDark?: boolean;
-  /** Extra Tailwind background class (default `bg-transparent`). */
+  /** Tailwind background class (default `bg-transparent`). */
   bgColor?: string;
-  /** URL for the title link (default `/`). */
-  titleHref?: string;  /** Make navbar sticky at the top (default: false). */
+  /** Make navbar sticky at the top. */
   sticky?: boolean;
-  /** Routing link component (e.g. `next/link`, `react-router-dom` Link). */
+  className?: string;
+
+  // ── Legacy shorthand props (still supported, prefer Navbar.Brand) ──
+
+  /** @deprecated Use `<Navbar.Brand>` instead. */
+  title?: string;
+  /** @deprecated Use `<Navbar.Brand>` instead. */
+  titleHref?: string;
+  /** @deprecated Use `<Navbar.Brand>` instead. */
   LinkComponent?: React.ComponentType<{
     href: string;
-    children: React.ReactNode;
+    children: ReactNode;
     className?: string;
   }>;
 }
 
-/**
- * Simple, responsive navbar.
- *
- * @see {@link NavbarProps}
- *
- */
-export const Navbar = ({
-  title,
+export interface NavbarBrandProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+export interface NavbarContentProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+function NavbarBrand({ children, className }: Readonly<NavbarBrandProps>) {
+  return (
+    <div className={cn('flex shrink-0 items-center', className)}>
+      {children}
+    </div>
+  );
+}
+
+function NavbarContent({ children, className }: Readonly<NavbarContentProps>) {
+  return (
+    <div className={cn('flex grow items-center gap-3', className)}>
+      {children}
+    </div>
+  );
+}
+
+const NavbarRoot = ({
   children,
   bgDark = false,
   bgColor,
-  titleHref = '/',
   sticky = false,
+  className,
+  // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
+  title,
+  // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
+  titleHref = '/',
+  // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
   LinkComponent,
-}: NavbarProps) => {
+}: Readonly<NavbarProps>) => {
   const textColor = bgDark ? 'text-light' : 'text-dark dark:text-light';
-  const LinkTag = LinkComponent ?? ('a' as React.ElementType);
   const positionClass = sticky ? 'sticky top-0 z-50' : '';
 
+  const hasLegacyTitle = typeof title === 'string' && title !== '';
+  const LinkTag = LinkComponent ?? ('a' as React.ElementType);
+
   return (
-    <nav className={`${bgColor} ${positionClass} ${textColor} m-0 p-0`}>
-      <div className="flex flex-wrap items-center justify-between mx-auto py-2 px-3">
-        { title && (
-        <LinkTag href={titleHref} className={`text-lg tracking-tight whitespace-nowrap no-underline ${textColor}`}>
-          {title}
-          </LinkTag>
+    <nav className={cn(bgColor, positionClass, textColor, 'm-0 p-0', className)}>
+      <div
+        className={cn(
+          'flex flex-wrap items-center mx-auto gap-3 py-2 px-3',
+          hasLegacyTitle && 'justify-between',
+        )}
+      >
+        {hasLegacyTitle && (
+          <NavbarBrand>
+            <LinkTag
+              href={titleHref}
+              className={cn('text-lg tracking-tight whitespace-nowrap no-underline', textColor)}
+            >
+              {title}
+            </LinkTag>
+          </NavbarBrand>
         )}
         {children}
       </div>
     </nav>
   );
 };
+
+export const Navbar = Object.assign(NavbarRoot, {
+  Brand: NavbarBrand,
+  Content: NavbarContent,
+});

--- a/libs/ratio-ui/src/core/Navbar/index.ts
+++ b/libs/ratio-ui/src/core/Navbar/index.ts
@@ -1,2 +1,2 @@
 export { Navbar } from './Navbar';
-export type { NavbarProps } from './Navbar';
+export type { NavbarProps, NavbarBrandProps, NavbarContentProps } from './Navbar';


### PR DESCRIPTION
Introduces Navbar.Brand (flex-shrink-0 left zone) and Navbar.Content (flex-grow remaining zone) via dot-notation on the existing Navbar export, giving consumers full control over brand, navigation, and action zones from a single import.

Brand is optional — admin bars and secondary navbars use Content alone. Stacking two <Navbar> gives a double-navbar layout with no extra API. Navbar.Content is also the natural collapse target for a future hamburger menu.

The previous title/titleHref/LinkComponent props stay functional for backward compatibility and are marked @deprecated.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>