### PR TITLE
feat(ratio-ui): Timeline compound component (beta)

### DIFF
--- a/.changeset/ratio-ui-timeline-beta.md
+++ b/.changeset/ratio-ui-timeline-beta.md
@@ -1,0 +1,37 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+feat(core): add `Timeline` component (beta)
+
+New compound component `Timeline` + `Timeline.Item` under
+`@eventuras/ratio-ui/core/Timeline` for rendering chronological event
+lists — audit logs, order history, registration activity, and the
+upcoming BusinessEvent feed.
+
+```tsx
+import { Timeline } from '@eventuras/ratio-ui/core/Timeline';
+
+<Timeline>
+  <Timeline.Item
+    timestamp="2026-04-19 10:22"
+    title="Order created"
+    status="success"
+    actor="Ada Lovelace"
+  />
+  <Timeline.Item
+    timestamp="2026-04-19 10:25"
+    title="Payment method updated"
+    actor="Ada Lovelace"
+  >
+    Changed from Email invoice to EHF invoice.
+  </Timeline.Item>
+</Timeline>
+```
+
+Props on `Timeline.Item`: `timestamp`, `title`, optional `actor`,
+`status` (controls dot color), `icon` (replaces the dot), and
+`children` for additional metadata or supporting content.
+
+Marked as **beta** via a `@beta` JSDoc tag. Prop shape and visuals may
+change before the component is promoted out of beta.

