### PR TITLE
refactor(api): move business-event emission into management services

### DIFF
--- a/apps/api/src/Eventuras.Services/Orders/OrderManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Orders/OrderManagementService.cs
@@ -60,6 +60,24 @@ public class OrderManagementService : IOrderManagementService
 
         await _orderAccessControlService.CheckOrderUpdateAccessAsync(order, cancellationToken);
 
+        // Load pre-update state (AsNoTracking, separate instance from the
+        // incoming mutated entity) for audit-delta detection.
+        var before = await _context.Orders
+            .AsNoTracking()
+            .FirstOrDefaultAsync(o => o.OrderId == order.OrderId, cancellationToken);
+
+        if (before != null && before.Status != order.Status)
+        {
+            var organizationUuid = await _registrationRetrievalService
+                .GetOrganizationUuidAsync(order.RegistrationId, cancellationToken);
+
+            _businessEventService.AddEvent(
+                BusinessEventSubjects.ForOrder(order.Uuid),
+                "order.status.changed",
+                $"Status changed from {before.Status} to {order.Status}",
+                organizationUuid: organizationUuid);
+        }
+
         _context.Update(order);
         await _context.SaveChangesAsync(cancellationToken);
 

--- a/apps/api/src/Eventuras.Services/Registrations/IRegistrationManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/IRegistrationManagementService.cs
@@ -23,7 +23,19 @@ public interface IRegistrationManagementService
         CancellationToken cancellationToken = default);
 
     /// <exception cref="Exceptions.NotAccessibleException">Not permitted to update the given registration.</exception>
