### PR TITLE
feat(api): populate actorUserUuid on business events

### DIFF
--- a/apps/api/src/Eventuras.Services/Invoicing/InvoicingService.cs
+++ b/apps/api/src/Eventuras.Services/Invoicing/InvoicingService.cs
@@ -5,9 +5,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Eventuras.Services.Auth;
 using Eventuras.Services.BusinessEvents;
 using Eventuras.Services.Orders;
 using Eventuras.Services.Registrations;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -18,6 +20,7 @@ internal class InvoicingService : IInvoicingService
     private readonly IBusinessEventService _businessEventService;
     private readonly IInvoicingProvider[] _components;
     private readonly ApplicationDbContext _db;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<InvoicingService> _logger;
     private readonly IOrderAccessControlService _orderAccessControlService;
     private readonly IRegistrationRetrievalService _registrationRetrievalService;
@@ -27,6 +30,7 @@ internal class InvoicingService : IInvoicingService
         IOrderAccessControlService orderAccessControlService,
         IBusinessEventService businessEventService,
         IRegistrationRetrievalService registrationRetrievalService,
+        IHttpContextAccessor httpContextAccessor,
         ILogger<InvoicingService> logger,
         ApplicationDbContext db)
     {
@@ -35,6 +39,7 @@ internal class InvoicingService : IInvoicingService
                                      throw new ArgumentNullException(nameof(orderAccessControlService));
         _businessEventService = businessEventService ?? throw new ArgumentNullException(nameof(businessEventService));
         _registrationRetrievalService = registrationRetrievalService ?? throw new ArgumentNullException(nameof(registrationRetrievalService));
+        _httpContextAccessor = httpContextAccessor ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _db = db ?? throw new ArgumentNullException(nameof(db));
     }
@@ -80,6 +85,8 @@ internal class InvoicingService : IInvoicingService
             ? await _registrationRetrievalService.GetOrganizationUuidAsync(orders[0].RegistrationId)
             : null;
 
+        var actorUserUuid = _httpContextAccessor.HttpContext?.User?.GetUserId();
+
         foreach (var order in orders)
         {
             order.Invoice = invoice;
@@ -88,7 +95,8 @@ internal class InvoicingService : IInvoicingService
                 BusinessEventSubjects.ForOrder(order.Uuid),
                 "order.status.changed",
                 $"Status changed to {Order.OrderStatus.Invoiced} (invoiced)",
-                organizationUuid: organizationUuid);
+                organizationUuid: organizationUuid,
+                actorUserUuid: actorUserUuid);
             _db.Orders.Update(order);
         }
 

--- a/apps/api/src/Eventuras.Services/Orders/OrderManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Orders/OrderManagementService.cs
@@ -7,10 +7,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Eventuras.Services.Auth;
 using Eventuras.Services.BusinessEvents;
 using Eventuras.Services.Events.Products;
 using Eventuras.Services.Exceptions;
 using Eventuras.Services.Registrations;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -20,6 +22,7 @@ public class OrderManagementService : IOrderManagementService
 {
     private readonly IBusinessEventService _businessEventService;
     private readonly ApplicationDbContext _context;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<OrderManagementService> _logger;
     private readonly IOrderAccessControlService _orderAccessControlService;
     private readonly IProductRetrievalService _productRetrievalService;
@@ -32,11 +35,13 @@ public class OrderManagementService : IOrderManagementService
         IRegistrationAccessControlService registrationAccessControlService,
         IProductRetrievalService productRetrievalService,
         IBusinessEventService businessEventService,
+        IHttpContextAccessor httpContextAccessor,
         ApplicationDbContext context,
         ILogger<OrderManagementService> logger)
     {
         _orderAccessControlService = orderAccessControlService;
         _businessEventService = businessEventService;
+        _httpContextAccessor = httpContextAccessor;
         _context = context;
         _registrationRetrievalService = registrationRetrievalService;
         _registrationAccessControlService = registrationAccessControlService;
@@ -70,12 +75,14 @@ public class OrderManagementService : IOrderManagementService
         {
             var organizationUuid = await _registrationRetrievalService
                 .GetOrganizationUuidAsync(order.RegistrationId, cancellationToken);
+            var actorUserUuid = _httpContextAccessor.HttpContext?.User?.GetUserId();
 
             _businessEventService.AddEvent(
                 BusinessEventSubjects.ForOrder(order.Uuid),
                 "order.status.changed",
                 $"Status changed from {before.Status} to {order.Status}",
-                organizationUuid: organizationUuid);
+                organizationUuid: organizationUuid,
+                actorUserUuid: actorUserUuid);
         }
 
         _context.Update(order);
@@ -96,12 +103,14 @@ public class OrderManagementService : IOrderManagementService
         // not the request header, so audit data reflects the resource's owner.
         var organizationUuid = await _registrationRetrievalService
             .GetOrganizationUuidAsync(order.RegistrationId, cancellationToken);
