### PR TITLE
feat(api): link BusinessEvent to Organization + org-scoped list

### DIFF
--- a/apps/api/src/Eventuras.Domain/BusinessEvent.cs
+++ b/apps/api/src/Eventuras.Domain/BusinessEvent.cs
@@ -12,6 +12,8 @@ public class BusinessEvent
     [Key]
     public Guid Uuid { get; set; } = Guid.CreateVersion7();
 
+    public Guid? OrganizationUuid { get; set; }
+
     public Instant CreatedAt { get; set; } = SystemClock.Instance.GetCurrentInstant();
 
     [Required]

--- a/apps/api/src/Eventuras.Infrastructure/ApplicationDbContext.cs
+++ b/apps/api/src/Eventuras.Infrastructure/ApplicationDbContext.cs
@@ -110,8 +110,7 @@ public class ApplicationDbContext : DbContext
             .IsUnique();
 
         builder.Entity<Organization>()
-            .HasIndex(x => x.Uuid)
-            .IsUnique();
+            .HasAlternateKey(x => x.Uuid);
 
         builder.Entity<OrganizationMember>()
             .HasIndex(x => x.Uuid)
@@ -161,8 +160,16 @@ public class ApplicationDbContext : DbContext
         {
             entity.HasIndex(x => x.CreatedAt);
             entity.HasIndex(x => new { x.SubjectType, x.SubjectUuid });
+            entity.HasIndex(x => x.OrganizationUuid);
+            entity.HasIndex(x => new { x.OrganizationUuid, x.SubjectType, x.SubjectUuid });
             entity.HasIndex(x => x.EventType);
             entity.HasIndex(x => x.ActorUserUuid);
+
+            entity.HasOne<Organization>()
+                .WithMany()
+                .HasForeignKey(x => x.OrganizationUuid)
+                .HasPrincipalKey(o => o.Uuid)
+                .OnDelete(DeleteBehavior.Restrict);
         });
     }
 

--- a/apps/api/src/Eventuras.Infrastructure/Migrations/20260419205942_AddBusinessEventOrganizationLink.Designer.cs
+++ b/apps/api/src/Eventuras.Infrastructure/Migrations/20260419205942_AddBusinessEventOrganizationLink.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eventuras.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eventuras.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419205942_AddBusinessEventOrganizationLink")]
+    partial class AddBusinessEventOrganizationLink
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Eventuras.Infrastructure/Migrations/20260419205942_AddBusinessEventOrganizationLink.cs
+++ b/apps/api/src/Eventuras.Infrastructure/Migrations/20260419205942_AddBusinessEventOrganizationLink.cs
@@ -1,0 +1,78 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eventuras.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBusinessEventOrganizationLink : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Organizations_Uuid",
+                table: "Organizations");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OrganizationUuid",
+                table: "BusinessEvents",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_Organizations_Uuid",
+                table: "Organizations",
+                column: "Uuid");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BusinessEvents_OrganizationUuid",
+                table: "BusinessEvents",
+                column: "OrganizationUuid");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_BusinessEvents_OrganizationUuid_SubjectType_SubjectUuid",
+                table: "BusinessEvents",
+                columns: new[] { "OrganizationUuid", "SubjectType", "SubjectUuid" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_BusinessEvents_Organizations_OrganizationUuid",
+                table: "BusinessEvents",
+                column: "OrganizationUuid",
+                principalTable: "Organizations",
+                principalColumn: "Uuid",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_BusinessEvents_Organizations_OrganizationUuid",
+                table: "BusinessEvents");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_Organizations_Uuid",
+                table: "Organizations");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BusinessEvents_OrganizationUuid",
+                table: "BusinessEvents");
+
+            migrationBuilder.DropIndex(
+                name: "IX_BusinessEvents_OrganizationUuid_SubjectType_SubjectUuid",
+                table: "BusinessEvents");
+
+            migrationBuilder.DropColumn(
+                name: "OrganizationUuid",
+                table: "BusinessEvents");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Organizations_Uuid",
+                table: "Organizations",
+                column: "Uuid",
+                unique: true);
+        }
+    }
+}

--- a/apps/api/src/Eventuras.Infrastructure/sqlscript/database-migrations.sql
+++ b/apps/api/src/Eventuras.Infrastructure/sqlscript/database-migrations.sql
@@ -2485,3 +2485,56 @@ BEGIN
 END $EF$;
 COMMIT;
 
