### PR TITLE
feat(fides-auth): opt-in Pushed Authorization Requests (RFC 9126)

### DIFF
--- a/.changeset/fides-auth-par.md
+++ b/.changeset/fides-auth-par.md
@@ -1,0 +1,17 @@
+---
+"@eventuras/fides-auth": minor
+---
+
+feat(oauth): opt-in Pushed Authorization Requests (RFC 9126)
+
+Adds a `usePar?: boolean` flag on `OAuthConfig` and a low-level
+`buildAuthorizationUrlWithPAR(config, pkceOptions)` helper that mirrors
+`openid-client`'s own API.
+
+`discoverAndBuildAuthorizationUrl` now routes based on the flag:
+
+- `usePar: true` + provider advertises `pushed_authorization_request_endpoint` → uses PAR.
+- `usePar: true` + provider does **not** advertise PAR → throws.
+- `usePar` unset/false + provider advertises PAR → standard flow plus a
+  one-line `info` log noting PAR is available but not enabled.
+- `usePar` unset/false + no PAR endpoint → standard flow, no advisory.

--- a/libs/fides-auth/README.md
+++ b/libs/fides-auth/README.md
@@ -5,6 +5,7 @@ Framework-agnostic OAuth 2.0 / OpenID Connect library with PKCE, encrypted sessi
 ## Features
 
 - **OAuth 2.0 + OIDC** — Authorization Code with PKCE, token refresh, client credentials
+- **Pushed Authorization Requests** — Opt-in RFC 9126 support (`usePar`) when the provider advertises it
 - **Dual environment** — Node.js (`openid-client`) and browser (Web Crypto) entry points
 - **Encrypted sessions** — AES-256-GCM encrypted JWTs for secure session storage
 - **Rate limiting** — Generic token-bucket algorithm, ready for login protection
