### PR TITLE
ci: sweep pnpm install for --ignore-scripts + bump action-setup to v6.0.2

### DIFF
--- a/.github/workflows/_changeset.yml
+++ b/.github/workflows/_changeset.yml
@@ -25,7 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -34,7 +34,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Check for pending changesets
         id: changesets

--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24.x"

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -32,7 +32,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Publish (tag packages)
         id: changesets

--- a/.github/workflows/conductor-ci.yml
+++ b/.github/workflows/conductor-ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -18,7 +18,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/conductor... --frozen-lockfile
+        run: pnpm install --filter @eventuras/conductor... --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm --filter @eventuras/conductor build

--- a/.github/workflows/convertoapi-ci.yml
+++ b/.github/workflows/convertoapi-ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -18,7 +18,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/convertoapi... --frozen-lockfile
+        run: pnpm install --filter @eventuras/convertoapi... --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm --filter @eventuras/convertoapi build

--- a/.github/workflows/datatable-publish.yml
+++ b/.github/workflows/datatable-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/datatable... --frozen-lockfile
+        run: pnpm install --filter @eventuras/datatable... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/datatable build

--- a/.github/workflows/dev-docs-ci.yml
+++ b/.github/workflows/dev-docs-ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -18,7 +18,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/dev-docs... --frozen-lockfile
+        run: pnpm install --filter @eventuras/dev-docs... --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm --filter @eventuras/dev-docs... build

--- a/.github/workflows/dev-docs-deploy.yml
+++ b/.github/workflows/dev-docs-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -27,7 +27,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/dev-docs... --frozen-lockfile
+        run: pnpm install --filter @eventuras/dev-docs... --frozen-lockfile --ignore-scripts
 
       - name: Build
         run: pnpm --filter @eventuras/dev-docs... build

--- a/.github/workflows/eslint-config-publish.yml
+++ b/.github/workflows/eslint-config-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/eslint-config... --frozen-lockfile
+        run: pnpm install --filter @eventuras/eslint-config... --frozen-lockfile --ignore-scripts
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/fides-auth-next-publish.yml
+++ b/.github/workflows/fides-auth-next-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/fides-auth-next... --frozen-lockfile
+        run: pnpm install --filter @eventuras/fides-auth-next... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/fides-auth-next build

--- a/.github/workflows/fides-auth-publish.yml
+++ b/.github/workflows/fides-auth-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/fides-auth... --frozen-lockfile
+        run: pnpm install --filter @eventuras/fides-auth... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/fides-auth build

--- a/.github/workflows/historia-ci.yml
+++ b/.github/workflows/historia-ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -19,7 +19,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/historia... --frozen-lockfile
+        run: pnpm install --filter @eventuras/historia... --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: pnpm --filter @eventuras/historia lint

--- a/.github/workflows/idem-admin-ci.yml
+++ b/.github/workflows/idem-admin-ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -19,7 +19,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/idem-admin... --frozen-lockfile
+        run: pnpm install --filter @eventuras/idem-admin... --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: pnpm --filter @eventuras/idem-admin lint

--- a/.github/workflows/idem-idp-ci.yml
+++ b/.github/workflows/idem-idp-ci.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -19,7 +19,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/idem-idp... --frozen-lockfile
+        run: pnpm install --filter @eventuras/idem-idp... --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: pnpm --filter @eventuras/idem-idp lint

--- a/.github/workflows/logger-publish.yml
+++ b/.github/workflows/logger-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/logger... --frozen-lockfile
+        run: pnpm install --filter @eventuras/logger... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/logger build

--- a/.github/workflows/ratio-ci.yml
+++ b/.github/workflows/ratio-ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -18,7 +18,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/ratio-ui... --frozen-lockfile
+        run: pnpm install --filter @eventuras/ratio-ui... --frozen-lockfile --ignore-scripts
 
       - name: Build Storybook
         run: pnpm --filter @eventuras/ratio-ui storybook:build

--- a/.github/workflows/ratio-deploy.yml
+++ b/.github/workflows/ratio-deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -28,7 +28,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/ratio-ui... --frozen-lockfile
+        run: pnpm install --filter @eventuras/ratio-ui... --frozen-lockfile --ignore-scripts
 
       - name: Build Storybook
         run: pnpm --filter @eventuras/ratio-ui storybook:build