+START TRANSACTION;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    DROP INDEX "IX_Organizations_Uuid";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    ALTER TABLE "BusinessEvents" ADD "OrganizationUuid" uuid;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    ALTER TABLE "Organizations" ADD CONSTRAINT "AK_Organizations_Uuid" UNIQUE ("Uuid");
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    CREATE INDEX "IX_BusinessEvents_OrganizationUuid" ON "BusinessEvents" ("OrganizationUuid");
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    CREATE INDEX "IX_BusinessEvents_OrganizationUuid_SubjectType_SubjectUuid" ON "BusinessEvents" ("OrganizationUuid", "SubjectType", "SubjectUuid");
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    ALTER TABLE "BusinessEvents" ADD CONSTRAINT "FK_BusinessEvents_Organizations_OrganizationUuid" FOREIGN KEY ("OrganizationUuid") REFERENCES "Organizations" ("Uuid") ON DELETE RESTRICT;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20260419205942_AddBusinessEventOrganizationLink') THEN
+    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20260419205942_AddBusinessEventOrganizationLink', '10.0.6');
+    END IF;
+END $EF$;
+COMMIT;
+

--- a/apps/api/src/Eventuras.Services/BusinessEvents/BusinessEventService.cs
+++ b/apps/api/src/Eventuras.Services/BusinessEvents/BusinessEventService.cs
@@ -1,10 +1,14 @@
 #nullable enable
 
 using System;
+using System.Linq;
 using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Microsoft.EntityFrameworkCore;
 
 namespace Eventuras.Services.BusinessEvents;
 
@@ -21,6 +25,7 @@ public class BusinessEventService : IBusinessEventService
         BusinessEventSubject subject,
         string eventType,
         string message,
+        Guid? organizationUuid = null,
         Guid? actorUserUuid = null,
         object? metadata = null)
     {
@@ -34,6 +39,7 @@ public class BusinessEventService : IBusinessEventService
             Message = message,
             SubjectType = subject.Type,
             SubjectUuid = subject.Uuid,
+            OrganizationUuid = organizationUuid,
             ActorUserUuid = actorUserUuid,
             MetadataJson = metadata is null
                 ? null
@@ -41,5 +47,26 @@ public class BusinessEventService : IBusinessEventService
         };
 
         _dbContext.BusinessEvents.Add(entity);
+    }
+
+    public async Task<Paging<BusinessEvent>> ListEventsAsync(
+        Guid organizationUuid,
+        BusinessEventSubject subject,
+        PagingRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(subject);
+        ArgumentNullException.ThrowIfNull(request);
+
+        var query = _dbContext.BusinessEvents
+            .AsNoTracking()
+            .Where(e =>
+                e.OrganizationUuid == organizationUuid &&
+                e.SubjectType == subject.Type &&
+                e.SubjectUuid == subject.Uuid)
+            .OrderByDescending(e => e.CreatedAt)
+            .ThenByDescending(e => e.Uuid);
+
+        return await Paging.CreateAsync(query, request, cancellationToken);
     }
 }

--- a/apps/api/src/Eventuras.Services/BusinessEvents/IBusinessEventService.cs
+++ b/apps/api/src/Eventuras.Services/BusinessEvents/IBusinessEventService.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 using Eventuras.Domain;
 
@@ -12,6 +14,13 @@ public interface IBusinessEventService
         BusinessEventSubject subject,
         string eventType,
         string message,
+        Guid? organizationUuid = null,
         Guid? actorUserUuid = null,
         object? metadata = null);
