### PR TITLE
feat(core): 5xx-aware fallback in formatApiError

### DIFF
--- a/apps/web/src/app/(admin)/admin/events/actions.ts
+++ b/apps/web/src/app/(admin)/admin/events/actions.ts
@@ -11,6 +11,7 @@ import {
 } from '@eventuras/core-nextjs/actions';
 import { Logger } from '@eventuras/logger';
 
+import { readCorrelationIdFromResponse } from '@/lib/correlation-id';
 import { client } from '@/lib/eventuras-client';
 import {
   EventFormDto,
@@ -215,7 +216,11 @@ export async function updateEvent(
 
       const userMessage = formatApiError(
         response.error,
-        'An error occurred while updating the event'
+        'An error occurred while updating the event',
+        (response.response as unknown as { status?: number })?.status,
+        response.response instanceof Response
+          ? readCorrelationIdFromResponse(response.response)
+          : undefined
       );
       return actionError(userMessage, 'API_ERROR', errorDetails);
     }

--- a/apps/web/src/app/(admin)/admin/registrations/actions.ts
+++ b/apps/web/src/app/(admin)/admin/registrations/actions.ts
@@ -6,6 +6,7 @@ import { formatApiError } from '@eventuras/core/errors';
 import { actionError, actionSuccess, ServerActionResult } from '@eventuras/core-nextjs/actions';
 import { Logger } from '@eventuras/logger';
 
+import { readCorrelationIdFromResponse } from '@/lib/correlation-id';
 import { client } from '@/lib/eventuras-client';
 import {
   getV3Registrations,
@@ -111,7 +112,14 @@ export async function updateRegistration(
 
     if (!response.data) {
       logger.error({ error: response.error, registrationId: id }, 'Failed to update registration');
-      return actionError(formatApiError(response.error, 'Failed to update registration'));
+      return actionError(
+        formatApiError(
+          response.error,
+          'Failed to update registration',
+          response.response?.status,
+          response.response ? readCorrelationIdFromResponse(response.response) : undefined
+        )
+      );
     }
 
     logger.info({ registrationId: id }, 'Registration updated successfully');
@@ -148,7 +156,14 @@ export async function patchRegistration(
 
     if (!response.data) {
       logger.error({ error: response.error, registrationId }, 'Failed to patch registration');
-      return actionError(formatApiError(response.error, 'Failed to update registration'));
+      return actionError(
+        formatApiError(
+          response.error,
+          'Failed to update registration',
+          response.response?.status,
+          response.response ? readCorrelationIdFromResponse(response.response) : undefined
+        )
+      );
     }
 
     logger.info({ registrationId }, 'Registration patched successfully');

--- a/libs/core/src/errors/formatApiError.ts
+++ b/libs/core/src/errors/formatApiError.ts
@@ -8,16 +8,31 @@
  *  - Problem Details with `detail` or `title`
  *  - Legacy shapes with `body.message`, `message`, or `statusText`
  *
- * Returns the provided `fallback` when nothing readable can be extracted.
+ * When nothing readable can be extracted, falls back to a status-aware
+ * synthetic message for 5xx responses — servers often return an empty body
+ * on unhandled exceptions, and "Failed to update X" hides that it's a
+ * server problem, not the caller's. Falls back to the caller-supplied
+ * `fallback` otherwise.
  */
-export function formatApiError(raw: unknown, fallback: string): string {
+export function formatApiError(
+  raw: unknown,
+  fallback: string,
+  statusCode?: number,
+  correlationId?: string | null
+): string {
+  const reference = correlationId ? `Reference ${correlationId}. ` : '';
+  const serverFallback =
+    statusCode != null && statusCode >= 500
+      ? `Server error (${statusCode}). ${reference}Please try again or contact support if the problem persists.`
+      : null;
+
   if (typeof raw === 'string') {
     const trimmed = raw.trim();
-    return trimmed || fallback;
+    return trimmed || serverFallback || fallback;
   }
 
   if (!raw || typeof raw !== 'object') {
-    return fallback;
+    return serverFallback || fallback;
   }
 
   const err = raw as {
@@ -48,6 +63,7 @@ export function formatApiError(raw: unknown, fallback: string): string {
     err.body?.message ||
     err.message ||
     err.statusText ||
+    serverFallback ||
     fallback
   );
 }


### PR DESCRIPTION
## Summary

When the backend returns a 5xx with an empty body (common for unhandled exceptions), callers currently surface a flat "Failed to update X" toast, which hides that it's a server problem rather than something the user can fix.

Adding an optional `statusCode` argument to `formatApiError` lets callers pass the HTTP status so the helper can substitute a server-aware fallback:

> Server error (500). Please try again or contact support if the problem persists.

…when nothing readable can be extracted from the response.

Existing two-arg callers are unaffected. Events and registrations actions now pass `response.response?.status`.

## Motivating incident

`PATCH /v3/registrations/480 { status: "Attended" }` returned 500 with an empty body earlier today. Admin saw the generic toast and had no way to distinguish from a validation error. With this change the toast would instead say "Server error (500). …", making it clear the user did nothing wrong.

(The underlying backend bug causing the 500 is a separate investigation.)

## Test plan

- [ ] Simulate a 500 with empty body (e.g. a registration PATCH against the incident scenario) → toast shows the server-error message with status code.
- [ ] 400 validation error → unchanged behaviour, per-field Problem-Details message surfaces.
- [ ] 400 with plain-string body → unchanged behaviour, string surfaces.
- [ ] Two-arg callers (callers that don't pass `statusCode` yet) → no behavioural change.

## Follow-up

Orders actions and any remaining server actions can adopt the 3-arg form as they're touched; not strictly required since the helper is backwards-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)