@@ -123,6 +124,8 @@ Full OIDC flows using `openid-client`:
 import {
   buildPKCEOptions,
   buildAuthorizationUrl,
+  buildAuthorizationUrlWithPAR,
+  discoverAndBuildAuthorizationUrl,
   exchangeAuthorizationCode,
   refreshAccessToken,
   extractUserFromTokens,
@@ -131,6 +134,43 @@ import {
   buildOidcLogoutUrl,
   clientCredentialsGrant,
 } from "@eventuras/fides-auth/oauth";
+```
+
+#### Pushed Authorization Requests (PAR, RFC 9126)
+
+Opt in by setting `usePar: true` on your `OAuthConfig`. The convenience
+helper `discoverAndBuildAuthorizationUrl` then posts the authorization
+parameters to the provider's PAR endpoint and returns a URL containing
+only `client_id` and `request_uri`:
+
+```typescript
+const oauthConfig = {
+  issuer: "https://auth.example.com",
+  clientId: "your-client-id",
+  clientSecret: "your-client-secret",
+  redirect_uri: "https://app.example.com/callback",
+  scope: "openid profile email offline_access",
+  usePar: true,
+};
+
+const pkce = await buildPKCEOptions(oauthConfig);
+const authUrl = await discoverAndBuildAuthorizationUrl(oauthConfig, pkce);
+// redirect user to authUrl
+```
+
+Behaviour:
+
+- `usePar: true` + provider advertises `pushed_authorization_request_endpoint` → uses PAR.
+- `usePar: true` + provider does **not** advertise PAR → throws.
+- `usePar` unset/false + provider advertises PAR → standard flow, with a
+  one-line `info` log noting that PAR is available but not enabled.
+- `usePar` unset/false + no PAR endpoint → standard flow, no advisory.
+
+If you already have a discovered `Configuration` you can call the
+low-level wrapper directly:
+
+```typescript
+const authUrl = await buildAuthorizationUrlWithPAR(config, pkce);
 ```
 
 ### OAuth — Browser (`/oauth-browser`)

--- a/libs/fides-auth/src/oauth.par.test.ts
+++ b/libs/fides-auth/src/oauth.par.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for Pushed Authorization Requests (RFC 9126) support in oauth.ts.
+ *
+ * Covers:
+ * - `buildAuthorizationUrlWithPAR` — thin wrapper over openid-client.
+ * - `discoverAndBuildAuthorizationUrl` — routing between PAR and non-PAR
+ *   based on `OAuthConfig.usePar` and provider discovery metadata.
+ *
+ * If these tests fail, run from the repo root:
+ *   pnpm --filter @eventuras/fides-auth test
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('openid-client', () => ({
+  discovery: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  buildAuthorizationUrlWithPAR: vi.fn(),
+  ClientSecretPost: vi.fn(() => () => undefined),
+  randomPKCECodeVerifier: vi.fn(() => 'verifier-123'),
+  calculatePKCECodeChallenge: vi.fn(async () => 'challenge-abc'),
+  randomState: vi.fn(() => 'state-xyz'),
+}));
+
+import * as openid from 'openid-client';
+import {
+  buildAuthorizationUrlWithPAR,
+  discoverAndBuildAuthorizationUrl,
+  type OAuthConfig,
+  type PKCEOptions,
+} from './oauth';
+import { configureLogger, type FidesLogger } from './logger';
+
+function makeOAuthConfig(overrides: Partial<OAuthConfig> = {}): OAuthConfig {
+  return {
+    issuer: 'https://auth.example.com',
+    clientId: 'test-client',
+    clientSecret: 'test-secret',
+    redirect_uri: 'https://app.example.com/callback',
+    scope: 'openid profile email',
+    ...overrides,
+  };
+}
+
+function makePkce(): PKCEOptions {
+  return {
+    code_verifier: 'verifier-123',
+    code_challenge: 'challenge-abc',
+    state: 'state-xyz',
+    parameters: {
+      redirect_uri: 'https://app.example.com/callback',
+      scope: 'openid profile email',
+      code_challenge: 'challenge-abc',
+      code_challenge_method: 'S256',
+      state: 'state-xyz',
+    },
+  };
+}
+
+function makeDiscoveredConfig(parEndpoint?: string): openid.Configuration {
+  return {
+    serverMetadata: () => ({
+      pushed_authorization_request_endpoint: parEndpoint,
+    }),
+  } as unknown as openid.Configuration;
+}
+
+type LogEntry = { level: string; msg?: string; data?: Record<string, unknown> };
+
+function installTestLogger(): LogEntry[] {
+  const entries: LogEntry[] = [];
+  const record =
+    (level: string) => (data?: Record<string, unknown> | string, msg?: string) => {
+      const entry: LogEntry = { level };
+      if (typeof data === 'string') {
+        entry.msg = data;
+      } else {
+        if (msg !== undefined) entry.msg = msg;
+        if (data) entry.data = data;
+      }
+      entries.push(entry);
+    };
+  configureLogger({
+    create() {
+      return {
+        debug: record('debug'),
+        info: record('info'),
+        warn: record('warn'),
+        error: record('error'),
+      };
+    },
+  });
+  return entries;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// `installTestLogger()` mutates the module-global logger factory.
+// Restore the default after each test so a test-local factory can't leak
+// into later tests — mirrors the teardown pattern in logger.test.ts.
+afterEach(() => {
+  configureLogger({
+    create({ namespace, context }) {
+      return createDefaultConsoleLogger(namespace, context);
+    },
+  });
+});
+
+function createDefaultConsoleLogger(
+  namespace: string,
+  context?: Record<string, unknown>,
+): FidesLogger {
+  const log =
+    (method: 'debug' | 'info' | 'warn' | 'error') =>
+    (data?: Record<string, unknown> | string, msg?: string) => {
+      const entry: Record<string, unknown> = {
+        level: method,
+        time: new Date().toISOString(),
+        namespace,
+        ...context,
+      };
+      if (typeof data === 'string') {
+        entry.msg = data;
+      } else {
+        if (msg !== undefined) entry.msg = msg;
+        if (data) Object.assign(entry, data);
+      }
+      console[method](JSON.stringify(entry));
+    };
+
+  return {
+    debug: log('debug'),
+    info: log('info'),
+    warn: log('warn'),
+    error: log('error'),
+  };
+}
+
+describe('buildAuthorizationUrlWithPAR', () => {
+  it('delegates to openid.buildAuthorizationUrlWithPAR with the PKCE parameters', async () => {
+    const discovered = makeDiscoveredConfig('https://auth.example.com/par');
+    const parUrl = new URL(
+      'https://auth.example.com/authorize?client_id=x&request_uri=urn:ietf:params:oauth:request_uri:1',
+    );
+    vi.mocked(openid.buildAuthorizationUrlWithPAR).mockResolvedValue(parUrl);
+
+    const pkce = makePkce();
+    const result = await buildAuthorizationUrlWithPAR(discovered, pkce);
+
+    expect(openid.buildAuthorizationUrlWithPAR).toHaveBeenCalledWith(
+      discovered,
+      pkce.parameters,
+    );
+    expect(result).toBe(parUrl);
+  });
+
+  it('propagates errors from openid-client', async () => {
+    const discovered = makeDiscoveredConfig('https://auth.example.com/par');
+    vi.mocked(openid.buildAuthorizationUrlWithPAR).mockRejectedValue(new Error('par failed'));
+
+    await expect(
+      buildAuthorizationUrlWithPAR(discovered, makePkce()),
+    ).rejects.toThrow('par failed');
+  });
+});
+
+describe('discoverAndBuildAuthorizationUrl — PAR routing', () => {
+  it('uses PAR when usePar=true and the provider advertises it', async () => {
+    const discovered = makeDiscoveredConfig('https://auth.example.com/par');
+    vi.mocked(openid.discovery).mockResolvedValue(discovered);
+    const parUrl = new URL(
+      'https://auth.example.com/authorize?client_id=x&request_uri=urn:1',
+    );
+    vi.mocked(openid.buildAuthorizationUrlWithPAR).mockResolvedValue(parUrl);
+
+    const result = await discoverAndBuildAuthorizationUrl(
+      makeOAuthConfig({ usePar: true }),
+      makePkce(),
+    );
+
+    expect(openid.buildAuthorizationUrlWithPAR).toHaveBeenCalledTimes(1);
+    expect(openid.buildAuthorizationUrl).not.toHaveBeenCalled();
+    expect(result).toBe(parUrl);
+  });
+
+  it('throws when usePar=true but the provider does not advertise PAR', async () => {
+    vi.mocked(openid.discovery).mockResolvedValue(makeDiscoveredConfig());
+
+    await expect(
+      discoverAndBuildAuthorizationUrl(
+        makeOAuthConfig({ usePar: true }),
+        makePkce(),
+      ),
+    ).rejects.toThrow(/does not advertise pushed_authorization_request_endpoint/);
+
+    expect(openid.buildAuthorizationUrlWithPAR).not.toHaveBeenCalled();
+    expect(openid.buildAuthorizationUrl).not.toHaveBeenCalled();
+  });
+
+  it('uses the standard flow when usePar is unset and logs an advisory if PAR is advertised', async () => {
+    const discovered = makeDiscoveredConfig('https://auth.example.com/par');
+    vi.mocked(openid.discovery).mockResolvedValue(discovered);
+    const authUrl = new URL('https://auth.example.com/authorize?client_id=x');
+    vi.mocked(openid.buildAuthorizationUrl).mockReturnValue(authUrl);
+
+    const logs = installTestLogger();
+
+    const result = await discoverAndBuildAuthorizationUrl(
+      makeOAuthConfig(),
+      makePkce(),
+    );
+
+    expect(openid.buildAuthorizationUrl).toHaveBeenCalledTimes(1);
+    expect(openid.buildAuthorizationUrlWithPAR).not.toHaveBeenCalled();
+    expect(result).toBe(authUrl);
+
+    const advisory = logs.find(
+      (e) =>
+        e.level === 'info' &&
+        typeof e.msg === 'string' &&
+        e.msg.includes('Provider advertises PAR but usePar is not enabled'),
+    );
+    expect(advisory).toBeDefined();
+    expect(advisory?.msg).toContain('set OAuthConfig.usePar=true to use it');
+  });
+
+  it('uses the standard flow without advisory when the provider does not advertise PAR', async () => {
+    vi.mocked(openid.discovery).mockResolvedValue(makeDiscoveredConfig());
+    const authUrl = new URL('https://auth.example.com/authorize?client_id=x');
+    vi.mocked(openid.buildAuthorizationUrl).mockReturnValue(authUrl);
+
+    const logs = installTestLogger();
+
+    await discoverAndBuildAuthorizationUrl(makeOAuthConfig(), makePkce());
+
+    expect(openid.buildAuthorizationUrl).toHaveBeenCalledTimes(1);
+    expect(openid.buildAuthorizationUrlWithPAR).not.toHaveBeenCalled();
+
+    const advisory = logs.find(
+      (e) =>
+        e.level === 'info' &&
+        typeof e.msg === 'string' &&
+        e.msg.includes('Provider advertises PAR'),
+    );
+    expect(advisory).toBeUndefined();
+  });
+
+  it('uses the standard flow when usePar=false even if PAR is advertised', async () => {
+    vi.mocked(openid.discovery).mockResolvedValue(
+      makeDiscoveredConfig('https://auth.example.com/par'),
+    );
+    const authUrl = new URL('https://auth.example.com/authorize?client_id=x');
+    vi.mocked(openid.buildAuthorizationUrl).mockReturnValue(authUrl);
+
+    const result = await discoverAndBuildAuthorizationUrl(
+      makeOAuthConfig({ usePar: false }),
+      makePkce(),
+    );
+
+    expect(openid.buildAuthorizationUrl).toHaveBeenCalledTimes(1);
+    expect(openid.buildAuthorizationUrlWithPAR).not.toHaveBeenCalled();
+    expect(result).toBe(authUrl);
+  });
+});

--- a/libs/fides-auth/src/oauth.ts
+++ b/libs/fides-auth/src/oauth.ts
@@ -20,6 +20,14 @@ export type OAuthConfig = {
   clientSecret: string;
   redirect_uri: string;
   scope: string;
+  /**
+   * Opt in to Pushed Authorization Requests (RFC 9126) when the provider
+   * supports it. When true, authorization parameters are posted to the
+   * provider's PAR endpoint ahead of the redirect, and only `client_id` +
+   * `request_uri` travel through the user-agent. The provider must advertise
+   * `pushed_authorization_request_endpoint` in its discovery metadata.
+   */
+  usePar?: boolean;
 };
 
 /**
@@ -131,7 +139,7 @@ export async function buildAuthorizationUrl(
 ): Promise<URL> {
   try {
     const authUrl = openid.buildAuthorizationUrl(config, pkceOptions.parameters);
-    logger.info({ authUrl: authUrl.origin }, 'Authorization URL built successfully');
+    logger.info('Authorization URL built successfully');
     return authUrl;
   } catch (error) {
     logger.error({ error }, 'Failed to build authorization URL');
@@ -140,8 +148,43 @@ export async function buildAuthorizationUrl(
 }
 
 /**
- * Convenience function to discover OpenID configuration and build authorization URL.
- * This combines discovery + buildAuthorizationUrl in one call.
+ * Builds an authorization URL using Pushed Authorization Requests (RFC 9126).
+ *
+ * Posts the PKCE parameters to the provider's PAR endpoint and returns a URL
+ * containing only `client_id` and `request_uri`. The provider's discovery
+ * metadata must include `pushed_authorization_request_endpoint`.
+ *
+ * @param config - Discovered OpenID Configuration (use openid.discovery() to obtain)
+ * @param pkceOptions - The PKCE options (e.g., code challenge, state, parameters)
+ * @returns A Promise that resolves to the PAR-based authorization URL
+ */
+export async function buildAuthorizationUrlWithPAR(
+  config: openid.Configuration,
+  pkceOptions: PKCEOptions
+): Promise<URL> {
+  try {
+    const authUrl = await openid.buildAuthorizationUrlWithPAR(
+      config,
+      pkceOptions.parameters,
+    );
+    logger.info('PAR authorization URL built successfully');
+    return authUrl;
+  } catch (error) {
+    logger.error({ error }, 'Failed to build PAR authorization URL');
+    throw error;
+  }
+}
+
+/**
+ * Convenience function to discover OpenID configuration and build an
+ * authorization URL. Routes through PAR when `oauthConfig.usePar` is true and
+ * the provider advertises `pushed_authorization_request_endpoint`.
+ *
+ * - `usePar === true` + provider advertises PAR → uses PAR.
+ * - `usePar === true` + provider does **not** advertise PAR → throws.
+ * - `usePar` unset/false + provider advertises PAR → standard flow + one-line
+ *   `info` advisory that PAR is available but not enabled.
+ * - `usePar` unset/false + no PAR endpoint → standard flow, no advisory.
  *
  * @param oauthConfig - Your OAuth configuration
  * @param pkceOptions - The PKCE options (e.g., code challenge, state, parameters)
@@ -160,6 +203,24 @@ export async function discoverAndBuildAuthorizationUrl(
       oauthConfig.clientSecret,
       openid.ClientSecretPost(oauthConfig.clientSecret)
     );
+
+    const parEndpoint = config.serverMetadata().pushed_authorization_request_endpoint;
+
+    if (oauthConfig.usePar) {
+      if (!parEndpoint) {
+        throw new Error(
+          'PAR requested (usePar=true) but provider does not advertise pushed_authorization_request_endpoint',
+        );
+      }
+      return buildAuthorizationUrlWithPAR(config, pkceOptions);
+    }
+
+    if (parEndpoint) {
+      logger.info(
+        { issuer: oauthConfig.issuer },
+        'Provider advertises PAR but usePar is not enabled — set OAuthConfig.usePar=true to use it',
+      );
+    }
 
     return buildAuthorizationUrl(config, pkceOptions);
   } catch (error) {


### PR DESCRIPTION
Adds `usePar?: boolean` to OAuthConfig and a `buildAuthorizationUrlWithPAR` helper mirroring openid-client. `discoverAndBuildAuthorizationUrl` routes on the flag; when PAR is advertised but not enabled, emits a one-line info log. Opt-in keeps behaviour deterministic across provider discovery-metadata changes.