### PR TITLE
feat(web): add Project Code field to event advanced settings

### DIFF
--- a/apps/web/src/app/(admin)/admin/events/[id]/EventEditorSections.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventEditorSections.tsx
@@ -243,6 +243,7 @@ export const AdvancedSection = ({
         testId="eventeditor-form-eventid"
       />
       <TextField name="slug" label="Slug" placeholder="Event Slug" disabled />
+      <TextField name="projectCode" label="Project Code" placeholder="Accounting project code" />
       <TextField
         name="externalInfoPageUrl"
         label="External Info Page URL"


### PR DESCRIPTION
## Summary

\`EventInfo.ProjectCode\` has always existed on the domain, is round-tripped through \`EventDto\`/\`EventFormDto\`, and is forwarded to PowerOffice on invoicing (see [InvoiceInfo.cs#L43](apps/api/src/Eventuras.Services/Invoicing/InvoiceInfo.cs#L43) → [PowerOfficeService.cs#L71-L74](apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeService.cs#L71-L74)). But the field has been absent from the Next.js admin since the Razor/MVC port (the old \`EventInfoViewModel\` was removed in \`d9bd7527b\` back in Oct 2023 and the input was never ported). As a result, any event created or edited after that fell through with \`projectCode = null\` and the generated PowerOffice invoices have no project/accounting code.

This adds a \`projectCode\` TextField to \`AdvancedSection\`. The form wiring already flows it through: \`defaultValues = eventinfo\` (which is \`EventDto\`, which already has \`projectCode\` from the SDK) and \`updateEvent(id, data)\` (which sends the full \`EventFormDto\`).

## Test plan

- [x] \`pnpm tsc --noEmit\` — 0 errors
- [ ] Manual: open an admin event → Advanced tab → Project Code field shows existing value (if any)
- [ ] Manual: set a value, save → \`GET /v3/events/{id}\` returns the new \`projectCode\`
- [ ] Manual: invoice an order for that event via PowerOffice → \`OutgoingInvoice.ProjectCode\` is populated