### PR TITLE
feat(api): expose more registration fields and broaden PATCH surface

### DIFF
--- a/apps/api/docs/eventuras-v3.json
+++ b/apps/api/docs/eventuras-v3.json
@@ -1047,7 +1047,7 @@
           "Registrations"
         ],
         "summary": "Partially update a registration",
-        "description": "Updates specific fields of a registration. Only Status, Type, and Notes can be modified.",
+        "description": "Updates specific fields of a registration using JSON Merge Patch semantics. Settable fields: Status, Type, Notes, PaymentMethod, CertificateComment, CustomerVatNumber, CustomerInvoiceReference. Fields omitted from the body are untouched; string fields set to null clear the corresponding value.",
         "parameters": [
           {
             "name": "id",
@@ -6811,6 +6811,10 @@
             "type": "integer",
             "format": "int32"
           },
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          },
           "eventId": {
             "type": "integer",
             "format": "int32"
@@ -6832,6 +6836,12 @@
             ],
             "format": "int32"
           },
+          "certificateComment": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "notes": {
             "type": [
               "null",
@@ -6839,6 +6849,31 @@
             ]
           },
           "log": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "registrationTime": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Instant"
+              }
+            ]
+          },
+          "paymentMethod": {
+            "$ref": "#/components/schemas/PaymentProvider"
+          },
+          "customerVatNumber": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "customerInvoiceReference": {
             "type": [
               "null",
               "string"
@@ -6893,7 +6928,7 @@
                 "type": "null"
               },
               {
-                "description": "The registration status.",
+                "description": "The registration status. Cannot be explicitly null.",
                 "$ref": "#/components/schemas/RegistrationStatus"
               }
             ]
@@ -6904,7 +6939,7 @@
                 "type": "null"
               },
               {
-                "description": "The registration type.",
+                "description": "The registration type. Cannot be explicitly null.",
                 "$ref": "#/components/schemas/RegistrationType"
               }
             ]
@@ -6914,10 +6949,42 @@
               "null",
               "string"
             ],
-            "description": "Notes about the registration."
+            "description": "Notes about the registration. Explicit null clears the field."
+          },
+          "paymentMethod": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "description": "Payment method for the registration. Cannot be explicitly null.",
+                "$ref": "#/components/schemas/PaymentProvider"
+              }
+            ]
+          },
+          "certificateComment": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "Comment shown on the certificate. Explicit null clears the field."
+          },
+          "customerVatNumber": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "Customer VAT number for invoicing. Explicit null clears the field."
+          },
+          "customerInvoiceReference": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "description": "Customer invoice reference. Explicit null clears the field."
           }
         },