+
+    Task<Paging<BusinessEvent>> ListEventsAsync(
+        Guid organizationUuid,
+        BusinessEventSubject subject,
+        PagingRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/tests/Eventuras.Services.Tests/BusinessEvents/BusinessEventServiceTests.cs
+++ b/apps/api/tests/Eventuras.Services.Tests/BusinessEvents/BusinessEventServiceTests.cs
@@ -3,10 +3,13 @@
 using System;
 using System.Linq;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Eventuras.Services;
 using Eventuras.Services.BusinessEvents;
 using Microsoft.EntityFrameworkCore;
+using NodaTime;
 using Xunit;
 
 namespace Eventuras.Services.Tests.BusinessEvents;
@@ -65,12 +68,14 @@ public class BusinessEventServiceTests
         using var db = CreateDbContext();
         var service = new BusinessEventService(db);
         var orderUuid = Guid.NewGuid();
+        var organizationUuid = Guid.NewGuid();
         var actorUuid = Guid.NewGuid();
 
         service.AddEvent(
             BusinessEventSubjects.ForOrder(orderUuid),
             "order.created",
             "Order was created",
+            organizationUuid: organizationUuid,
             actorUserUuid: actorUuid);
 
         var entry = db.ChangeTracker.Entries<BusinessEvent>().Single();
@@ -78,6 +83,7 @@ public class BusinessEventServiceTests
 
         Assert.Equal("order", entity.SubjectType);
         Assert.Equal(orderUuid, entity.SubjectUuid);
+        Assert.Equal(organizationUuid, entity.OrganizationUuid);
         Assert.Equal("order.created", entity.EventType);
         Assert.Equal("Order was created", entity.Message);
         Assert.Equal(actorUuid, entity.ActorUserUuid);
@@ -100,5 +106,74 @@ public class BusinessEventServiceTests
         var parsed = JsonDocument.Parse(entity.MetadataJson);
         Assert.Equal("duplicate", parsed.RootElement.GetProperty("reason").GetString());
         Assert.Equal("admin", parsed.RootElement.GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public async Task ListEventsAsync_Returns_Subject_Events_In_Descending_Created_Order()
+    {
+        using var db = CreateDbContext();
+        var service = new BusinessEventService(db);
+        var orderUuid = Guid.NewGuid();
+        var organizationUuid = Guid.NewGuid();
+        var otherOrganizationUuid = Guid.NewGuid();
+        var otherOrderUuid = Guid.NewGuid();
+
+        db.BusinessEvents.AddRange(
+            new BusinessEvent
+            {
+                CreatedAt = Instant.FromUtc(2026, 4, 19, 10, 0),
+                EventType = "order.created",
+                Message = "Created",
+                SubjectType = "order",
+                SubjectUuid = orderUuid,
+                OrganizationUuid = organizationUuid
+            },
+            new BusinessEvent
+            {
+                CreatedAt = Instant.FromUtc(2026, 4, 19, 11, 0),
+                EventType = "order.status.changed",
+                Message = "Verified",
+                SubjectType = "order",
+                SubjectUuid = orderUuid,
+                OrganizationUuid = organizationUuid
+            },
+            new BusinessEvent
+            {
+                CreatedAt = Instant.FromUtc(2026, 4, 19, 12, 0),
+                EventType = "order.invoice.created",
+                Message = "Invoiced",
+                SubjectType = "order",
+                SubjectUuid = orderUuid,
+                OrganizationUuid = organizationUuid
+            },
+            new BusinessEvent
+            {
+                CreatedAt = Instant.FromUtc(2026, 4, 19, 12, 30),
+                EventType = "order.status.changed",
+                Message = "Other organization",
+                SubjectType = "order",
+                SubjectUuid = orderUuid,
+                OrganizationUuid = otherOrganizationUuid
+            },
+            new BusinessEvent
+            {
+                CreatedAt = Instant.FromUtc(2026, 4, 19, 13, 0),
+                EventType = "order.created",
+                Message = "Other order",
+                SubjectType = "order",
+                SubjectUuid = otherOrderUuid,
+                OrganizationUuid = organizationUuid
+            });
+        await db.SaveChangesAsync();
+
+        var result = await service.ListEventsAsync(
+            organizationUuid,
+            BusinessEventSubjects.ForOrder(orderUuid),
+            new PagingRequest(offset: 0, limit: 2));
+
+        Assert.Equal(3, result.TotalRecords);
+        Assert.Equal(
+            new[] { "order.invoice.created", "order.status.changed" },
+            result.Data.Select(e => e.EventType).ToArray());
     }
 }


### PR DESCRIPTION
## Summary
- Adds `OrganizationUuid` (`Guid?`) to `BusinessEvent` + FK to `Organization.Uuid`. EF auto-created an alternate key `AK_Organizations_Uuid` for the principal column. `OnDelete: Restrict` — Organizations with business events cannot be deleted (audit trails should survive; archive the org instead).
- `AddEvent` now accepts an optional `organizationUuid`.
- New `ListEventsAsync(organizationUuid, subject, pagingRequest)` returns paged events for a (org, subject) pair, newest first.
- Single squashed migration `AddBusinessEventOrganizationLink` covers the column, indexes, alternate key, and FK in one step. Idempotent SQL script regenerated.
- Tests updated + new coverage for organization scoping.

## Why a FK here, when ADR-0001 said no FKs?
ADR-0001 excluded FKs for the polymorphic `SubjectUuid` — an event could reference any entity type, so there is no single parent table. `OrganizationUuid` is different: it is a tenant boundary with a known parent table, so referential integrity applies without violating the ADR's spirit. Worth a follow-up ADR note.

## Follow-ups (next PRs)
- Simple access control on `BusinessEventService`: system admin reads all, org admin reads own org, others denied.
- Expose via an API endpoint + wire up in web admin UI (will use the new `Timeline` beta component from #1343).

## Test plan
- [x] `dotnet build apps/api` — clean (6 unrelated MailKit CVE warnings)
- [x] BusinessEventService unit tests updated + green locally
- [ ] `MigrationsScriptTests.IdempotentMigrationsScript_ShouldBeUpToDate` — run in CI
- [ ] Manual: run migration on local dev DB, confirm FK + AK exist with correct names

🤖 Generated with [Claude Code](https://claude.com/claude-code)