+    /// <remarks>
+    ///     Emits <c>registration.status.changed</c> and <c>registration.type.changed</c>
+    ///     BusinessEvents for any detected delta. The caller no longer needs to
+    ///     track which fields changed or invoke the audit log.
+    /// </remarks>
     Task UpdateRegistrationAsync(
         Registration registration,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>Sets a registration's status to Cancelled and emits the audit event.</summary>
+    /// <exception cref="Exceptions.NotFoundException">Registration not found.</exception>
+    /// <exception cref="Exceptions.NotAccessibleException">Not permitted to cancel the given registration.</exception>
+    Task<Registration> CancelRegistrationAsync(
+        int id,
         CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
@@ -183,23 +183,31 @@ internal class RegistrationManagementService : IRegistrationManagementService
         var registration = await _registrationRetrievalService.GetRegistrationByIdAsync(
             id, null, cancellationToken);
 
-        if (registration.Status == Registration.RegistrationStatus.Cancelled)
-        {
-            return registration; // already cancelled — no-op, don't double-audit
-        }
-
-        var before = new Registration
-        {
-            RegistrationId = registration.RegistrationId,
-            Status = registration.Status,
-            Type = registration.Type,
-            Uuid = registration.Uuid,
-        };
-        registration.Status = Registration.RegistrationStatus.Cancelled;
-
+        // Access is checked on the (soon-to-be) mutated entity before we
+        // decide idempotency — a caller without update rights must not
+        // silently succeed just because the registration is already
+        // Cancelled.
         await _registrationAccessControlService.CheckRegistrationUpdateAccessAsync(registration, cancellationToken);
 
-        await EmitAuditEventsAsync(before, registration, cancellationToken);
+        // Idempotent: if already cancelled, do nothing and skip the audit
+        // event. DELETE is not expected to emit a second "cancelled" record.
+        if (registration.Status == Registration.RegistrationStatus.Cancelled)
+        {
+            return registration;
+        }
+
+        registration.Status = Registration.RegistrationStatus.Cancelled;
+
+        // Cancellation gets its own dedicated message rather than the generic
+        // status-delta text from EmitAuditEventsAsync.
+        var organizationUuid = await _registrationRetrievalService
+            .GetOrganizationUuidAsync(registration.RegistrationId, cancellationToken);
+        _businessEventService.AddEvent(
+            BusinessEventSubjects.ForRegistration(registration.Uuid),
+            "registration.status.changed",
+            "Registration cancelled",
+            organizationUuid: organizationUuid);
+
         await _context.UpdateAsync(registration, cancellationToken);
 
         return registration;
@@ -222,13 +230,10 @@ internal class RegistrationManagementService : IRegistrationManagementService
 
         if (before.Status != after.Status)
         {
-            var message = after.Status == Registration.RegistrationStatus.Cancelled
-                ? "Registration cancelled"
-                : $"Status changed from {before.Status} to {after.Status}";
             _businessEventService.AddEvent(
                 BusinessEventSubjects.ForRegistration(after.Uuid),
                 "registration.status.changed",
-                message,
+                $"Status changed from {before.Status} to {after.Status}",
                 organizationUuid: organizationUuid);
         }
 

--- a/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Eventuras.Services.BusinessEvents;
 using Eventuras.Services.Events;
 using Eventuras.Services.Exceptions;
 using Eventuras.Services.Notifications;
@@ -18,6 +19,7 @@ namespace Eventuras.Services.Registrations;
 
 internal class RegistrationManagementService : IRegistrationManagementService
 {
+    private readonly IBusinessEventService _businessEventService;
     private readonly ApplicationDbContext _context;
     private readonly IEventInfoRetrievalService _eventInfoRetrievalService;
     private readonly ILogger<RegistrationManagementService> _logger;
@@ -25,23 +27,28 @@ internal class RegistrationManagementService : IRegistrationManagementService
     private readonly INotificationManagementService _notificationsManagementService;
     private readonly IOrderManagementService _orderManagementService;
     private readonly IRegistrationAccessControlService _registrationAccessControlService;
+    private readonly IRegistrationRetrievalService _registrationRetrievalService;
     private readonly IUserRetrievalService _userRetrievalService;
 
     public RegistrationManagementService(
         IRegistrationAccessControlService registrationAccessControlService,
+        IRegistrationRetrievalService registrationRetrievalService,
         IOrderManagementService orderManagementService,
         IEventInfoRetrievalService eventInfoRetrievalService,
         INotificationDeliveryService notificationDeliveryService,
         INotificationManagementService notificationsManagementService,
         IUserRetrievalService userRetrievalService,
+        IBusinessEventService businessEventService,
         ILogger<RegistrationManagementService> logger,
         ApplicationDbContext context)
     {
         _registrationAccessControlService = registrationAccessControlService;
+        _registrationRetrievalService = registrationRetrievalService;
         _eventInfoRetrievalService = eventInfoRetrievalService;
         _notificationDeliveryService = notificationDeliveryService;
         _notificationsManagementService = notificationsManagementService;
         _userRetrievalService = userRetrievalService;
+        _businessEventService = businessEventService;
         _context = context;
         _orderManagementService = orderManagementService;
         _logger = logger;
@@ -155,7 +162,84 @@ internal class RegistrationManagementService : IRegistrationManagementService
 
         await _registrationAccessControlService.CheckRegistrationUpdateAccessAsync(registration, cancellationToken);
 
+        // Load pre-update state (AsNoTracking, separate instance from the
+        // incoming mutated entity) for audit-delta detection.
+        var before = await _context.Registrations
+            .AsNoTracking()
+            .FirstOrDefaultAsync(r => r.RegistrationId == registration.RegistrationId, cancellationToken);
+
+        if (before != null)
+        {
+            await EmitAuditEventsAsync(before, registration, cancellationToken);
+        }
+
         await _context.UpdateAsync(registration, cancellationToken);
+    }
+
+    public async Task<Registration> CancelRegistrationAsync(
+        int id,
+        CancellationToken cancellationToken = default)
+    {
+        var registration = await _registrationRetrievalService.GetRegistrationByIdAsync(
+            id, null, cancellationToken);
+
+        if (registration.Status == Registration.RegistrationStatus.Cancelled)
+        {
+            return registration; // already cancelled — no-op, don't double-audit
+        }
+
+        var before = new Registration
+        {
+            RegistrationId = registration.RegistrationId,
+            Status = registration.Status,
+            Type = registration.Type,
+            Uuid = registration.Uuid,
+        };
+        registration.Status = Registration.RegistrationStatus.Cancelled;
+
+        await _registrationAccessControlService.CheckRegistrationUpdateAccessAsync(registration, cancellationToken);
+
+        await EmitAuditEventsAsync(before, registration, cancellationToken);
+        await _context.UpdateAsync(registration, cancellationToken);
+
+        return registration;
+    }
+
+    private async Task EmitAuditEventsAsync(
+        Registration before,
+        Registration after,
+        CancellationToken cancellationToken)
+    {
+        if (before.Status == after.Status && before.Type == after.Type)
+        {
+            return;
+        }
+
+        // Tenant derived from the registration's event organization — audit
+        // data tracks the resource's owner, not any request header.
+        var organizationUuid = await _registrationRetrievalService
+            .GetOrganizationUuidAsync(after.RegistrationId, cancellationToken);
+
+        if (before.Status != after.Status)
+        {
+            var message = after.Status == Registration.RegistrationStatus.Cancelled
+                ? "Registration cancelled"
+                : $"Status changed from {before.Status} to {after.Status}";
+            _businessEventService.AddEvent(
+                BusinessEventSubjects.ForRegistration(after.Uuid),
+                "registration.status.changed",
+                message,
+                organizationUuid: organizationUuid);
+        }
+
+        if (before.Type != after.Type)
+        {
+            _businessEventService.AddEvent(
+                BusinessEventSubjects.ForRegistration(after.Uuid),
+                "registration.type.changed",
+                $"Type changed from {before.Type} to {after.Type}",
+                organizationUuid: organizationUuid);
+        }
     }
 
     public async Task SendWelcomeLetterAsync(Registration registration, CancellationToken cancellationToken)

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Orders/OrdersController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Orders/OrdersController.cs
@@ -2,10 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Asp.Versioning;
-using Eventuras.Domain;
-using Eventuras.Services.BusinessEvents;
 using Eventuras.Services.Orders;
-using Eventuras.Services.Registrations;
 using Eventuras.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -19,21 +16,15 @@ namespace Eventuras.WebApi.Controllers.v3.Orders;
 [ApiController]
 public class OrdersController : ControllerBase
 {
-    private readonly IBusinessEventService _businessEventService;
     private readonly IOrderManagementService _orderManagementService;
     private readonly IOrderRetrievalService _orderRetrievalService;
-    private readonly IRegistrationRetrievalService _registrationRetrievalService;
 
     public OrdersController(
         IOrderRetrievalService orderRetrievalService,
-        IOrderManagementService orderManagementService,
-        IBusinessEventService businessEventService,
-        IRegistrationRetrievalService registrationRetrievalService)
+        IOrderManagementService orderManagementService)
     {
         _orderRetrievalService = orderRetrievalService ?? throw new ArgumentNullException(nameof(orderRetrievalService));
         _orderManagementService = orderManagementService ?? throw new ArgumentNullException(nameof(orderManagementService));
-        _businessEventService = businessEventService ?? throw new ArgumentNullException(nameof(businessEventService));
-        _registrationRetrievalService = registrationRetrievalService ?? throw new ArgumentNullException(nameof(registrationRetrievalService));
     }
 
     [HttpGet("{id:int}")]
@@ -122,8 +113,6 @@ public class OrdersController : ControllerBase
             return BadRequest(ModelState);
         }
 
-        var oldStatus = order.Status;
-
         try
         {
             patchDto.ApplyTo(order);
@@ -131,19 +120,6 @@ public class OrdersController : ControllerBase
         catch (InvalidOperationException ex)
         {
             return BadRequest(ex.Message);
-        }
-
-        if (order.Status != oldStatus)
-        {
-            // Tenant derived from the order's registration → event → organization
-            var organizationUuid = await _registrationRetrievalService
-                .GetOrganizationUuidAsync(order.RegistrationId, cancellationToken);
-
-            _businessEventService.AddEvent(
-                BusinessEventSubjects.ForOrder(order.Uuid),
-                "order.status.changed",
-                $"Status changed from {oldStatus} to {order.Status}",
-                organizationUuid: organizationUuid);
         }
 
         await _orderManagementService.UpdateOrderAsync(order, cancellationToken);

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
@@ -4,9 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Asp.Versioning;
-using Eventuras.Domain;
 using Eventuras.Services.Auth;
-using Eventuras.Services.BusinessEvents;
 using Eventuras.Services.Exceptions;
 using Eventuras.Services.Registrations;
 using Eventuras.WebApi.Models;
@@ -25,7 +23,6 @@ public class RegistrationsController : ControllerBase
 {
     private const string MimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
-    private readonly IBusinessEventService _businessEventService;
     private readonly ILogger<RegistrationsController> _logger;
     private readonly IRegistrationExportService _registrationExportService;
     private readonly IRegistrationManagementService _registrationManagementService;
@@ -35,7 +32,6 @@ public class RegistrationsController : ControllerBase
         IRegistrationRetrievalService registrationRetrievalService,
         IRegistrationManagementService registrationManagementService,
         IRegistrationExportService registrationExportService,
-        IBusinessEventService businessEventService,
         ILogger<RegistrationsController> logger)
     {
         _registrationRetrievalService = registrationRetrievalService ?? throw
@@ -46,9 +42,6 @@ public class RegistrationsController : ControllerBase
 
         _registrationExportService = registrationExportService ?? throw
             new ArgumentNullException(nameof(registrationExportService));
-
-        _businessEventService = businessEventService ?? throw
-            new ArgumentNullException(nameof(businessEventService));
 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -238,40 +231,10 @@ public class RegistrationsController : ControllerBase
             return NotFound("Registration not found.");
         }
 
-        var oldStatus = registration.Status;
-        var oldType = registration.Type;
-
         patchDto.ApplyTo(registration);
 
-        var statusChanged = registration.Status != oldStatus;
-        var typeChanged = registration.Type != oldType;
-
-        if (statusChanged || typeChanged)
-        {
-            // Tenant derived from the registration's event organization — audit
-            // data reflects the resource's owner, not the Eventuras-Org-Id header.
-            var organizationUuid = await _registrationRetrievalService
-                .GetOrganizationUuidAsync(id, cancellationToken);
-
-            if (statusChanged)
-            {
-                _businessEventService.AddEvent(
-                    BusinessEventSubjects.ForRegistration(registration.Uuid),
-                    "registration.status.changed",
-                    $"Status changed from {oldStatus} to {registration.Status}",
-                    organizationUuid: organizationUuid);
-            }
-
-            if (typeChanged)
-            {
-                _businessEventService.AddEvent(
-                    BusinessEventSubjects.ForRegistration(registration.Uuid),
-                    "registration.type.changed",
-                    $"Type changed from {oldType} to {registration.Type}",
-                    organizationUuid: organizationUuid);
-            }
-        }
-
+        // UpdateRegistrationAsync now owns audit-event emission for status/type
+        // deltas — the controller doesn't need to track before/after itself.
         await _registrationManagementService.UpdateRegistrationAsync(registration, cancellationToken);
 
         var updatedDto = new RegistrationDto(registration);
@@ -288,26 +251,15 @@ public class RegistrationsController : ControllerBase
             return BadRequest("Invalid registration ID.");
         }
 
-        var registration = await _registrationRetrievalService.GetRegistrationByIdAsync(id, null, cancellationToken);
-
-        if (registration == null)
+        try
+        {
+            await _registrationManagementService.CancelRegistrationAsync(id, cancellationToken);
+        }
+        catch (NotFoundException)
         {
             _logger.LogWarning("CancelRegistration called with non-existent registration ID: {id}", id);
             return NotFound("Registration not found.");
         }
-
-        registration.Status = Registration.RegistrationStatus.Cancelled;
-
-        var organizationUuid = await _registrationRetrievalService
-            .GetOrganizationUuidAsync(id, cancellationToken);
-
-        _businessEventService.AddEvent(
-            BusinessEventSubjects.ForRegistration(registration.Uuid),
-            "registration.status.changed",
-            "Registration cancelled",
-            organizationUuid: organizationUuid);
-
-        await _registrationManagementService.UpdateRegistrationAsync(registration, cancellationToken);
 
         return Ok();
     }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
@@ -251,16 +251,9 @@ public class RegistrationsController : ControllerBase
             return BadRequest("Invalid registration ID.");
         }
 
