### PR TITLE
fix(web): silence React 19 script-tag warning in InitTheme

### DIFF
--- a/apps/web/src/providers/theme/InitTheme.tsx
+++ b/apps/web/src/providers/theme/InitTheme.tsx
@@ -1,3 +1,5 @@
+import Script from 'next/script';
+
 import { defaultTheme, themeLocalStorageKey } from './shared';
 
 const themeScript = `
@@ -28,6 +30,11 @@ const themeScript = `
 })();
 `;
 
-export const InitTheme = () => {
-  return <script id="theme-script" dangerouslySetInnerHTML={{ __html: themeScript }} />;
-};
+// Uses next/script with beforeInteractive so the script lands in the SSR
+// head and runs before hydration (anti-FOUC). A plain <script> here
+// triggers a React 19 dev warning even though it works at runtime.
+export const InitTheme = () => (
+  <Script id="theme-script" strategy="beforeInteractive">
+    {themeScript}
+  </Script>
+);


### PR DESCRIPTION
## Summary

\`InitTheme\` renders an inline \`<script>\` in \`<head>\` to set \`data-theme\` before hydration (anti-FOUC pattern). React 19's dev runtime has started flagging bare \`<script>\` tags inside components because *client*-rendered scripts don't execute — even though this one only ever reaches the client via SSR output and works fine.

Switches to \`next/script\` with \`strategy="beforeInteractive"\`. Same timing (script lands in the SSR HTML and runs before interactive), no warning.

## Test plan

- [x] \`pnpm tsc --noEmit\` — 0 errors
- [ ] Manual: load any page → warning gone from console
- [ ] Manual: reload with a \`theme\` preference in localStorage → \`data-theme\` attribute is correct on \`<html>\` before first paint (no light-theme flash)
- [ ] Manual: toggle system theme pref → default picks it up