### PR TITLE
Refactor/navbar web

### DIFF
--- a/.changeset/navbar-overlay-glass.md
+++ b/.changeset/navbar-overlay-glass.md
@@ -1,0 +1,35 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+feat(navbar): `overlay`/`glass` props and container-aligned content
+
+Adds two composable props to `<Navbar>`:
+
+- `overlay` — absolute positioning pinned to the viewport top. The navbar
+  floats over the next sibling (typically a hero section) without
+  reserving layout space and scrolls away with the page. Mutually
+  exclusive with `sticky`.
+- `glass` — translucent dark background with backdrop-blur, for the
+  classic "glass navbar over hero image" look.
+
+Combine with `bgDark` for white text readable over dark hero imagery:
+
+```tsx
+<Navbar overlay glass bgDark>
+  <Navbar.Brand>…</Navbar.Brand>
+  <Navbar.Content className="justify-end">…</Navbar.Content>
+</Navbar>
+```
+
+The inner content row now also applies the Tailwind `container` class so
+brand and navigation align with `<Container>`-wrapped page content
+instead of stretching to the viewport edges.
+
+See the `OverlayGlass` story for a live example.
+
+Also safelists a set of commonly-needed layout utilities in ratio-ui's
+bundled CSS: spacing (`pt-16…pt-40`, `pb-16…pb-40`, `mt-16…mt-40`,
+`mb-16…mb-40`) and hero viewport heights (`min-h-[20vh]` through
+`min-h-[80vh]`). Consumers (apps/*) can now use these without setting
+up their own Tailwind entry.

--- a/.changeset/web-site-navbar.md
+++ b/.changeset/web-site-navbar.md
@@ -1,0 +1,19 @@
+---
+"@eventuras/web": patch
+---
+
+refactor: extract `SiteNavbar` and migrate layouts to compound Navbar API
+
+Consolidates four duplicated navbar blocks across `(public)`, `(user)`,
+`(admin)`, and `(frontpage)` into a single async server component with
+a `variant` prop (`primary` | `transparent` | `dark`), optional `title`
+override, and internal `UserMenu` wiring. Uses ratio-ui's compound
+`<Navbar.Brand>` + `<Navbar.Content>` slots.
+
+The frontpage's dark variant now uses ratio-ui's new `overlay` + `glass`
+props to float above the hero image.
+
+UserMenu translation keys on the frontpage are standardised to the
+`common.labels.*` set already used by the other three layouts. Net
+visible change: the landing-page user menu now reads "Mine kurs"
+instead of "Dine kurs" for consistency.

--- a/apps/web/src/app/(admin)/layout.tsx
+++ b/apps/web/src/app/(admin)/layout.tsx
@@ -1,13 +1,11 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
-import { getTranslations } from 'next-intl/server';
 
 import { Unauthorized } from '@eventuras/ratio-ui/blocks/Unauthorized';
 import { Footer } from '@eventuras/ratio-ui/core/Footer';
 import { List } from '@eventuras/ratio-ui/core/List';
-import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
 
-import UserMenu from '@/components/eventuras/UserMenu';
+import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import { checkAuthorization } from '@/utils/auth/checkAuthorization';
 import getSiteSettings from '@/utils/site/getSiteSettings';
 
@@ -30,28 +28,10 @@ export default async function AdminLayout({ children }: Readonly<{ children: Rea
   }
 
   const site = await getSiteSettings();
-  const t = await getTranslations();
 
   return (
     <>
-      <Navbar
-        title={site?.name ?? 'Eventuras'}
-        bgColor="bg-transparent w-full py-1"
-        LinkComponent={Link}
-      >
-        <UserMenu
-          translations={{
-            loginLabel: t('common.labels.login'),
-            accountLabel: t('common.labels.account'),
-            adminLabel: t('common.labels.admin'),
-            userLabel: t('common.labels.user'),
-            logoutLabel: t('common.labels.logout'),
-            loggingOutLabel: t('common.labels.loggingOut'),
-            lightThemeLabel: t('common.labels.lightTheme'),
-            darkThemeLabel: t('common.labels.darkTheme'),
-          }}
-        />
-      </Navbar>
+      <SiteNavbar />
 
       <main id="main-content">{children}</main>
 

--- a/apps/web/src/app/(frontpage)/page.tsx
+++ b/apps/web/src/app/(frontpage)/page.tsx
@@ -3,15 +3,13 @@ import { getTranslations } from 'next-intl/server';
 
 import { Logger } from '@eventuras/logger';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
-import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
 import { Text } from '@eventuras/ratio-ui/core/Text';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 import { buildCoverImageStyle } from '@eventuras/ratio-ui/utils';
-import { Link } from '@eventuras/ratio-ui-next';
 
 import { EventGrid, FeaturedCollectionSection } from '@/components/event';
-import UserMenu from '@/components/eventuras/UserMenu';
+import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import {
   type EventCollectionDto,
   type EventDto,
@@ -106,29 +104,15 @@ export default async function Homepage() {
 
   return (
     <>
-      {/* Sticky navbar */}
-      <Navbar title={site?.frontpage.title ?? 'Eventuras'} bgDark LinkComponent={Link}>
-        <UserMenu
-          translations={{
-            loginLabel: t('common.buttons.login'),
-            userLabel: t('common.user.profile'),
-            accountLabel: t('common.labels.account'),
-            adminLabel: t('common.labels.admin'),
-            logoutLabel: t('common.labels.logout'),
-            loggingOutLabel: t('common.labels.loggingOut'),
-            lightThemeLabel: t('common.labels.lightTheme'),
-            darkThemeLabel: t('common.labels.darkTheme'),
-          }}
-        />
-      </Navbar>
+      <SiteNavbar variant="dark" title={site?.frontpage.title ?? 'Eventuras'} />
 
       {/* Hero section with background image */}
       <Section
         style={buildCoverImageStyle('/assets/images/mountains.jpg')}