-        "description": "DTO for partial updates to a registration.\nOnly allows updating Status, Type, and Notes fields."
+        "description": "DTO for partial updates to a registration (JSON Merge Patch semantics).\n\nOnly fields present in the request body are applied. A field set to\n`null` clears the corresponding entity field (for nullable\nstring fields). Omitted fields are left untouched.\n\nPresence is tracked via property setters: the JSON deserializer only\ninvokes a setter when the field is in the payload, so a dedicated\nbacking flag can distinguish \"absent\" from \"explicit null\"."
       },
       "RegistrationStatus": {
         "enum": [

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationDto.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationDto.cs
@@ -9,6 +9,8 @@ using Eventuras.WebApi.Controllers.v3.Events;
 using Eventuras.WebApi.Controllers.v3.Events.Products;
 using Eventuras.WebApi.Controllers.v3.Orders;
 using Eventuras.WebApi.Controllers.v3.Users;
+using NodaTime;
+using static Eventuras.Domain.PaymentMethod;
 
 namespace Eventuras.WebApi.Controllers.v3.Registrations;
 
@@ -23,11 +25,17 @@ public class RegistrationDto
         bool includeOrders = true)
     {
         RegistrationId = registration.RegistrationId;
+        Uuid = registration.Uuid;
         EventId = registration.EventInfoId;
         UserId = registration.UserId;
         Status = registration.Status;
         Type = registration.Type;
         Notes = registration.Notes;
+        RegistrationTime = registration.RegistrationTime;
+        PaymentMethod = registration.PaymentMethod;
+        CertificateComment = registration.CertificateComment;
+        CustomerVatNumber = registration.CustomerVatNumber;
+        CustomerInvoiceReference = registration.CustomerInvoiceReference;
 
         if (includeOrders && registration.Orders != null)
         {
@@ -63,13 +71,19 @@ public class RegistrationDto
     }
 
     public int RegistrationId { get; init; }
+    public Guid Uuid { get; init; }
     public int EventId { get; init; }
     public Guid UserId { get; init; }
     public Registration.RegistrationStatus Status { get; init; }
     public Registration.RegistrationType Type { get; init; }
     public int? CertificateId { get; init; }
+    public string? CertificateComment { get; init; }
     public string? Notes { get; init; }
     public string? Log { get; set; }
+    public Instant? RegistrationTime { get; init; }
+    public PaymentProvider PaymentMethod { get; init; }
+    public string? CustomerVatNumber { get; init; }
+    public string? CustomerInvoiceReference { get; init; }
     public UserDto? User { get; init; }
     public EventDto? Event { get; init; }
     public IEnumerable<ProductOrderDto>? Products { get; init; }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationPatchDto.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationPatchDto.cs
@@ -1,50 +1,125 @@
 #nullable enable
 
 using Eventuras.Domain;
+using static Eventuras.Domain.PaymentMethod;
 using static Eventuras.Domain.Registration;
 
 namespace Eventuras.WebApi.Controllers.v3.Registrations;
 
 /// <summary>
-///     DTO for partial updates to a registration.
-///     Only allows updating Status, Type, and Notes fields.
+///     DTO for partial updates to a registration (JSON Merge Patch semantics).
+///
+///     Only fields present in the request body are applied. Nullable string
+///     fields set to <c>null</c> clear the corresponding entity value.
+///     Omitted fields are left untouched. Sending <c>null</c> on non-nullable
+///     fields (status/type/paymentMethod) is rejected with a 400 by the JSON
+///     deserializer.
+///
+///     Presence is tracked via property setters: the JSON deserializer only
+///     invokes a setter when the field is in the payload, so a dedicated
+///     backing flag can distinguish "absent" from "explicit null".
 /// </summary>
 public class RegistrationPatchDto
 {
-    /// <summary>
-    ///     The registration status.
-    /// </summary>
-    public RegistrationStatus? Status { get; set; }
+    private RegistrationStatus _status;
+    private bool _statusSet;
+    /// <summary>The registration status.</summary>
+    public RegistrationStatus Status
+    {
+        get => _status;
+        set { _status = value; _statusSet = true; }
+    }
 
-    /// <summary>
-    ///     The registration type.
-    /// </summary>
-    public RegistrationType? Type { get; set; }
+    private RegistrationType _type;
+    private bool _typeSet;
+    /// <summary>The registration type.</summary>
+    public RegistrationType Type
+    {
+        get => _type;
+        set { _type = value; _typeSet = true; }
+    }
 
-    /// <summary>
-    ///     Notes about the registration.
-    /// </summary>
-    public string? Notes { get; set; }
+    private string? _notes;
+    private bool _notesSet;
+    /// <summary>Notes about the registration. Explicit null clears the field.</summary>
+    public string? Notes
+    {
+        get => _notes;
+        set { _notes = value; _notesSet = true; }
+    }
 
-    /// <summary>
-    ///     Applies the changes from this DTO to a Registration entity.
-    /// </summary>
-    /// <param name="registration">The registration to update</param>
+    private PaymentProvider _paymentMethod;
+    private bool _paymentMethodSet;
+    /// <summary>Payment method for the registration.</summary>
+    public PaymentProvider PaymentMethod
+    {
+        get => _paymentMethod;
+        set { _paymentMethod = value; _paymentMethodSet = true; }
+    }
+
+    private string? _certificateComment;
+    private bool _certificateCommentSet;
+    /// <summary>Comment shown on the certificate. Explicit null clears the field.</summary>
+    public string? CertificateComment
+    {
+        get => _certificateComment;
+        set { _certificateComment = value; _certificateCommentSet = true; }
+    }
+
+    private string? _customerVatNumber;
+    private bool _customerVatNumberSet;
+    /// <summary>Customer VAT number for invoicing. Explicit null clears the field.</summary>
+    public string? CustomerVatNumber
+    {
+        get => _customerVatNumber;
+        set { _customerVatNumber = value; _customerVatNumberSet = true; }
+    }
+
+    private string? _customerInvoiceReference;
+    private bool _customerInvoiceReferenceSet;
+    /// <summary>Customer invoice reference. Explicit null clears the field.</summary>
+    public string? CustomerInvoiceReference
+    {
+        get => _customerInvoiceReference;
+        set { _customerInvoiceReference = value; _customerInvoiceReferenceSet = true; }
+    }
+
+    /// <summary>Applies the changes from this DTO to a Registration entity.</summary>
     public void ApplyTo(Registration registration)
     {
-        if (Status.HasValue)
+        if (_statusSet)
         {
-            registration.Status = Status.Value;
+            registration.Status = Status;
         }
 
-        if (Type.HasValue)
+        if (_typeSet)
         {
-            registration.Type = Type.Value;
+            registration.Type = Type;
         }
 
-        if (Notes != null)
+        if (_paymentMethodSet)
+        {
+            registration.PaymentMethod = PaymentMethod;
+        }
+
+        if (_notesSet)
         {
             registration.Notes = Notes;
+        }
+
+        if (_certificateCommentSet)
+        {
+            registration.CertificateComment = CertificateComment;
+        }
+
+        if (_customerVatNumberSet)
+        {
+            registration.CustomerVatNumber = CustomerVatNumber;
+        }
+
+        if (_customerInvoiceReferenceSet)
+        {
+            registration.CustomerInvoiceReference = CustomerInvoiceReference;
         }
     }
 }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
@@ -218,7 +218,7 @@ public class RegistrationsController : ControllerBase
 
     [HttpPatch("{id}")]
     [EndpointSummary("Partially update a registration")]
-    [EndpointDescription("Updates specific fields of a registration. Only Status, Type, and Notes can be modified.")]
+    [EndpointDescription("Updates specific fields of a registration using JSON Merge Patch semantics. Settable fields: Status, Type, Notes, PaymentMethod, CertificateComment, CustomerVatNumber, CustomerInvoiceReference. Fields omitted from the body are untouched; string fields set to null clear the corresponding value.")]
     [ProducesResponseType(typeof(RegistrationDto), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(404)]

--- a/apps/api/tests/Eventuras.TestAbstractions/Eventuras.TestAbstractions.csproj
+++ b/apps/api/tests/Eventuras.TestAbstractions/Eventuras.TestAbstractions.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
     <PackageReference Include="xunit.v3.assert" Version="3.2.2" />
     <PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
   </ItemGroup>

--- a/apps/api/tests/Eventuras.TestAbstractions/HttpResponseMessageExtensions.cs
+++ b/apps/api/tests/Eventuras.TestAbstractions/HttpResponseMessageExtensions.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
 using Xunit;
 
 namespace Eventuras.TestAbstractions;
@@ -59,6 +61,9 @@ public static class HttpResponseMessageExtensions
             Converters = { new JsonStringEnumConverter() },
             PropertyNameCaseInsensitive = true
         };
+        // Match the API's NodaTime serialization so DTOs containing `Instant`,
+        // `LocalDate`, etc. round-trip through tests without manual converters.
+        options.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
         return await response.Content.ReadFromJsonAsync<TContent>(options, cancellationToken);
     }
 

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Registrations/RegistrationProductsControllerTest.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Registrations/RegistrationProductsControllerTest.cs
@@ -8,6 +8,8 @@ using Eventuras.Domain;
 using Eventuras.TestAbstractions;
 using Eventuras.WebApi.Controllers.v3.Registrations;
 using Eventuras.WebApi.Models;
+using NodaTime;
+using NodaTime.Serialization.SystemTextJson;
 using Xunit;
 
 namespace Eventuras.WebApi.Tests.Controllers.Registrations;
@@ -19,12 +21,19 @@ namespace Eventuras.WebApi.Tests.Controllers.Registrations;
 /// </summary>
 public class RegistrationProductsControllerTest : IClassFixture<CustomWebApiApplicationFactory<Program>>
 {
-    // JSON options matching the API's configuration (enums as strings)
-    private static readonly JsonSerializerOptions JsonOptions = new()
+    // JSON options matching the API's configuration (enums as strings + NodaTime).
+    private static readonly JsonSerializerOptions JsonOptions = CreateJsonOptions();
+
+    private static JsonSerializerOptions CreateJsonOptions()
     {
-        PropertyNameCaseInsensitive = true,
-        Converters = { new JsonStringEnumConverter() }
-    };
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new JsonStringEnumConverter() }
+        };
+        options.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb);
+        return options;
+    }
 
     private readonly CustomWebApiApplicationFactory<Program> _factory;
 

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Registrations/RegistrationsControllerTest.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Registrations/RegistrationsControllerTest.cs
@@ -850,6 +850,248 @@ public class RegistrationsControllerTest(CustomWebApiApplicationFactory<Program>
         return updated;
     }
 
