### PR TITLE
feat(web): admin patch for payment method on order

### DIFF
--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -198,6 +198,7 @@
       "id": "Id",
       "items": "Items",
       "orderId": "Order id",
+      "paymentMethod": "Payment method",
       "price": "Price",
       "product": "Product",
       "quantity": "Quantity",

--- a/apps/web/locales/nb-NO/common.json
+++ b/apps/web/locales/nb-NO/common.json
@@ -197,6 +197,7 @@
       "id": "Id",
       "items": "Ordrelinjer",
       "orderId": "Ordre id",
+      "paymentMethod": "Betalingsmåte",
       "price": "Pris",
       "product": "Produkt",
       "quantity": "Antall",

--- a/apps/web/src/app/(admin)/admin/orders/Order.tsx
+++ b/apps/web/src/app/(admin)/admin/orders/Order.tsx
@@ -9,8 +9,10 @@ import { Table } from '@eventuras/ratio-ui/core/Table';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 
 import { OrderDto } from '@/lib/eventuras-sdk';
+import { getPaymentMethodLabel } from '@/lib/paymentMethod';
 
 import { OrderActionsMenu } from './OrderActionsMenu';
+import OrderPaymentMethodSelect from './OrderPaymentMethodSelect';
 type OrderProps = {
   order: OrderDto;
   admin?: boolean;
@@ -44,6 +46,16 @@ const Order: React.FC<OrderProps> = ({ admin, order }) => {
         <DescriptionList.Item>
           <DescriptionList.Term>{t('common.order.labels.date')}</DescriptionList.Term>
           <DescriptionList.Definition>{formatDateSpan(order.time!)}</DescriptionList.Definition>
+        </DescriptionList.Item>
+        <DescriptionList.Item>
+          <DescriptionList.Term>{t('common.order.labels.paymentMethod')}</DescriptionList.Term>
+          <DescriptionList.Definition>
+            {admin ? (
+              <OrderPaymentMethodSelect order={order} />
+            ) : (
+              getPaymentMethodLabel(order.paymentMethod)
+            )}
+          </DescriptionList.Definition>
         </DescriptionList.Item>
       </DescriptionList>
       <div>

--- a/apps/web/src/app/(admin)/admin/orders/OrderActionsMenu.tsx
+++ b/apps/web/src/app/(admin)/admin/orders/OrderActionsMenu.tsx
@@ -38,16 +38,20 @@ export const OrderActionsMenu = ({ order }: OrderActionsMenuProps) => {
   const handleVerifyOrder = async () => {
     if (!order.orderId) {
       logger.error('Order ID is required');
+      toast.error('Order ID is required');
       return;
     }
 
-    try {
-      await verifyOrderAction(order.orderId);
-      logger.info({ orderId: order.orderId }, 'Order verified successfully');
-      router.refresh();
-    } catch (error) {
-      logger.error({ error, orderId: order.orderId }, 'Failed to verify order');
+    const result = await verifyOrderAction(order.orderId);
+    if (!result.success) {
+      logger.error({ error: result.error, orderId: order.orderId }, 'Failed to verify order');
+      toast.error(result.error.message);
+      return;
     }
+
+    logger.info({ orderId: order.orderId }, 'Order verified successfully');
+    toast.success(result.message ?? 'Order verified');
+    router.refresh();
   };
 
   const handleInvoiceOrder = async () => {

--- a/apps/web/src/app/(admin)/admin/orders/OrderPaymentMethodSelect.tsx
+++ b/apps/web/src/app/(admin)/admin/orders/OrderPaymentMethodSelect.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Logger } from '@eventuras/logger';
+import { Select } from '@eventuras/ratio-ui/forms';
+import { useToast } from '@eventuras/ratio-ui/toast';
+
+import type { OrderDto, PaymentProvider } from '@/lib/eventuras-sdk';
+import { paymentMethodLabels } from '@/lib/paymentMethod';
+
+import { patchOrder } from './actions';
+
+const logger = Logger.create({
+  namespace: 'web:admin:orders',
+  context: { component: 'OrderPaymentMethodSelect' },
+});
+
+interface OrderPaymentMethodSelectProps {
+  order: OrderDto;
+  onUpdate?: (order: OrderDto) => void;
+}
+
+const OrderPaymentMethodSelect = ({ order, onUpdate }: OrderPaymentMethodSelectProps) => {
+  const toast = useToast();
+  // Local state lets the Select stay on the new value while we await patchOrder,
+  // and lets us roll back on failure without waiting for the parent to re-render.
+  const [selected, setSelected] = useState<PaymentProvider | undefined>(
+    order.paymentMethod ?? undefined
+  );
+
+  const handleChange = async (next: string) => {
+    if (!order.orderId || next === selected) {
+      return;
+    }
+
+    const previous = selected;
+    setSelected(next as PaymentProvider);
+
+    const result = await patchOrder(order.orderId, {
+      paymentMethod: next as PaymentProvider,
+    });
+
+    if (!result.success) {
+      logger.error(
+        { error: result.error, orderId: order.orderId },
+        'Failed to update payment method'
+      );
+      toast.error(result.error.message);
+      setSelected(previous);
+      return;
+    }
+
+    logger.info({ orderId: order.orderId, paymentMethod: next }, 'Payment method updated');
+    toast.success(result.message ?? 'Payment method updated');
+    if (onUpdate) onUpdate(result.data);
+  };
+
+  return (
+    <Select
+      aria-label="Payment method"
+      placeholder="Select payment method..."
+      options={paymentMethodLabels}
+      value={selected}
+      onSelectionChange={handleChange}
+    />
+  );
+};
+
+export default OrderPaymentMethodSelect;

--- a/apps/web/src/app/(admin)/admin/orders/actions.ts
+++ b/apps/web/src/app/(admin)/admin/orders/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 
+import { formatApiError } from '@eventuras/core/errors';
 import { actionError, actionSuccess, ServerActionResult } from '@eventuras/core-nextjs/actions';
 import { Logger } from '@eventuras/logger';
 
@@ -10,6 +11,7 @@ import {
   getV3Orders,
   InvoiceRequestDto,
   OrderDto,
+  OrderPatchDto,
   patchV3OrdersById,
   postV3Invoices,
 } from '@/lib/eventuras-sdk';
@@ -90,37 +92,48 @@ export async function getOrders(page: number = 1, pageSize: number = 50) {
   }
 }
 
-export async function verifyOrderAction(orderId: number) {
-  logger.info({ orderId }, 'Verifying order...');
-
-  const orgId = getOrganizationId();
+/**
+ * Apply a partial update to an order via PATCH. Callers can pass any subset
+ * of the {@link OrderPatchDto} shape (status, comments, paymentMethod).
+ */
+export async function patchOrder(
+  orderId: number,
+  patch: OrderPatchDto
+): Promise<ServerActionResult<OrderDto>> {
+  logger.info({ orderId, fields: Object.keys(patch) }, 'Patching order');
 
   try {
+    const orgId = getOrganizationId();
     const response = await patchV3OrdersById({
       client,
-      headers: {
-        'Eventuras-Org-Id': orgId,
-      },
-      path: {
-        id: orderId,
-      },
-      body: {
-        status: 'Verified',
-      },
+      headers: { 'Eventuras-Org-Id': orgId },
+      path: { id: orderId },
+      body: patch,
     });
 
-    if (response.error) {
-      logger.error({ orderId, error: response.error }, 'Failed to verify order');
-      throw new Error('Failed to verify order');
+    if (!response.data) {
+      logger.error({ orderId, error: response.error }, 'Failed to patch order');
+      return actionError(formatApiError(response.error, 'Failed to update order'));
     }
 
-    logger.info({ orderId }, 'Order verified successfully');
+    logger.info({ orderId }, 'Order patched successfully');
     revalidatePath('/admin/orders');
-    return { success: true };
+    revalidatePath(`/admin/orders/${orderId}`);
+    // Callers supply context-specific success toast text via `result.message ?? '...'`.
+    return actionSuccess(response.data);
   } catch (error) {
-    logger.error({ error, orderId }, 'Error verifying order');
-    throw error;
+    logger.error({ error, orderId }, 'Unexpected error patching order');
+    return actionError('An unexpected error occurred');
   }
+}
+
+/**
+ * Narrow helper: flip an order's status to Verified. Thin wrapper over
+ * `patchOrder` so existing callers keep working and get the same
+ * formatted-error + revalidate behaviour.
+ */
+export async function verifyOrderAction(orderId: number): Promise<ServerActionResult<OrderDto>> {
+  return patchOrder(orderId, { status: 'Verified' });
 }
 
 export async function invoiceOrderAction(orderId: number): Promise<ServerActionResult<void>> {
@@ -143,20 +156,10 @@ export async function invoiceOrderAction(orderId: number): Promise<ServerActionR
       logger.info({ orderId }, 'Invoice sent to accounting system successfully');
       revalidatePath('/admin/orders');
       return actionSuccess(undefined, 'Invoice sent to accounting system');
-    } else {
-      logger.error({ orderId, error: response.error }, 'Failed to create invoice');
-
-      // Extract error message from API response
-      const errorMessage =
-        typeof response.error === 'object' &&
-        response.error &&
-        'message' in response.error &&
-        typeof response.error.message === 'string'
-          ? response.error.message
-          : 'Failed to create invoice';
-
-      return actionError(errorMessage);
     }
+
+    logger.error({ orderId, error: response.error }, 'Failed to create invoice');
+    return actionError(formatApiError(response.error, 'Failed to create invoice'));
   } catch (error) {
     logger.error({ error, orderId }, 'Error creating invoice');
     return actionError(error instanceof Error ? error.message : 'An unexpected error occurred');

--- a/apps/web/src/app/(admin)/admin/registrations/Registration.tsx
+++ b/apps/web/src/app/(admin)/admin/registrations/Registration.tsx
@@ -12,12 +12,12 @@ import { Form, Select } from '@eventuras/smartform';
 
 import { CertificateActionsButton } from '@/components/eventuras/CertificateActionsButton';
 import {
-  PaymentProvider,
   RegistrationDto,
   RegistrationPatchDto,
   RegistrationStatus,
   RegistrationType,
 } from '@/lib/eventuras-sdk';
+import { getPaymentMethodLabel, paymentMethodLabels } from '@/lib/paymentMethod';
 
 import { patchRegistration } from './actions';
 import Order from '../orders/Order';
@@ -71,28 +71,7 @@ export const getTypeLabels = (t: TranslationFunction) => [
   { value: 'Artist' as RegistrationType, label: t('common.registrations.labels.artist') },
 ];
 
-/**
- * Payment method labels. Hardcoded strings until translations are added.
- */
-export const paymentMethodLabels: { value: PaymentProvider; label: string }[] = [
-  { value: 'EmailInvoice', label: 'Email invoice' },
-  { value: 'PowerOfficeEmailInvoice', label: 'PowerOffice email invoice' },
-  { value: 'PowerOfficeEHFInvoice', label: 'PowerOffice EHF invoice' },
-  { value: 'StripeInvoice', label: 'Stripe invoice' },
-  { value: 'StripeDirect', label: 'Stripe (direct)' },
-  { value: 'VippsInvoice', label: 'Vipps invoice' },
-  { value: 'VippsDirect', label: 'Vipps (direct)' },
-];
-
-export const getPaymentMethodLabel = (method?: PaymentProvider | null): string => {
-  if (!method) return '';
-  return paymentMethodLabels.find(x => x.value === method)?.label ?? method;
-};
-
-export const formatRegistrationTime = (
-  instant?: string | null,
-  locale?: string
-): string | null => {
+export const formatRegistrationTime = (instant?: string | null, locale?: string): string | null => {
   if (!instant) return null;
   const date = new Date(instant);
   if (Number.isNaN(date.getTime())) return null;

--- a/apps/web/src/lib/paymentMethod.ts
+++ b/apps/web/src/lib/paymentMethod.ts
@@ -1,0 +1,20 @@
+import type { PaymentProvider } from '@/lib/eventuras-sdk';
+
+/**
+ * Display labels for PaymentProvider values. Hardcoded until translations
+ * are added.
+ */
+export const paymentMethodLabels: { value: PaymentProvider; label: string }[] = [
+  { value: 'EmailInvoice', label: 'Email invoice' },
+  { value: 'PowerOfficeEmailInvoice', label: 'PowerOffice email invoice' },
+  { value: 'PowerOfficeEHFInvoice', label: 'PowerOffice EHF invoice' },
+  { value: 'StripeInvoice', label: 'Stripe invoice' },
+  { value: 'StripeDirect', label: 'Stripe (direct)' },
+  { value: 'VippsInvoice', label: 'Vipps invoice' },
+  { value: 'VippsDirect', label: 'Vipps (direct)' },
+];
+
+export const getPaymentMethodLabel = (method?: PaymentProvider | null): string => {
+  if (!method) return '';
+  return paymentMethodLabels.find(x => x.value === method)?.label ?? method;
+};


### PR DESCRIPTION
## Summary

Adds an inline payment-method Select on the admin Order card so admins can change an order's payment method without leaving the detail view. Mirrors the inline `RegistrationStatusSelect` pattern (auto-save on selection, toast feedback).

## Changes

### Shared location for payment method labels
Moves `paymentMethodLabels` + `getPaymentMethodLabel` out of `Registration.tsx` into `apps/web/src/lib/paymentMethod.ts` so orders and registrations share a single source instead of orders cross-importing from `admin/registrations/`.

### New server action
`patchOrder(orderId, patch)` — generic partial PATCH matching the shape of `patchRegistration`. Uses the shared `formatApiError` to surface backend validation errors.

### New client component
`OrderPaymentMethodSelect` — inline Select, auto-saves via `patchOrder`, toast feedback.

### Cleanup along the way
- `verifyOrderAction` is now a thin wrapper over `patchOrder` so both admin actions share the same formatted-error + revalidate path.
- `handleVerifyOrder` in `OrderActionsMenu` now surfaces a toast on failure instead of failing silently.
- `invoiceOrderAction` drops its inline error-shape extraction in favour of `formatApiError`.

Non-admin callers of `<Order>` still see the read-only label via `getPaymentMethodLabel`.

## Test plan

- [ ] As admin, open an order and change Payment method in the Select — toast confirms, value persists on reload.
- [ ] Change to a backend-invalid value (if any) — toast shows the API error via `formatApiError`.
- [ ] Click Verify on a Draft order with a bad state → toast now shows the failure instead of being silent.
- [ ] Non-admin rendering of `<Order>` (e.g. in `Registration.tsx` via orders nesting) still shows the read-only payment-method label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)