+        var actorUserUuid = _httpContextAccessor.HttpContext?.User?.GetUserId();
 
         _businessEventService.AddEvent(
             BusinessEventSubjects.ForOrder(order.Uuid),
             "order.status.changed",
             "Order cancelled",
-            organizationUuid: organizationUuid);
+            organizationUuid: organizationUuid,
+            actorUserUuid: actorUserUuid);
 
         await _context.UpdateAsync(order, cancellationToken);
     }

--- a/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
@@ -6,12 +6,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Eventuras.Domain;
 using Eventuras.Infrastructure;
+using Eventuras.Services.Auth;
 using Eventuras.Services.BusinessEvents;
 using Eventuras.Services.Events;
 using Eventuras.Services.Exceptions;
 using Eventuras.Services.Notifications;
 using Eventuras.Services.Orders;
 using Eventuras.Services.Users;
+using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
@@ -22,6 +24,7 @@ internal class RegistrationManagementService : IRegistrationManagementService
     private readonly IBusinessEventService _businessEventService;
     private readonly ApplicationDbContext _context;
     private readonly IEventInfoRetrievalService _eventInfoRetrievalService;
+    private readonly IHttpContextAccessor _httpContextAccessor;
     private readonly ILogger<RegistrationManagementService> _logger;
     private readonly INotificationDeliveryService _notificationDeliveryService;
     private readonly INotificationManagementService _notificationsManagementService;
@@ -39,6 +42,7 @@ internal class RegistrationManagementService : IRegistrationManagementService
         INotificationManagementService notificationsManagementService,
         IUserRetrievalService userRetrievalService,
         IBusinessEventService businessEventService,
+        IHttpContextAccessor httpContextAccessor,
         ILogger<RegistrationManagementService> logger,
         ApplicationDbContext context)
     {
@@ -49,6 +53,7 @@ internal class RegistrationManagementService : IRegistrationManagementService
         _notificationsManagementService = notificationsManagementService;
         _userRetrievalService = userRetrievalService;
         _businessEventService = businessEventService;
+        _httpContextAccessor = httpContextAccessor;
         _context = context;
         _orderManagementService = orderManagementService;
         _logger = logger;
@@ -206,7 +211,8 @@ internal class RegistrationManagementService : IRegistrationManagementService
             BusinessEventSubjects.ForRegistration(registration.Uuid),
             "registration.status.changed",
             "Registration cancelled",
-            organizationUuid: organizationUuid);
+            organizationUuid: organizationUuid,
+            actorUserUuid: _httpContextAccessor.HttpContext?.User?.GetUserId());
 
         await _context.UpdateAsync(registration, cancellationToken);
 
@@ -228,13 +234,18 @@ internal class RegistrationManagementService : IRegistrationManagementService
         var organizationUuid = await _registrationRetrievalService
             .GetOrganizationUuidAsync(after.RegistrationId, cancellationToken);
 
+        // Actor is the authenticated user from the current request, if any.
+        // Null for background jobs / anonymous paths.
+        var actorUserUuid = _httpContextAccessor.HttpContext?.User?.GetUserId();
+
         if (before.Status != after.Status)
         {
             _businessEventService.AddEvent(
                 BusinessEventSubjects.ForRegistration(after.Uuid),
                 "registration.status.changed",
                 $"Status changed from {before.Status} to {after.Status}",
-                organizationUuid: organizationUuid);
+                organizationUuid: organizationUuid,
+                actorUserUuid: actorUserUuid);
         }
 
         if (before.Type != after.Type)
@@ -243,7 +254,8 @@ internal class RegistrationManagementService : IRegistrationManagementService
                 BusinessEventSubjects.ForRegistration(after.Uuid),
                 "registration.type.changed",
                 $"Type changed from {before.Type} to {after.Type}",
-                organizationUuid: organizationUuid);
+                organizationUuid: organizationUuid,
+                actorUserUuid: actorUserUuid);
         }
     }
 


### PR DESCRIPTION
## Summary

- `RegistrationManagementService`, `OrderManagementService`, and `InvoicingService` now take `IHttpContextAccessor` and pull `User.GetUserId()` off the current request to populate `actorUserUuid` on every emitted BusinessEvent (`registration.status.changed`, `registration.type.changed`, `order.status.changed`).
- Actor is `null` for unauthenticated or background paths — no change in behavior for those.
- Stacked on #1352. Merge that first.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 898 passed / 7 skipped / 0 failed
- [ ] Manual: PATCH a registration's status as admin → business event has `ActorUserUuid = <admin user id>`
- [ ] Manual: DELETE a registration → event has correct `ActorUserUuid`
- [ ] Manual: PATCH an order's status → event has correct `ActorUserUuid`
- [ ] Manual: invoicing flow (order → invoiced) → event has correct `ActorUserUuid`