### PR TITLE
refactor(web): align admin/users with registrations patterns

### DIFF
--- a/.changeset/api-business-events-actor.md
+++ b/.changeset/api-business-events-actor.md
@@ -1,0 +1,13 @@
+---
+"@eventuras/api": minor
+---
+
+feat(api): populate actorUserUuid on business events
+
+`RegistrationManagementService`, `OrderManagementService`, and
+`InvoicingService` now take `IHttpContextAccessor` and pull
+`User.GetUserId()` off the current request to populate
+`actorUserUuid` on every emitted BusinessEvent
+(`registration.status.changed`, `registration.type.changed`,
+`order.status.changed`). Actor is `null` for unauthenticated or
+background paths — no change in behavior for those.

--- a/.changeset/web-event-project-code.md
+++ b/.changeset/web-event-project-code.md
@@ -1,0 +1,15 @@
+---
+"@eventuras/web": minor
+---
+
+feat(web): add Project Code field to event advanced settings
+
+`EventInfo.ProjectCode` has been round-tripped through the API and
+forwarded to PowerOffice on invoicing, but the field was missing from
+the Next.js admin since the Razor/MVC port (the old
+`EventInfoViewModel` was removed back in Oct 2023 and the input was
+never re-added). Any event created or edited after that had
+`projectCode = null`, and generated PowerOffice invoices had no
+project/accounting code. Adds a `projectCode` TextField to the event
+editor's Advanced tab; existing form wiring (defaultValues +
+updateEvent) carries it through with no other changes.

--- a/.changeset/web-registration-drawer.md
+++ b/.changeset/web-registration-drawer.md
@@ -1,0 +1,14 @@
+---
+"@eventuras/web": minor
+---
+
+feat(web): registration drawer for quick view from admin lists
+
+Admins can now inspect (and edit) a registration without leaving the
+current list. A new `RegistrationDrawer` fetches the full
+`RegistrationDto` via a `getRegistrationDetail` server action and
+renders the existing `<Registration adminMode />` inside a slide-out
+panel. Wired into both `/admin/registrations` and the
+`/admin/events/[id]` participant list; the drawer footer has a link
+to the full detail page where the BusinessEvents timeline still
+lives. Deletes unused `AdminRegistrationsList.tsx` dead code.

--- a/.changeset/web-theme-init-script.md
+++ b/.changeset/web-theme-init-script.md
@@ -1,0 +1,13 @@
+---
+"@eventuras/web": patch
+---
+
+fix(web): silence React 19 script-tag warning in InitTheme
+
+`InitTheme` renders an inline `<script>` in `<head>` to set
+`data-theme` before hydration (anti-FOUC pattern). React 19's dev
+runtime flags bare `<script>` tags inside components because
+client-rendered scripts don't execute — the warning fires even
+though this one only reaches the client via SSR output and works
+fine. Switches to `next/script` with `strategy="beforeInteractive"`:
+same timing, no warning.

