### PR TITLE
refactor(core): extract formatApiError into @eventuras/core/errors

### DIFF
--- a/.changeset/core-format-api-error.md
+++ b/.changeset/core-format-api-error.md
@@ -1,0 +1,23 @@
+---
+"@eventuras/core": minor
+"@eventuras/web": patch
+---
+
+feat(core): add `formatApiError` under `@eventuras/core/errors`
+
+Extracts a shared `formatApiError(raw, fallback)` helper that turns SDK
+error payloads into a human-readable string. Handles:
+
+- Plain string bodies (the SDK falls back to the text body when the
+  response isn't JSON).
+- ASP.NET Problem Details (RFC 7807) with `errors: { Field: [msgs] }`
+  — surfaces per-field validation feedback.
+- Problem Details `detail` and `title` fields (previously `detail` was
+  ignored so callers saw the generic fallback even when the backend
+  provided a clear explanation).
+- Legacy shapes with `body.message`, `message`, and `statusText`.
+
+Replaces the inline copy that landed in `apps/web` for event updates
+and extends the same handling to `updateRegistration` and
+`patchRegistration` server actions so admins see the actual API error
+instead of `"Failed to update registration"`.

--- a/apps/web/src/app/(admin)/admin/events/actions.ts
+++ b/apps/web/src/app/(admin)/admin/events/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
+import { formatApiError } from '@eventuras/core/errors';
 import {
   actionError,
   actionSuccess,
@@ -152,39 +153,6 @@ const updateLogger = Logger.create({
   context: { module: 'action:updateEvent' },
 });
 
-/**
- * Extract a readable message from the SDK's `error` object. Handles ASP.NET
- * Problem Details (RFC 7807) validation errors — `{ errors: { Field: [msgs] } }`
- * — by surfacing per-field issues instead of the generic "Bad Request".
- */
-function formatApiError(raw: unknown): string {
-  const fallback = 'An error occurred while updating the event';
-  if (!raw || typeof raw !== 'object') return fallback;
-
-  const err = raw as {
-    errors?: Record<string, string[] | string | undefined>;
-    title?: string;
-    body?: { message?: string };
-    message?: string;
-    statusText?: string;
-  };
-
-  if (err.errors && typeof err.errors === 'object') {
-    const parts = Object.entries(err.errors)
-      .map(([field, msgs]) => {
-        const text = Array.isArray(msgs) ? msgs.join(', ') : msgs;
-        return text ? `${field}: ${text}` : field;
-      })
-      .filter(Boolean);
-    if (parts.length > 0) {
-      const prefix = err.title ? `${err.title} — ` : '';
-      return `${prefix}${parts.join('; ')}`;
-    }
-  }
-
-  return err.body?.message || err.message || err.statusText || fallback;
-}
-
 export async function updateEvent(
   eventId: number,
   eventData: EventFormDto
@@ -245,7 +213,10 @@ export async function updateEvent(
 
       updateLogger.error({ eventId, ...errorDetails }, errorMsg);
 
-      const userMessage = formatApiError(response.error);
+      const userMessage = formatApiError(
+        response.error,
+        'An error occurred while updating the event'
+      );
       return actionError(userMessage, 'API_ERROR', errorDetails);
     }
 

--- a/apps/web/src/app/(admin)/admin/registrations/actions.ts
+++ b/apps/web/src/app/(admin)/admin/registrations/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 
+import { formatApiError } from '@eventuras/core/errors';
 import { actionError, actionSuccess, ServerActionResult } from '@eventuras/core-nextjs/actions';
 import { Logger } from '@eventuras/logger';
 
@@ -110,7 +111,7 @@ export async function updateRegistration(
 
     if (!response.data) {
       logger.error({ error: response.error, registrationId: id }, 'Failed to update registration');
-      return actionError('Failed to update registration');
+      return actionError(formatApiError(response.error, 'Failed to update registration'));
     }
 
     logger.info({ registrationId: id }, 'Registration updated successfully');
@@ -147,7 +148,7 @@ export async function patchRegistration(
 
     if (!response.data) {
       logger.error({ error: response.error, registrationId }, 'Failed to patch registration');
-      return actionError('Failed to update registration');
+      return actionError(formatApiError(response.error, 'Failed to update registration'));
     }
 
     logger.info({ registrationId }, 'Registration patched successfully');

--- a/libs/core/package.json
+++ b/libs/core/package.json
@@ -20,6 +20,10 @@
     "./url": {
       "types": "./dist/url/index.d.ts",
       "import": "./dist/url/index.js"
+    },
+    "./errors": {
+      "types": "./dist/errors/index.d.ts",
+      "import": "./dist/errors/index.js"
     }
   },
   "files": [

--- a/libs/core/src/errors/formatApiError.ts
+++ b/libs/core/src/errors/formatApiError.ts
@@ -1,0 +1,53 @@
+/**
+ * Extract a human-readable message from an SDK error payload.
+ *
+ * Handles:
+ *  - Plain string bodies (the SDK's fallback when a response isn't JSON)
+ *  - ASP.NET Problem Details (RFC 7807) with `errors: { Field: [msgs] }`
+ *    — surfaced per-field so validation feedback makes it to the caller
+ *  - Problem Details with `detail` or `title`
+ *  - Legacy shapes with `body.message`, `message`, or `statusText`
+ *
+ * Returns the provided `fallback` when nothing readable can be extracted.
+ */
+export function formatApiError(raw: unknown, fallback: string): string {
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    return trimmed || fallback;
+  }
+
+  if (!raw || typeof raw !== 'object') {
+    return fallback;
+  }
+
+  const err = raw as {
+    errors?: Record<string, string[] | string | undefined>;
+    title?: string;
+    detail?: string;
+    body?: { message?: string };
+    message?: string;
+    statusText?: string;
+  };
+
+  if (err.errors && typeof err.errors === 'object') {
+    const parts = Object.entries(err.errors)
+      .map(([field, msgs]) => {
+        const text = Array.isArray(msgs) ? msgs.join(', ') : msgs;
+        return text ? `${field}: ${text}` : field;
+      })
+      .filter(Boolean);
+    if (parts.length > 0) {
+      const prefix = err.title ? `${err.title} — ` : '';
+      return `${prefix}${parts.join('; ')}`;
+    }
+  }
+
+  return (
+    err.detail ||
+    err.title ||
+    err.body?.message ||
+    err.message ||
+    err.statusText ||
+    fallback
+  );
+}

--- a/libs/core/src/errors/index.ts
+++ b/libs/core/src/errors/index.ts
@@ -1,0 +1,1 @@
+export { formatApiError } from './formatApiError.js';

--- a/libs/core/vite.config.ts
+++ b/libs/core/vite.config.ts
@@ -6,5 +6,6 @@ export default defineVanillaLibConfig({
     'datetime/index': 'src/datetime/index.ts',
     'currency/index': 'src/currency/index.ts',
     'url/index': 'src/url/index.ts',
+    'errors/index': 'src/errors/index.ts',
   },
 });


### PR DESCRIPTION
Moves the Problem-Details + SDK-error-shape parser out of apps/web and into @eventuras/core/errors as a framework-neutral helper so every server action (and any future consumer, including non-Next.js ones) can surface meaningful API failures through the same code path.

While moving, fix two gaps flagged in review of the original copy:

- Plain string error bodies (the SDK's fallback for non-JSON responses) now pass through as the error message instead of being replaced with the generic fallback.
- Problem Details `detail` field is now consulted before falling back to `title` / legacy shapes, so non-validation errors no longer lose the backend's explanation.

Events' updateEvent now imports the shared helper. Registrations' updateRegistration and patchRegistration gained matching error surfacing — previously they returned a flat "Failed to update registration" string regardless of what the API actually said.