--- a/libs/ratio-ui/src/core/Timeline/Timeline.stories.tsx
+++ b/libs/ratio-ui/src/core/Timeline/Timeline.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Timeline } from './Timeline';
+
+const meta: Meta<typeof Timeline> = {
+  title: 'Core/Timeline (beta)',
+  component: Timeline,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Timeline>;
+
+export const Basic: Story = {
+  render: (args) => (
+    <Timeline {...args}>
+      <Timeline.Item
+        timestamp="2026-04-19 10:22"
+        title="Order created"
+        status="success"
+        actor="Ada Lovelace"
+      />
+      <Timeline.Item
+        timestamp="2026-04-19 10:25"
+        title="Payment method updated"
+        actor="Ada Lovelace"
+      />
+      <Timeline.Item
+        timestamp="2026-04-19 11:00"
+        title="Order verified"
+        status="info"
+      />
+    </Timeline>
+  ),
+};
+
+export const WithMetadata: Story = {
+  render: (args) => (
+    <Timeline {...args}>
+      <Timeline.Item
+        timestamp="2026-04-19 10:22"
+        title="Order created"
+        status="success"
+        actor="Ada Lovelace"
+      >
+        <pre className="rounded bg-neutral-100 p-2 text-xs dark:bg-neutral-900">
+{JSON.stringify({ orderId: 42, total: 1200 }, null, 2)}
+        </pre>
+      </Timeline.Item>
+      <Timeline.Item
+        timestamp="2026-04-19 10:25"
+        title="Payment method updated"
+        actor="Ada Lovelace"
+      >
+        <div>Changed from <strong>Email invoice</strong> to <strong>EHF invoice</strong>.</div>
+      </Timeline.Item>
+    </Timeline>
+  ),
+};
+
+export const AllStatuses: Story = {
+  render: (args) => (
+    <Timeline {...args}>
+      <Timeline.Item timestamp="10:00" title="Neutral event" status="neutral" />
+      <Timeline.Item timestamp="10:05" title="Info event" status="info" />
+      <Timeline.Item timestamp="10:10" title="Success event" status="success" />
+      <Timeline.Item timestamp="10:15" title="Warning event" status="warning" />
+      <Timeline.Item timestamp="10:20" title="Error event" status="error" />
+    </Timeline>
+  ),
+};

--- a/libs/ratio-ui/src/core/Timeline/Timeline.tsx
+++ b/libs/ratio-ui/src/core/Timeline/Timeline.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import type { Status } from '../../tokens/colors';
+import { cn } from '../../utils/cn';
+
+const dotStatusClasses: Record<Status, string> = {
+  neutral: 'bg-neutral-400 dark:bg-neutral-600',
+  info: 'bg-info',
+  success: 'bg-success',
+  warning: 'bg-warning',
+  error: 'bg-error',
+};
+
+export interface TimelineProps {
+  children: React.ReactNode;
+  className?: string;
+  testId?: string;
+}
+
+export interface TimelineItemProps {
+  children?: React.ReactNode;
+  className?: string;
+  /** Timestamp — callers format it (e.g. via Intl.DateTimeFormat). */
+  timestamp: React.ReactNode;
+  /** Main line describing the event. */
+  title: React.ReactNode;
+  /** Optional "who did it" — rendered inline next to the timestamp. */
+  actor?: React.ReactNode;
+  /** Dot color — defaults to neutral. */
+  status?: Status;
+  /**
+   * Optional custom dot content. Replaces the solid dot entirely. Useful for
+   * small icons (e.g. Lucide) sized at h-3 w-3.
+   */
+  icon?: React.ReactNode;
+  testId?: string;
+}
+
+const Root: React.FC<TimelineProps> = ({ children, className, testId }) => (
+  <ol className={cn('relative m-0 list-none p-0', className)} data-testid={testId}>
+    {children}
+  </ol>
+);
+
+const Item: React.FC<TimelineItemProps> = ({
+  children,
+  className,
+  timestamp,
+  title,
+  actor,
+  status = 'neutral',
+  icon,
+  testId,
+}) => (
+  <li
+    className={cn(
+      'relative border-l-2 border-gray-200 pb-6 pl-6 last:border-transparent last:pb-0 dark:border-gray-800',
+      className,
+    )}
+    data-testid={testId}
+  >
+    <span
+      className={cn(
+        'absolute left-0 top-1 flex h-3 w-3 -translate-x-1/2 items-center justify-center rounded-full ring-4 ring-white dark:ring-neutral-950',
+        !icon && dotStatusClasses[status],
+      )}
+      aria-hidden="true"
+    >
+      {icon}
+    </span>
+    <div className="flex flex-wrap items-baseline gap-x-2 text-xs text-neutral-600 dark:text-neutral-400">
+      <time>{timestamp}</time>
+      {actor && <span>· {actor}</span>}
+    </div>
+    <div className="mt-0.5 text-sm font-medium text-neutral-900 dark:text-neutral-100">
+      {title}
+    </div>
+    {children && <div className="mt-2 text-sm text-neutral-700 dark:text-neutral-300">{children}</div>}
+  </li>
+);
+
+/**
+ * Vertical timeline for chronological event lists (audit logs, order history,
+ * registration activity, business events).
+ *
+ * @beta This component is experimental. The prop shape and visual design may
+ * change before release.
+ *
+ * @example
+ * <Timeline>
+ *   <Timeline.Item timestamp="2026-04-19 10:22" title="Order created" status="success" />
+ *   <Timeline.Item timestamp="2026-04-19 10:25" title="Payment method updated" actor="Ada">
+ *     <pre>{JSON.stringify(metadata, null, 2)}</pre>
+ *   </Timeline.Item>
+ * </Timeline>
+ */
+export const Timeline = Object.assign(Root, {
+  Item,
+});

--- a/libs/ratio-ui/src/core/Timeline/index.ts
+++ b/libs/ratio-ui/src/core/Timeline/index.ts
@@ -1,0 +1,1 @@
+export { Timeline, type TimelineProps, type TimelineItemProps } from './Timeline';


### PR DESCRIPTION
## Summary
- New `Timeline` + `Timeline.Item` compound component under `@eventuras/ratio-ui/core/Timeline` for rendering chronological event lists (audit logs, order history, registration activity, upcoming BusinessEvent feed).
- Marked `@beta` in JSDoc — prop shape may change before release.
- Three Storybook stories: `Basic`, `WithMetadata`, and `AllStatuses`.

## Item props
- `timestamp` — callers format (e.g. via `Intl.DateTimeFormat`)
- `title` — main line describing the event
- `actor?` — inline "who did it"
- `status?` — dot color (`neutral` | `info` | `success` | `warning` | `error`)
- `icon?` — replaces the dot
- `children?` — additional metadata / extra content

## Test plan
- [x] `pnpm exec tsc --noEmit` in `libs/ratio-ui` — clean
- [x] `pnpm exec eslint src/core/Timeline/` — clean
- [x] `pnpm test` in `libs/ratio-ui` — 350/350 pass
- [ ] `pnpm storybook` — visually verify all stories in light + dark
- [ ] Confirm tree-shaking: importing `@eventuras/ratio-ui/core/Timeline` does not pull unrelated components

🤖 Generated with [Claude Code](https://claude.com/claude-code)