+    #region PATCH Tests
+
+    [Fact]
+    public async Task Patch_Should_Require_Auth()
+    {
+        var client = factory.CreateClient();
+        var response = await client.PatchAsync("/v3/registrations/1", new { status = "Verified" });
+        response.CheckUnauthorized();
+    }
+
+    [Fact]
+    public async Task Patch_Should_Return_NotFound_For_Missing_Registration()
+    {
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync("/v3/registrations/10001", new { status = "Verified" });
+        response.CheckNotFound();
+    }
+
+    [Fact]
+    public async Task Patch_Should_Update_Status_And_Type()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { status = "Verified", type = "Student" });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity, updated =>
+        {
+            Assert.Equal(Registration.RegistrationStatus.Verified, updated.Status);
+            Assert.Equal(Registration.RegistrationType.Student, updated.Type);
+        });
+    }
+
+    [Fact]
+    public async Task Patch_Should_Update_PaymentMethod()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { paymentMethod = "StripeDirect" });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity,
+            updated => Assert.Equal(PaymentMethod.PaymentProvider.StripeDirect, updated.PaymentMethod));
+    }
+
+    [Fact]
+    public async Task Patch_Should_Update_CertificateComment()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { certificateComment = "Well done" });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity,
+            updated => Assert.Equal("Well done", updated.CertificateComment));
+    }
+
+    [Fact]
+    public async Task Patch_Should_Update_Customer_Vat_And_Invoice_Reference()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { customerVatNumber = "NO999888777", customerInvoiceReference = "PO-42" });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity, updated =>
+        {
+            Assert.Equal("NO999888777", updated.CustomerVatNumber);
+            Assert.Equal("PO-42", updated.CustomerInvoiceReference);
+        });
+    }
+
+    [Fact]
+    public async Task Patch_Should_Null_Notes_When_Explicit_Null()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        // Seed notes so we can observe clearing them.
+        reg.Entity.Notes = "to be cleared";
+        await scope.Db.SaveChangesAsync();
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        // Anonymous object with an explicit null string serializes as `"notes":null`
+        // under System.Text.Json's default settings (DefaultIgnoreCondition = Never),
+        // which is what we need to trigger the JSON-Merge-Patch clear semantics.
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { notes = (string)null });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity, updated => Assert.Null(updated.Notes));
+    }
+
+    [Fact]
+    public async Task Patch_Should_Null_CertificateComment_When_Explicit_Null()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        reg.Entity.CertificateComment = "to be cleared";
+        await scope.Db.SaveChangesAsync();
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { certificateComment = (string)null });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity, updated => Assert.Null(updated.CertificateComment));
+    }
+
+    [Fact]
+    public async Task Patch_Should_Null_CustomerVatNumber_When_Explicit_Null()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        reg.Entity.CustomerVatNumber = "NO999888777";
+        await scope.Db.SaveChangesAsync();
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { customerVatNumber = (string)null });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity, updated => Assert.Null(updated.CustomerVatNumber));
+    }
+
+    [Fact]
+    public async Task Patch_Should_Null_CustomerInvoiceReference_When_Explicit_Null()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        reg.Entity.CustomerInvoiceReference = "PO-42";
+        await scope.Db.SaveChangesAsync();
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { customerInvoiceReference = (string)null });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity,
+            updated => Assert.Null(updated.CustomerInvoiceReference));
+    }
+
+    [Fact]
+    public async Task Patch_Should_Reject_Explicit_Null_For_NonNullable_Status()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        // Non-nullable enum: explicit null must not silently succeed.
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { status = (string)null });
+
+        response.CheckBadRequest();
+    }
+
+    [Fact]
+    public async Task Patch_Should_Not_Touch_Notes_When_Field_Absent()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        reg.Entity.Notes = "keep me";
+        await scope.Db.SaveChangesAsync();
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        // Body only sets status — notes must stay as "keep me".
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new { status = "Verified" });
+        response.CheckOk();
+
+        await LoadAndCheckAsync(scope, reg.Entity, updated =>
+        {
+            Assert.Equal("keep me", updated.Notes);
+            Assert.Equal(Registration.RegistrationStatus.Verified, updated.Status);
+        });
+    }
+
+    [Fact]
+    public async Task Patch_Response_Should_Include_New_Fields()
+    {
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync();
+        using var reg = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
+        var response = await client.PatchAsync($"/v3/registrations/{reg.Entity.RegistrationId}",
+            new
+            {
+                certificateComment = "ok",
+                customerVatNumber = "NO123",
+                customerInvoiceReference = "REF-1",
+                paymentMethod = "StripeDirect",
+            });
+        var dto = await response.AsTokenAsync();
+
+        Assert.Equal(reg.Entity.Uuid.ToString(), dto.GetProperty("uuid").GetString());
+        Assert.Equal("ok", dto.GetProperty("certificateComment").GetString());
+        Assert.Equal("NO123", dto.GetProperty("customerVatNumber").GetString());
+        Assert.Equal("REF-1", dto.GetProperty("customerInvoiceReference").GetString());
+        Assert.Equal("StripeDirect", dto.GetProperty("paymentMethod").GetString());
+        Assert.NotEqual(JsonValueKind.Null, dto.GetProperty("registrationTime").ValueKind);
+    }
+
+    #endregion
+
     public static object[][] GetRegInfoWithAdditionalInfoFilled()
         => new[]
         {

--- a/libs/event-sdk/src/client-next/core/serverSentEvents.gen.ts
+++ b/libs/event-sdk/src/client-next/core/serverSentEvents.gen.ts
@@ -79,7 +79,7 @@ export type ServerSentEventsResult<TData = unknown, TReturn = void, TNext = unkn
   >;
 };
 