-        try
-        {
-            await _registrationManagementService.CancelRegistrationAsync(id, cancellationToken);
-        }
-        catch (NotFoundException)
-        {
-            _logger.LogWarning("CancelRegistration called with non-existent registration ID: {id}", id);
-            return NotFound("Registration not found.");
-        }
-
+        // NotFoundException bubbles to HttpResponseExceptionFilter, which
+        // maps it to 404. No local try/catch needed.
+        await _registrationManagementService.CancelRegistrationAsync(id, cancellationToken);
         return Ok();
     }
 


### PR DESCRIPTION
## Summary

- Controllers no longer own audit-log bookkeeping for registration and order changes. `RegistrationManagementService.UpdateRegistrationAsync`, a new `CancelRegistrationAsync`, and `OrderManagementService.UpdateOrderAsync` now detect before/after deltas via an `AsNoTracking` fetch and emit the existing `registration.status.changed` / `registration.type.changed` / `order.status.changed` events.
- Pure relocation — no behavior change. Controllers drop their `IBusinessEventService` dependency; `OrdersController` also drops `IRegistrationRetrievalService`. `CancelRegistration` now relies on the global `NotFoundException → 404` filter (already covered by `HttpResponseExceptionFilter`).
- Sets up the next PR (stacked) to inject `IHttpContextAccessor` once in the service layer and populate `ActorUserUuid` uniformly, instead of at every controller callsite.

## Test plan

- [x] `dotnet build` (all projects) — 0 errors
- [x] `dotnet test` — 898 passed / 7 skipped / 0 failed
- [ ] Manual: PATCH a registration's status → verify `registration.status.changed` still lands in `/v3/business-events`
- [ ] Manual: DELETE a registration → verify `registration.status.changed` ("Registration cancelled") still appears
- [ ] Manual: PATCH an order's status → verify `order.status.changed` still appears