### PR TITLE
fix(api): preserve correlation id + Problem Details on unhandled exceptions

### DIFF
--- a/apps/api/src/Eventuras.WebApi/CorrelationIdMiddleware.cs
+++ b/apps/api/src/Eventuras.WebApi/CorrelationIdMiddleware.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Eventuras.Services.Constants;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Sentry;
 
 namespace Eventuras.WebApi;
 
@@ -36,6 +37,10 @@ public partial class CorrelationIdMiddleware
 
         context.TraceIdentifier = correlationId;
         context.Response.Headers[Api.CorrelationIdHeader] = correlationId;
+
+        // Tag the Sentry/GlitchTip scope so captured events carry the same id
+        // the client sees in the response header and the logs.
+        SentrySdk.ConfigureScope(scope => scope.SetTag("correlation_id", correlationId));
 
         using (_logger.BeginScope(new Dictionary<string, object>
         {

--- a/apps/api/src/Eventuras.WebApi/Program.cs
+++ b/apps/api/src/Eventuras.WebApi/Program.cs
@@ -106,6 +106,20 @@ builder.Services.AddApplicationServices(builder.Configuration);
 builder.Services.AddMemoryCache();
 builder.Services.Configure<AuthSettings>(builder.Configuration.GetSection("Auth"));
 
+// Problem Details for unhandled exceptions. Populates `traceId` from the
+// correlation ID and re-sets the X-Correlation-Id response header after
+// ASP.NET's exception middleware clears response state — so clients can
+// still look the failure up in logs.
+builder.Services.AddProblemDetails(options =>
+{
+    options.CustomizeProblemDetails = ctx =>
+    {
+        var correlationId = ctx.HttpContext.TraceIdentifier;
+        ctx.ProblemDetails.Extensions["traceId"] = correlationId;
+        ctx.HttpContext.Response.Headers[Api.CorrelationIdHeader] = correlationId;
+    };
+});
+
 builder.Services.AddCors(options =>
 {
     var origins =
@@ -169,6 +183,11 @@ app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseWhen(
     ctx => !ctx.Request.Path.StartsWithSegments("/health"),
     branch => branch.UseSerilogRequestLogging());
+
+// Production-style exception handler — renders Problem Details (with traceId
+// and re-applied correlation-id header). DeveloperExceptionPage is pushed on
+// top in dev/tests so contributors still see the full stack trace.
+app.UseExceptionHandler();
 
 if (app.Environment.IsDevelopment() || app.Environment.IsEnvironment("IntegrationTests"))
 {


### PR DESCRIPTION
## Summary

ASP.NET's default exception handling clears response state before writing the 500, which strips the `X-Correlation-Id` header our `CorrelationIdMiddleware` set. Clients saw 500 responses with empty bodies and no correlation id — admins had no way to report the incident and support had nothing to look up.

## Changes

- **`AddProblemDetails`** with a customizer that re-applies `X-Correlation-Id` from `HttpContext.TraceIdentifier` after the exception handler clears response state, and adds the same value as `traceId` in the Problem Details body — correlation id reaches the client via both channels.
- **`app.UseExceptionHandler()`** unconditionally. `DeveloperExceptionPage` still layers on top in Development / IntegrationTests so contributors see the full stack locally.
- **`SentrySdk.ConfigureScope`** in `CorrelationIdMiddleware` tags the current scope with `correlation_id` so captured events in Sentry / GlitchTip carry the same id.

## Motivating incident

`PATCH /v3/registrations/480` returned 500 with an empty body and `correlationId: null` on the client side, blocking triage. With this change the client would receive:

- `X-Correlation-Id: <id>` header
- `{ "status": 500, "title": "...", "traceId": "<id>" }` body

and the same id would be attached to the corresponding Sentry event.

## Test plan

- [ ] Trigger a 500 (e.g. the failing registration PATCH) → response has `X-Correlation-Id` header, body is Problem Details JSON with `traceId`.
- [ ] Dev environment → `DeveloperExceptionPage` still shows full stack in the browser.
- [ ] Integration tests pass (preserved stack-trace visibility for assertions that inspect exceptions).
- [ ] Sentry/GlitchTip event for an API exception shows `correlation_id` tag matching the response header.

## Paired client change

PR #1341 already teaches the frontend helper to surface `Reference <id>` in toasts when correlation id is present on the response — so this PR closes the loop: backend emits it, frontend shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)