-export const createSseClient = <TData = unknown>({
+export function createSseClient<TData = unknown>({
   onRequest,
   onSseError,
   onSseEvent,
@@ -91,7 +91,7 @@ export const createSseClient = <TData = unknown>({
   sseSleepFn,
   url,
   ...options
-}: ServerSentEventsOptions): ServerSentEventsResult<TData> => {
+}: ServerSentEventsOptions): ServerSentEventsResult<TData> {
   let lastEventId: string | undefined;
 
   const sleep = sseSleepFn ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
@@ -155,8 +155,7 @@ export const createSseClient = <TData = unknown>({
             const { done, value } = await reader.read();
             if (done) break;
             buffer += value;
-            // Normalize line endings: CRLF -> LF, then CR -> LF
-            buffer = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+            buffer = buffer.replace(/\r\n?/g, '\n'); // normalize line endings
 
             const chunks = buffer.split('\n\n');
             buffer = chunks.pop() ?? '';
@@ -240,4 +239,4 @@ export const createSseClient = <TData = unknown>({
   const stream = createStream();
 
   return { stream };
-};
+}

--- a/libs/event-sdk/src/client-next/sdk.gen.ts
+++ b/libs/event-sdk/src/client-next/sdk.gen.ts
@@ -101,7 +101,7 @@ export const getV3RegistrationsById = <ThrowOnError extends boolean = false>(opt
 /**
  * Partially update a registration
  *
- * Updates specific fields of a registration. Only Status, Type, and Notes can be modified.
+ * Updates specific fields of a registration using JSON Merge Patch semantics. Settable fields: Status, Type, Notes, PaymentMethod, CertificateComment, CustomerVatNumber, CustomerInvoiceReference. Fields omitted from the body are untouched; string fields set to null clear the corresponding value.
  */
 export const patchV3RegistrationsById = <ThrowOnError extends boolean = false>(options: Options<PatchV3RegistrationsByIdData, ThrowOnError>) => (options.client ?? client).patch<PatchV3RegistrationsByIdResponses, PatchV3RegistrationsByIdErrors, ThrowOnError>({
     url: '/v3/registrations/{id}',

--- a/libs/event-sdk/src/client-next/types.gen.ts
+++ b/libs/event-sdk/src/client-next/types.gen.ts
@@ -635,13 +635,19 @@ export type RegistrationCustomerInfoDto = {
 
 export type RegistrationDto = {
     registrationId?: number;
+    uuid?: string;
     eventId?: number;
     userId?: string;
     status?: RegistrationStatus;
     type?: RegistrationType;
     certificateId?: null | number;
+    certificateComment?: null | string;
     notes?: null | string;
     log?: null | string;
+    registrationTime?: null | Instant;
+    paymentMethod?: PaymentProvider;
+    customerVatNumber?: null | string;
+    customerInvoiceReference?: null | string;
     user?: null | UserDto;
     event?: null | EventDto;
     products?: null | Array<ProductOrderDto>;
@@ -649,16 +655,36 @@ export type RegistrationDto = {
 };
 
 /**
- * DTO for partial updates to a registration.
- * Only allows updating Status, Type, and Notes fields.
+ * DTO for partial updates to a registration (JSON Merge Patch semantics).
+ *
+ * Only fields present in the request body are applied. A field set to
+ * `null` clears the corresponding entity field (for nullable
+ * string fields). Omitted fields are left untouched.
+ *
+ * Presence is tracked via property setters: the JSON deserializer only
+ * invokes a setter when the field is in the payload, so a dedicated
+ * backing flag can distinguish "absent" from "explicit null".
  */
 export type RegistrationPatchDto = {
     status?: null | RegistrationStatus;
     type?: null | RegistrationType;
     /**
-     * Notes about the registration.
+     * Notes about the registration. Explicit null clears the field.
      */
     notes?: null | string;
+    paymentMethod?: null | PaymentProvider;
+    /**
+     * Comment shown on the certificate. Explicit null clears the field.
+     */
+    certificateComment?: null | string;
+    /**
+     * Customer VAT number for invoicing. Explicit null clears the field.
+     */
+    customerVatNumber?: null | string;
+    /**
+     * Customer invoice reference. Explicit null clears the field.
+     */
+    customerInvoiceReference?: null | string;
 };
 
 export const RegistrationStatus = {


### PR DESCRIPTION
Adds to RegistrationDto: uuid, registrationTime, paymentMethod, certificateComment, customerVatNumber, customerInvoiceReference — fields that were stored on the entity but never serialized to API consumers.

Extends RegistrationPatchDto with paymentMethod, certificateComment, customerVatNumber, customerInvoiceReference. Adopts JSON Merge Patch semantics via per-property setter tracking: absent fields are left untouched, and nullable string fields set to null clear the stored value. Notes now follows the same pattern — reversing the previous "null = ignore" behaviour so admins can actually clear a note via PATCH.

Adds a PATCH integration test suite (previously absent) covering status/type updates, each new patchable field, null-clearing of Notes, and absent-field preservation. Also threads NodaTime serialization through the shared test HTTP helpers so DTOs containing Instant round- trip in CheckOkAndGetContentAsync<T>.

Regenerates the TS SDK against the updated OpenAPI spec so consumers pick up the new read and patch surfaces.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>