-        className="min-h-[30vh] flex items-center"
+        className="min-h-[30vh] flex flex-col justify-end"
       >
-        <Container>
-          <Heading as="h1" onDark paddingBottom="sm" className="text-3xl md:text-4xl lg:text-5xl">
+        <Container className="pb-3">
+          <Heading as="h1" onDark paddingBottom="xs" className="text-3xl md:text-4xl lg:text-5xl">
             {site?.frontpage.introduction ?? 'Eventuras for your life!'}
           </Heading>
         </Container>

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
-import { getTranslations } from 'next-intl/server';
 
 import { Footer } from '@eventuras/ratio-ui/core/Footer';
 import { List } from '@eventuras/ratio-ui/core/List';
-import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
 
-import UserMenu from '@/components/eventuras/UserMenu';
+import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import getSiteSettings from '@/utils/site/getSiteSettings';
 
 /**
@@ -16,28 +14,10 @@ import getSiteSettings from '@/utils/site/getSiteSettings';
  */
 export default async function PublicLayout({ children }: Readonly<{ children: ReactNode }>) {
   const site = await getSiteSettings();
-  const t = await getTranslations();
 
   return (
     <>
-      <Navbar
-        title={site?.name ?? 'Eventuras'}
-        bgColor="bg-transparent w-full py-1"
-        LinkComponent={Link}
-      >
-        <UserMenu
-          translations={{
-            loginLabel: t('common.labels.login'),
-            accountLabel: t('common.labels.account'),
-            adminLabel: t('common.labels.admin'),
-            userLabel: t('common.labels.user'),
-            logoutLabel: t('common.labels.logout'),
-            loggingOutLabel: t('common.labels.loggingOut'),
-            lightThemeLabel: t('common.labels.lightTheme'),
-            darkThemeLabel: t('common.labels.darkTheme'),
-          }}
-        />
-      </Navbar>
+      <SiteNavbar />
 
       <main id="main-content">{children}</main>
 

--- a/apps/web/src/app/(user)/layout.tsx
+++ b/apps/web/src/app/(user)/layout.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
-import { getTranslations } from 'next-intl/server';
 
 import { Footer } from '@eventuras/ratio-ui/core/Footer';
 import { List } from '@eventuras/ratio-ui/core/List';
-import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
 
-import UserMenu from '@/components/eventuras/UserMenu';
+import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import getSiteSettings from '@/utils/site/getSiteSettings';
 
 // Force dynamic rendering for all user routes since they use authentication
@@ -20,28 +18,10 @@ export const dynamic = 'force-dynamic';
  */
 export default async function UserLayout({ children }: Readonly<{ children: ReactNode }>) {
   const site = await getSiteSettings();
-  const t = await getTranslations();
 
   return (
     <>
-      <Navbar
-        title={site?.name ?? 'Eventuras'}
-        bgColor="bg-transparent w-full py-1"
-        LinkComponent={Link}
-      >
-        <UserMenu
-          translations={{
-            loginLabel: t('common.labels.login'),
-            accountLabel: t('common.labels.account'),
-            adminLabel: t('common.labels.admin'),
-            userLabel: t('common.labels.user'),
-            logoutLabel: t('common.labels.logout'),
-            loggingOutLabel: t('common.labels.loggingOut'),
-            lightThemeLabel: t('common.labels.lightTheme'),
-            darkThemeLabel: t('common.labels.darkTheme'),
-          }}
-        />
-      </Navbar>
+      <SiteNavbar />
 
       <main id="main-content">{children}</main>
 

--- a/apps/web/src/components/eventuras/SiteNavbar.tsx
+++ b/apps/web/src/components/eventuras/SiteNavbar.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
+
+import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
+
+import UserMenu from '@/components/eventuras/UserMenu';
+import getSiteSettings from '@/utils/site/getSiteSettings';
+
+export type SiteNavbarVariant = 'primary' | 'transparent' | 'dark';
+
+export interface SiteNavbarProps {
+  variant?: SiteNavbarVariant;
+  /** Override the brand label. Defaults to `site.name`. */
+  title?: string;
+  sticky?: boolean;
+}
+
+const BG_COLOR_BY_VARIANT: Record<Exclude<SiteNavbarVariant, 'dark'>, string> = {
+  primary: 'bg-primary w-full py-1',
+  transparent: 'bg-transparent w-full py-1',
+};
+
+export default async function SiteNavbar({
+  variant = 'transparent',
+  title,
+  sticky,
+}: Readonly<SiteNavbarProps>) {
+  const site = await getSiteSettings();
+  const t = await getTranslations();
+
+  const brand = title ?? site?.name ?? 'Eventuras';
+  const isDark = variant === 'dark';
+
+  return (
+    <Navbar
+      {...(isDark
+        ? { bgDark: true, overlay: true, glass: true }
+        : { bgColor: BG_COLOR_BY_VARIANT[variant], sticky })}
+    >
+      <Navbar.Brand>
+        <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
+          {brand}
+        </Link>
+      </Navbar.Brand>
+      <Navbar.Content className="justify-end">
+        <UserMenu
+          translations={{
+            loginLabel: t('common.labels.login'),
+            accountLabel: t('common.labels.account'),
+            adminLabel: t('common.labels.admin'),
+            userLabel: t('common.labels.user'),
+            logoutLabel: t('common.labels.logout'),
+            loggingOutLabel: t('common.labels.loggingOut'),
+            lightThemeLabel: t('common.labels.lightTheme'),
+            darkThemeLabel: t('common.labels.darkTheme'),
+          }}
+        />
+      </Navbar.Content>
+    </Navbar>
+  );
+}

--- a/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
@@ -79,6 +79,34 @@ export const DoubleNavbar: Story = {
   ),
 };
 
+/**
+ * Glass navbar floating over a hero section. `overlay` anchors it to the
+ * viewport top without reserving layout space; `glass` gives the translucent
+ * dark bg + backdrop-blur; `bgDark` makes the text readable over the image.
+ * The nav scrolls away with the page (unlike `sticky`, which stays pinned).
+ */
+export const OverlayGlass: Story = {
+  render: () => (
+    <div className="relative">
+      <Navbar overlay glass bgDark>
+        <Navbar.Brand>
+          <a href="/" className="text-lg tracking-tight no-underline">
+            Eventuras
+          </a>
+        </Navbar.Brand>
+        <Navbar.Content className="justify-end">
+          <a href="/login" className="hover:underline">
+            Log in
+          </a>
+        </Navbar.Content>
+      </Navbar>
+      <section className="flex min-h-[60vh] items-center justify-center bg-linear-to-br from-slate-700 via-slate-900 to-black">
+        <h1 className="text-4xl text-white">Hero with a glass navbar on top</h1>
+      </section>
+    </div>
+  ),
+};
+
 /** Legacy API — still works, renders identically to the old Navbar. */
 export const LegacyTitle: Story = {
   args: {

--- a/libs/ratio-ui/src/core/Navbar/Navbar.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.tsx
@@ -7,8 +7,20 @@ export interface NavbarProps {
   bgDark?: boolean;
   /** Tailwind background class (default `bg-transparent`). */
   bgColor?: string;
-  /** Make navbar sticky at the top. */
+  /** Make navbar sticky at the top. Ignored when `overlay` is also set. */
   sticky?: boolean;
+  /**
+   * Float the navbar over the next sibling (e.g. a hero section) using
+   * absolute positioning. Unlike `sticky`, it doesn't reserve layout space
+   * and scrolls away with the page. Takes precedence over `sticky` when
+   * both are provided.
+   */
+  overlay?: boolean;
+  /**
+   * Translucent dark background with backdrop-blur. Composes with `overlay`
+   * for a glass hero-overlay look, and with `bgDark` for white text.
+   */
+  glass?: boolean;
   className?: string;
 
   // ── Legacy shorthand props (still supported, prefer Navbar.Brand) ──
@@ -56,6 +68,8 @@ const NavbarRoot = ({
   bgDark = false,
   bgColor,
   sticky = false,
+  overlay = false,
+  glass = false,
   className,
   // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
   title,
@@ -65,7 +79,13 @@ const NavbarRoot = ({
   LinkComponent,
 }: Readonly<NavbarProps>) => {
   const textColor = bgDark ? 'text-light' : 'text-dark dark:text-light';
-  const positionClass = sticky ? 'sticky top-0 z-50' : '';
+  // overlay takes precedence over sticky when both are passed.
+  const positionClass = overlay
+    ? 'absolute top-0 left-0 right-0 z-50'
+    : sticky
+      ? 'sticky top-0 z-50'
+      : '';
+  const glassClass = glass ? 'bg-black/20 dark:bg-white/10  backdrop-blur-md' : '';
   // CSS custom property so Brand/Content get the resolved color without
   // React context (which would require 'use client').
   const navbarColorVar = bgDark
@@ -76,10 +96,10 @@ const NavbarRoot = ({
   const LinkTag = LinkComponent ?? ('a' as React.ElementType);
 
   return (
-    <nav className={cn(bgColor, positionClass, textColor, navbarColorVar, 'm-0 p-0', className)}>
+    <nav className={cn(bgColor, positionClass, glassClass, textColor, navbarColorVar, 'm-0 p-0', className)}>
       <div
         className={cn(
-          'flex flex-wrap items-center mx-auto gap-3 py-2 px-3',
+          'container flex flex-wrap items-center mx-auto gap-3 py-2 px-3',
           hasLegacyTitle && 'justify-between',
         )}
       >

--- a/libs/ratio-ui/src/global.css
+++ b/libs/ratio-ui/src/global.css
@@ -11,6 +11,19 @@
 @plugin 'tailwindcss-react-aria-components';
 @source '**/*.tsx';
 
+/*
+ * Safelist utility classes that consumers (apps/*) commonly use but that
+ * aren't referenced inside ratio-ui itself. Without this they'd be stripped
+ * from the bundled ratio-ui.css because Tailwind only scans ratio-ui's own
+ * tsx files. Grow this list pragmatically as real needs surface.
+ */
+@source inline("pt-16 pt-20 pt-24 pt-28 pt-32 pt-40");
+@source inline("pb-16 pb-20 pb-24 pb-28 pb-32 pb-40");
+@source inline("mt-16 mt-20 mt-24 mt-28 mt-32 mt-40");
+@source inline("mb-16 mb-20 mb-24 mb-28 mb-32 mb-40");
+/* Hero/section viewport heights. */
+@source inline("min-h-[20vh] min-h-[30vh] min-h-[33vh] min-h-[40vh] min-h-[50vh] min-h-[60vh] min-h-[66vh] min-h-[70vh] min-h-[80vh]");
+
 /* Dark mode variant */
 @custom-variant dark (&:where(html[data-theme="dark"] &, body[data-theme="dark"] &, [data-theme="dark"] *));
 


### PR DESCRIPTION

- **ratio-ui:** new composable `overlay` (absolute, floats over next sibling) and `glass` (translucent + backdrop-blur) Navbar props. Inner content row now respects `container` so brand/nav align with page content instead of stretching to viewport edges.
- **apps/web:** four duplicated navbar blocks across `(public)`, `(user)`, `(admin)`, `(frontpage)` collapsed into a single `SiteNavbar` server component with a `variant` prop. Frontpage uses the new glass overlay over the hero image.
- Safelists common layout utilities (`pt/pb/mt/mb 16–40`, `min-h-[20vh]…[80vh]`) in the bundled `ratio-ui.css` so consumer apps can use them without their own Tailwind entry.
- UserMenu translation keys on the frontpage standardised to `common.labels.*` (shared with the other three layouts). Visible text change: landing page shows "Mine kurs" instead of "Dine kurs".

## Changes

### `@eventuras/ratio-ui` (minor)
- `<Navbar overlay glass bgDark>` — hero-overlay pattern in a single line.
- `container` on the inner flex row.
- New `OverlayGlass` Storybook story.
- Safelist of layout-offset utilities via `@source inline(...)` in `global.css`.

### `@eventuras/web` (patch)
- New `SiteNavbar` component in `src/components/eventuras/`.
- `(public)` / `(user)` / `(admin)` → `<SiteNavbar />` (default `variant="transparent"`).
- `(frontpage)` → `<SiteNavbar variant="dark" title={…} />`.