--- a/.github/workflows/ratio-release.yml
+++ b/.github/workflows/ratio-release.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/ratio-ui... --frozen-lockfile
+        run: pnpm install --filter @eventuras/ratio-ui... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/ratio-ui build

--- a/.github/workflows/scribo-ci.yml
+++ b/.github/workflows/scribo-ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -18,7 +18,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/scribo... --frozen-lockfile
+        run: pnpm install --filter @eventuras/scribo... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/scribo build

--- a/.github/workflows/scribo-deploy.yml
+++ b/.github/workflows/scribo-deploy.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/scribo... --frozen-lockfile
+        run: pnpm install --filter @eventuras/scribo... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/scribo build

--- a/.github/workflows/scribo-publish.yml
+++ b/.github/workflows/scribo-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/scribo... --frozen-lockfile
+        run: pnpm install --filter @eventuras/scribo... --frozen-lockfile --ignore-scripts
 
       - name: Build package
         run: pnpm --filter @eventuras/scribo build

--- a/.github/workflows/typescript-config-publish.yml
+++ b/.github/workflows/typescript-config-publish.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: ${{ steps.ref.outputs.ref }}
 
-      - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
@@ -42,7 +42,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/typescript-config... --frozen-lockfile
+        run: pnpm install --filter @eventuras/typescript-config... --frozen-lockfile --ignore-scripts
 
       - name: Publish to npm
         run: |

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
         with:
           run_install: false
 
@@ -23,7 +23,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: pnpm turbo run lint
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@71c92474e7e4f5bca283fb17ef80fba9cdb2b4b1 # v6.0.2
         with:
           run_install: false
 
@@ -47,7 +47,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build dependencies
         run: pnpm turbo run build --filter=@eventuras/web^...

--- a/package.json
+++ b/package.json
@@ -73,6 +73,18 @@
         "@types/react-dom"
       ]
     },
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@sentry/cli",
+      "@swc/core",
+      "aws-crt",
+      "esbuild",
+      "protobufjs",
+      "sharp",
+      "simple-git-hooks",
+      "unrs-resolver",
+      "yarn"
+    ],
     "updateConfig": {
       "ignoreDependencies": [
         "@types/node",


### PR DESCRIPTION
## Summary

Consolidates two CI fixes that kept bouncing around during #1348.

### 1. Add `--ignore-scripts` to every `pnpm install --frozen-lockfile`

pnpm 10.33 exits 1 on `ERR_PNPM_IGNORED_BUILDS` in CI regardless of `pnpm.onlyBuiltDependencies` or `strict-dep-builds`. Locally the same install succeeds (warn only), but in every GitHub Actions runner the allowlist isn't honoured and a dozen native-binary installers (sharp, esbuild, @swc/core, @parcel/watcher, simple-git-hooks, …) trip the check.

Mirroring the fix already applied to `_checks.yml` (commitlint), 21 additional workflows now pass `--ignore-scripts` to `pnpm install`. Turbo re-runs any real compilation downstream jobs need, so nothing functional is lost.

### 2. Bump `pnpm/action-setup` 6.0.0 → 6.0.2

Pinned SHA 08c4be7... → 71c9247... across all 23 workflow files.

- **v6.0.1** stopped saving `pnpm-lock.yaml` as two YAML documents unless `devEngines.packageManager` is set. Complements the earlier `managePackageManagerVersions: false` fix in #1347.
- **v6.0.2** fixed "pnpm self-update binary shadowed by bootstrap on PATH" — plausibly related to the allowlist resolution issues.

### 3. `pnpm.onlyBuiltDependencies` in root `package.json`

Approves the common native-binary installers so `pnpm install` on a dev machine no longer prints the ignored-builds warning. CI ignores this list — `--ignore-scripts` is doing the heavy lifting there — but it keeps local dev clean.

## Test plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts` locally — clean exit
- [ ] CI: Web / Dev Docs / conductor / historia / idem-*  etc. all green

## Follow-up

- Revisit if pnpm or `pnpm/action-setup` eventually ships something that makes the allowlist reliably honoured in CI without `--ignore-scripts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)