### PR TITLE
fix: use workspace:^ for internal peerDependencies to stop false major bumps

### DIFF
--- a/libs/lustro-search/package.json
+++ b/libs/lustro-search/package.json
@@ -40,7 +40,7 @@
     "vite": "^8.0.8"
   },
   "peerDependencies": {
-    "@eventuras/ratio-ui": "workspace:*",
+    "@eventuras/ratio-ui": "workspace:^",
     "react": "^18 || ^19"
   },
   "peerDependenciesMeta": {

--- a/libs/markdown-plugin-happening/package.json
+++ b/libs/markdown-plugin-happening/package.json
@@ -36,7 +36,7 @@
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
-    "@eventuras/ratio-ui": "workspace:*",
+    "@eventuras/ratio-ui": "workspace:^",
     "@eventuras/typescript-config": "workspace:*",
     "@eventuras/vite-config": "workspace:*",
     "@testing-library/jest-dom": "6.9.1",
@@ -52,7 +52,7 @@
     "vitest": "4.1.4"
   },
   "peerDependencies": {
-    "@eventuras/ratio-ui": "workspace:*",
+    "@eventuras/ratio-ui": "workspace:^",
     "react": ">=18 <20",
     "react-dom": ">=18 <20"
   }

--- a/libs/markdown/package.json
+++ b/libs/markdown/package.json
@@ -41,7 +41,7 @@
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
-    "@eventuras/ratio-ui": "workspace:*",
+    "@eventuras/ratio-ui": "workspace:^",
     "@eventuras/typescript-config": "workspace:*",
     "@eventuras/vite-config": "workspace:*",
     "@testing-library/jest-dom": "6.9.1",
@@ -60,7 +60,7 @@
     "vitest": "4.1.4"
   },
   "peerDependencies": {
-    "@eventuras/ratio-ui": "workspace:*",
+    "@eventuras/ratio-ui": "workspace:^",
     "react": ">=18 <20",
     "react-dom": ">=18 <20",
     "react-markdown": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,7 +1168,7 @@ importers:
   libs/lustro-search:
     dependencies:
       '@eventuras/ratio-ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../ratio-ui
       '@orama/orama':
         specifier: ^3.1.18
@@ -1231,7 +1231,7 @@ importers:
         version: 5.1.0
     devDependencies:
       '@eventuras/ratio-ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../ratio-ui
       '@eventuras/typescript-config':
         specifier: workspace:*
@@ -1295,7 +1295,7 @@ importers:
         version: 5.1.0
     devDependencies:
       '@eventuras/ratio-ui':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../ratio-ui
       '@eventuras/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

`workspace:*` in `peerDependencies` resolves to an **exact version** during changeset versioning, so any bump of the dependency — even a patch — made the peer range "out of range" and triggered a **major** bump in every dependent package.

This is why `@eventuras/lustro-search` is at `5.0.0`, `@eventuras/markdown-plugin-happening` at `5.0.0`, and `@eventuras/markdown` at `10.0.0` despite having no breaking changes of their own — each ratio-ui patch/minor cascaded into a major here.

Switching to `workspace:^` resolves to `^currentVersion`, which allows minor and patch bumps without breaking the peer range. Only a true major bump in ratio-ui will trigger a major in these packages going forward.

Affected: `lustro-search`, `markdown`, `markdown-plugin-happening` (all peer-depend on `ratio-ui`).

## Test plan

- [x] `pnpm install` succeeds with updated lock file.
- [ ] Next changeset version run should only produce patch bumps for these packages when ratio-ui gets a minor/patch bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)