--- a/.changeset/web-users-server-side-list.md
+++ b/.changeset/web-users-server-side-list.md
@@ -1,0 +1,15 @@
+---
+"@eventuras/web": minor
+---
+
+refactor(web): align admin/users with registrations patterns
+
+- Server-side pagination on `/admin/users` via `?page=` URL param
+  (replaces the client-side 10-row window that didn't scale).
+- Server-side search via `?q=` forwarded to the SDK's `Query`
+  parameter; debounced input resets `?page=` on a new search.
+- `createUser`, `updateUser`, and `updateUserProfile` run API errors
+  through `formatApiError` + `readCorrelationIdFromResponse`, matching
+  the registrations actions for operational debugging parity.
+- Pagination input hardened against `NaN` / out-of-range URL values.
+- Adds `common.labels.search` in both locales.

--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -182,6 +182,7 @@
     "registration": "Registration",
     "registrations": "Registrations",
     "save": "Save",
+    "search": "Search",
     "slug": "Slug",
     "status": "Status",
     "type": "Type",

--- a/apps/web/locales/nb-NO/common.json
+++ b/apps/web/locales/nb-NO/common.json
@@ -181,6 +181,7 @@
     "registration": "Registrering",
     "registrations": "Registreringer",
     "save": "Lagre",
+    "search": "Søk",
     "slug": "Kode",
     "status": "Status",
     "type": "Type",

--- a/apps/web/src/app/(admin)/admin/users/UserList.tsx
+++ b/apps/web/src/app/(admin)/admin/users/UserList.tsx
@@ -1,26 +1,34 @@
 'use client';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
 import { createColumnHelper, DataTable } from '@eventuras/datatable';
+import { Pagination } from '@eventuras/ratio-ui/core/Pagination';
 import { Link } from '@eventuras/ratio-ui-next/Link';
 
 import { UserDto } from '@/lib/eventuras-sdk';
-const columnHelper = createColumnHelper<UserDto>();
-interface UserListProps {
-  users: UserDto[];
-}
 
-const UserList: React.FC<UserListProps> = ({ users = [] }) => {
+const columnHelper = createColumnHelper<UserDto>();
+
+type UserListProps = {
+  users: UserDto[];
+  currentPage: number;
+  totalPages: number;
+};
+
+const UserList: React.FC<UserListProps> = ({ users, currentPage, totalPages }) => {
   const t = useTranslations();
-  const renderUserActions = (u: UserDto) => {
-    return (
-      <div className="flex flex-row">
-        <Link variant="button-outline" href={`/admin/users/${u.id}`}>
-          {t('common.labels.view')}
-        </Link>
-      </div>
-    );
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handlePageChange = (newPage: number) => {
+    if (!Number.isFinite(newPage)) return;
+    const safePage = Math.min(totalPages, Math.max(1, newPage));
+    const params = new URLSearchParams(searchParams);
+    params.set('page', safePage.toString());
+    router.push(`?${params.toString()}`);
   };
+
   const columns = [
     columnHelper.accessor('name', {
       header: 'Name',
@@ -37,17 +45,24 @@ const UserList: React.FC<UserListProps> = ({ users = [] }) => {
     columnHelper.display({
       id: 'actions',
       header: t('admin.participantColumns.actions').toString(),
-      cell: info => renderUserActions(info.row.original),
+      cell: info => (
+        <div className="flex flex-row">
+          <Link variant="button-outline" href={`/admin/users/${info.row.original.id}`}>
+            {t('common.labels.view')}
+          </Link>
+        </div>
+      ),
     }),
   ];
+
   return (
     <>
-      <DataTable
-        data={users}
-        columns={columns}
-        clientsidePagination={true}
-        pageSize={10}
-        enableGlobalSearch={true}
+      <DataTable data={users} columns={columns} enableGlobalSearch={true} />
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPreviousPageClick={() => handlePageChange(currentPage - 1)}
+        onNextPageClick={() => handlePageChange(currentPage + 1)}
       />
     </>
   );

--- a/apps/web/src/app/(admin)/admin/users/UserList.tsx
+++ b/apps/web/src/app/(admin)/admin/users/UserList.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
@@ -14,12 +15,31 @@ type UserListProps = {
   users: UserDto[];
   currentPage: number;
   totalPages: number;
+  query: string;
 };
 
-const UserList: React.FC<UserListProps> = ({ users, currentPage, totalPages }) => {
+const UserList: React.FC<UserListProps> = ({ users, currentPage, totalPages, query }) => {
   const t = useTranslations();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [input, setInput] = useState(query);
+  const lastPushedRef = useRef(query);
+
+  // Debounce the input → URL sync so typing one letter at a time doesn't
+  // fire a server request per keystroke. Also resets ?page so a new search
+  // doesn't land on an out-of-range page.
+  useEffect(() => {
+    if (input === lastPushedRef.current) return;
+    const timeout = setTimeout(() => {
+      const params = new URLSearchParams(searchParams);
+      if (input) params.set('q', input);
+      else params.delete('q');
+      params.delete('page');
+      lastPushedRef.current = input;
+      router.push(`?${params.toString()}`);
+    }, 300);
+    return () => clearTimeout(timeout);
+  }, [input, router, searchParams]);
 
   const handlePageChange = (newPage: number) => {
     if (!Number.isFinite(newPage)) return;
@@ -57,7 +77,16 @@ const UserList: React.FC<UserListProps> = ({ users, currentPage, totalPages }) =
 
   return (
     <>
-      <DataTable data={users} columns={columns} enableGlobalSearch={true} />
+      <div className="mb-4">
+        <input
+          type="search"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder={t('common.labels.search').toString()}
+          className="w-full max-w-md rounded border border-gray-300 px-3 py-2 dark:border-gray-600 dark:bg-gray-800"
+        />
+      </div>
+      <DataTable data={users} columns={columns} />
       <Pagination
         currentPage={currentPage}
         totalPages={totalPages}

--- a/apps/web/src/app/(admin)/admin/users/actions.ts
+++ b/apps/web/src/app/(admin)/admin/users/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache';
 
+import { formatApiError } from '@eventuras/core/errors';
 import {
   actionError,
   actionSuccess,
@@ -10,23 +11,65 @@ import {
 import { Logger } from '@eventuras/logger';
 
 import { appConfig } from '@/config.server';
+import { readCorrelationIdFromResponse } from '@/lib/correlation-id';
 import { client } from '@/lib/eventuras-client';
 import {
+  getV3Users,
+  PageResponseDtoOfUserDto,
   postV3Users,
   putV3Userprofile,
   putV3UsersById,
   UserDto,
   UserFormDto,
 } from '@/lib/eventuras-sdk';
+import { getOrganizationId } from '@/utils/organization';
 
 const logger = Logger.create({
   namespace: 'web:users',
   context: { module: 'actions' },
 });
 
-/**
- * Create a new user
- */
+export async function getUsers(page: number = 1, pageSize: number = 50) {
+  let organizationId: number | undefined;
+
+  try {
+    organizationId = getOrganizationId();
+
+    const { data, error } = await getV3Users({
+      client,
+      headers: {
+        'Eventuras-Org-Id': organizationId,
+      },
+      query: {
+        Page: page,
+        Count: pageSize,
+      },
+    });
+
+    if (error) {
+      logger.error({ error, organizationId, page, pageSize }, 'Failed to fetch users');
+      return {
+        ok: false as const,
+        error: String(error),
+        data: null,
+      };
+    }
+
+    return {
+      ok: true as const,
+      data: data as PageResponseDtoOfUserDto,
+      error: null,
+    };
+  } catch (error) {
+    logger.error({ error, organizationId, page, pageSize }, 'Unexpected error fetching users');
+    return {
+      ok: false as const,
+      error: error instanceof Error ? error.message : 'Unknown error',
+      data: null,
+    };
+  }
+}
+
 export async function createUser(userData: UserFormDto): Promise<ServerActionResult<UserDto>> {
   logger.info('Creating new user');
 
@@ -38,7 +81,14 @@ export async function createUser(userData: UserFormDto): Promise<ServerActionRes
 
     if (!response.data) {
       logger.error({ error: response.error }, 'Failed to create user');
-      return actionError('Failed to create user');
+      return actionError(
+        formatApiError(
+          response.error,
+          'Failed to create user',
+          response.response?.status,
+          response.response ? readCorrelationIdFromResponse(response.response) : undefined
+        )
+      );
     }
 
     logger.info({ userId: response.data.id }, 'User created successfully');
@@ -50,9 +100,6 @@ export async function createUser(userData: UserFormDto): Promise<ServerActionRes
   }
 }
 
-/**
- * Update an existing user (admin endpoint)
- */
 export async function updateUser(
   userId: string,
   userData: UserFormDto
@@ -68,7 +115,14 @@ export async function updateUser(
 
     if (!response.data) {
       logger.error({ error: response.error, userId }, 'Failed to update user');
-      return actionError('Failed to update user');
+      return actionError(
+        formatApiError(
+          response.error,
+          'Failed to update user',
+          response.response?.status,
+          response.response ? readCorrelationIdFromResponse(response.response) : undefined
+        )
+      );
     }
 
     logger.info({ userId }, 'User updated successfully');
@@ -81,9 +135,6 @@ export async function updateUser(
   }
 }
 
-/**
- * Update the current user's profile
- */
 export async function updateUserProfile(
   userData: UserFormDto
 ): Promise<ServerActionResult<UserDto>> {
@@ -110,7 +161,14 @@ export async function updateUserProfile(
 
     if (!response.data) {
       logger.error({ error: response.error }, 'Failed to update user profile');
-      return actionError('Failed to update your profile');
+      return actionError(
+        formatApiError(
+          response.error,
+          'Failed to update your profile',
+          response.response?.status,
+          response.response ? readCorrelationIdFromResponse(response.response) : undefined
+        )
+      );
     }
 
     logger.info({ userId: response.data.id }, 'User profile updated successfully');

--- a/apps/web/src/app/(admin)/admin/users/actions.ts
+++ b/apps/web/src/app/(admin)/admin/users/actions.ts
@@ -29,7 +29,7 @@ const logger = Logger.create({
   context: { module: 'actions' },
 });
 
-export async function getUsers(page: number = 1, pageSize: number = 50) {
+export async function getUsers(page: number = 1, pageSize: number = 50, query?: string) {
   let organizationId: number | undefined;
 
   try {
@@ -43,11 +43,12 @@ export async function getUsers(page: number = 1, pageSize: number = 50) {
       query: {
         Page: page,
         Count: pageSize,
+        ...(query ? { Query: query } : {}),
       },
     });
 
     if (error) {
-      logger.error({ error, organizationId, page, pageSize }, 'Failed to fetch users');
+      logger.error({ error, organizationId, page, pageSize, query }, 'Failed to fetch users');
       return {
         ok: false as const,
         error: String(error),
@@ -61,7 +62,10 @@ export async function getUsers(page: number = 1, pageSize: number = 50) {
       error: null,
     };
   } catch (error) {
-    logger.error({ error, organizationId, page, pageSize }, 'Unexpected error fetching users');
+    logger.error(
+      { error, organizationId, page, pageSize, query },
+      'Unexpected error fetching users'
+    );
     return {
       ok: false as const,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/apps/web/src/app/(admin)/admin/users/page.tsx
+++ b/apps/web/src/app/(admin)/admin/users/page.tsx
@@ -2,29 +2,49 @@ import { getTranslations } from 'next-intl/server';
 
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
+import { Section } from '@eventuras/ratio-ui/layout/Section';
 
-import { UserDto } from '@/lib/eventuras-sdk';
-import { getV3Users } from '@/lib/eventuras-sdk';
-import { getOrganizationId } from '@/utils/organization';
+import FatalError from '@/components/FatalError';
 
+import { getUsers } from './actions';
 import UserList from './UserList';
 import UsersActionMenu from './UsersActionMenu';
-const AdminUserPage = async () => {
+
+type PageProps = {
+  searchParams: Promise<{ page?: string }>;
+};
+
+export default async function AdminUserPage({ searchParams }: Readonly<PageProps>) {
   const t = await getTranslations();
-  const orgId = getOrganizationId();
-  const response = await getV3Users({
-    headers: {
-      'Eventuras-Org-Id': orgId,
-    },
-  });
-  const data: UserDto[] = response.data?.data ?? [];
+  const params = await searchParams;
+  const parsedPage = params.page ? Number.parseInt(params.page, 10) : 1;
+  const page = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
+  const pageSize = 50;
+  const response = await getUsers(page, pageSize);
+
+  if (!response.ok || !response.data) {
+    return (
+      <Section className="py-8">
+        <Container>
+          <Heading as="h1">{t('admin.users.page.title')}</Heading>
+          <FatalError
+            title="Failed to load users"
+            description={response.error || 'Unknown error'}
+          />
+        </Container>
+      </Section>
+    );
+  }
+
   return (
     <Container>
       <Heading as="h1">{t('admin.users.page.title')}</Heading>
       <UsersActionMenu />
-      <UserList users={data} />
+      <UserList
+        users={response.data.data ?? []}
+        currentPage={page}
+        totalPages={response.data.pages ?? 0}
+      />
     </Container>
   );
-};
-
-export default AdminUserPage;
+}

--- a/apps/web/src/app/(admin)/admin/users/page.tsx
+++ b/apps/web/src/app/(admin)/admin/users/page.tsx
@@ -11,7 +11,7 @@ import UserList from './UserList';
 import UsersActionMenu from './UsersActionMenu';
 
 type PageProps = {
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{ page?: string; q?: string }>;
 };
 
 export default async function AdminUserPage({ searchParams }: Readonly<PageProps>) {
@@ -20,7 +20,8 @@ export default async function AdminUserPage({ searchParams }: Readonly<PageProps
   const parsedPage = params.page ? Number.parseInt(params.page, 10) : 1;
   const page = Number.isInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
   const pageSize = 50;
-  const response = await getUsers(page, pageSize);
+  const query = params.q?.trim() || undefined;
+  const response = await getUsers(page, pageSize, query);
 
   if (!response.ok || !response.data) {
     return (
@@ -44,6 +45,7 @@ export default async function AdminUserPage({ searchParams }: Readonly<PageProps
         users={response.data.data ?? []}
         currentPage={page}
         totalPages={response.data.pages ?? 0}
+        query={query ?? ''}
       />
     </Container>
   );


### PR DESCRIPTION
## Summary

Brings admin/users up to the same baseline as admin/registrations. Three changes, one commit:

- **Server-side pagination.** `page.tsx` now reads `?page=` from `searchParams` and delegates data fetching to a new `getUsers` server action; \`UserList\` is a presentation component that navigates via the URL instead of handling pagination state client-side. Replaces the hard-coded 10-row client-side window.
- **Richer error context.** \`createUser\`, \`updateUser\`, and \`updateUserProfile\` now run response errors through \`formatApiError\` + \`readCorrelationIdFromResponse\`, matching [registrations/actions.ts](apps/web/src/app/(admin)/admin/registrations/actions.ts).
- **Consistent structure.** \`getUsers\` mirrors \`getRegistrations\` (\`Eventuras-Org-Id\` header, try/catch wrapper, ok/data/error result shape) for parity.

Success paths on create/update are unchanged; only the error branches pick up better context.

## Out of scope — follow-up (PR 2)

Separate PR will add BusinessEvents-emission on user create/update and org-scoped filtering in \`UserRetrievalService.ListUsers()\` on the API side.

## Test plan

- [x] \`pnpm tsc --noEmit\` — 0 errors
- [x] \`pnpm lint\` — 0 errors (pre-existing warnings unchanged)
- [ ] Manual: \`/admin/users\` → pagination buttons update URL \`?page=\` and reload with fresh data
- [ ] Manual: search still works (\`enableGlobalSearch\` preserved)
- [ ] Manual: trigger a failing create/update (e.g. duplicate email) → toast shows formatted API error with correlation id