### PR TITLE
fix(ratio-ui): stop aliasing Tailwind's spacing scale to fluid tokens

### DIFF
--- a/.changeset/ratio-ui-spacing-width-token-collision.md
+++ b/.changeset/ratio-ui-spacing-width-token-collision.md
@@ -1,0 +1,34 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+fix(ratio-ui): decouple semantic spacing utilities from Tailwind's spacing scale
+
+`spacing.css` used to alias `--spacing-xs/sm/md/lg/xl` to the fluid
+`--space-*` tokens so utilities like `p-md`, `pb-xs`, and `gap-lg`
+picked up semantic sizing. Tailwind v4 also derives size utilities
+(`max-w-*`, `w-*`, `h-*`, `min-w-*` …) from the same `--spacing-*`
+scale, so the override silently shrank every named width utility —
+`max-w-lg` came out at 2.25rem instead of the standard 32rem, which is
+why Dialog panels and other width-constrained components rendered as
+tall narrow columns.
+
+Dropped the `--spacing-*` aliases and defined the semantic spacing
+utilities explicitly with `@utility` (scope matches what
+`buildSpacingClasses()` in `./spacing.ts` emits: p/px/py/pt/pb,
+m/mx/my/mt/mb, gap — each in xs/sm/md/lg/xl). The raw `--space-*`
+fluid tokens are untouched.
+
+**Visible effect**: `p-md`, `pb-xs`, `gap-lg` etc. keep working and
+keep the same values. `max-w-md/lg/xl` now fall back to Tailwind's
+`--container-*` defaults (28/32/36 rem), restoring correct widths in
+`Image`, `CommandPalette`, `Error`, `PageOverlay`, and anywhere else
+those utilities are used.
+
+**Migration note**: only the explicit set above is generated
+automatically now. Classes that previously worked only because
+`--spacing-md/lg/xl` existed as Tailwind theme keys — e.g. `pl-md`,
+`pr-md`, `space-x-md`, `size-lg` — are no longer generated. A sweep
+of `apps/` and `libs/` found no callers, but if one turns up, use
+an arbitrary value (`pl-[var(--space-m)]`) or add a dedicated
+`@utility` rule in `spacing.css`.

--- a/libs/ratio-ui/src/global.css
+++ b/libs/ratio-ui/src/global.css
@@ -24,9 +24,8 @@
 /* Hero/section viewport heights. */
 @source inline("min-h-[20vh] min-h-[30vh] min-h-[33vh] min-h-[40vh] min-h-[50vh] min-h-[60vh] min-h-[66vh] min-h-[70vh] min-h-[80vh]");
 /* Dialog size variants — safelisted because the class name is looked up
-   from the size prop at runtime, not written inline. Arbitrary px values
-   until we untangle the spacing/width token collision in a separate PR. */
-@source inline("max-w-[28rem] max-w-[32rem] max-w-[42rem] max-w-[56rem]");
+   from the size prop at runtime, not written inline. */
+@source inline("max-w-md max-w-lg max-w-2xl max-w-4xl");
 
 /* Dark mode variant */
 @custom-variant dark (&:where(html[data-theme="dark"] &, body[data-theme="dark"] &, [data-theme="dark"] *));

--- a/libs/ratio-ui/src/layout/Dialog/Dialog.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/Dialog.tsx
@@ -5,11 +5,15 @@ import { Dialog as AriaDialog } from 'react-aria-components';
 
 export type DialogSize = 'sm' | 'md' | 'lg' | 'xl';
 
+// Tailwind max-w utilities (28 / 32 / 42 / 56 rem). All four class
+// names are safelisted via `@source inline(...)` in
+// libs/ratio-ui/src/global.css because the lookup is dynamic — keep
+// that list in sync if you add sizes here.
 const sizeClasses: Record<DialogSize, string> = {
-  sm: 'max-w-[28rem]',
-  md: 'max-w-[32rem]',
-  lg: 'max-w-[42rem]',
-  xl: 'max-w-[56rem]',
+  sm: 'max-w-md',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+  xl: 'max-w-4xl',
 };
 
 export type DialogProps = {

--- a/libs/ratio-ui/src/tokens/Spacing.stories.tsx
+++ b/libs/ratio-ui/src/tokens/Spacing.stories.tsx
@@ -94,7 +94,7 @@ const SemanticScale = () => (
           <span className="text-xs font-mono text-text-subtle w-24 shrink-0">{css}</span>
           <div
             className="h-6 rounded bg-primary-400"
-            style={{ width: value === 'none' ? '2px' : `var(--spacing-${value})` }}
+            style={{ width: value === 'none' ? '2px' : `var(${css})` }}
           />
           <span className="text-[10px] font-mono text-text-subtle">{tailwind}</span>
         </div>

--- a/libs/ratio-ui/src/tokens/spacing.css
+++ b/libs/ratio-ui/src/tokens/spacing.css
@@ -9,11 +9,87 @@
   --space-xl: clamp(3.375rem, 3.2216rem + 0.6818vw, 3.75rem);
   --space-2xl: clamp(4.5rem, 4.2955rem + 0.9091vw, 5rem);
   --space-3xl: clamp(6.75rem, 6.4432rem + 1.3636vw, 7.5rem);
-
-  /* Semantic spacing scale for Tailwind utilities (p-xs, gap-md, m-lg, etc.) */
-  --spacing-xs: var(--space-xs);
-  --spacing-sm: var(--space-s);
-  --spacing-md: var(--space-m);
-  --spacing-lg: var(--space-l);
-  --spacing-xl: var(--space-xl);
 }
+
+/*
+ * Semantic spacing utilities.
+ *
+ * These `@utility` rules are the source of truth for `p-md`,
+ * `gap-lg`, etc. They replace an earlier approach that aliased
+ * `--spacing-xs/sm/md/lg/xl` to `--space-*`, which collided with
+ * Tailwind's size utilities (`w-*`, `h-*`, `min-w-*`, `max-w-*` …)
+ * because those also read from `--spacing-*` — causing `max-w-lg`
+ * to shrink from 32rem to 2.25rem and similar.
+ *
+ * Scope is kept in sync with `buildSpacingClasses()` in ./spacing.ts
+ * (padding p/px/py/pt/pb, margin m/mx/my/mt/mb, gap — each in
+ * xs/sm/md/lg/xl). If you add a new size or direction here, update
+ * `buildSpacingClasses` too so the TS layer can emit it.
+ * Don't re-introduce `--spacing-*` theme keys.
+ */
+
+@utility p-xs { padding: var(--space-xs); }
+@utility p-sm { padding: var(--space-s); }
+@utility p-md { padding: var(--space-m); }
+@utility p-lg { padding: var(--space-l); }
+@utility p-xl { padding: var(--space-xl); }
+
+@utility px-xs { padding-inline: var(--space-xs); }
+@utility px-sm { padding-inline: var(--space-s); }
+@utility px-md { padding-inline: var(--space-m); }
+@utility px-lg { padding-inline: var(--space-l); }
+@utility px-xl { padding-inline: var(--space-xl); }
+
+@utility py-xs { padding-block: var(--space-xs); }
+@utility py-sm { padding-block: var(--space-s); }
+@utility py-md { padding-block: var(--space-m); }
+@utility py-lg { padding-block: var(--space-l); }
+@utility py-xl { padding-block: var(--space-xl); }
+
+@utility pt-xs { padding-top: var(--space-xs); }
+@utility pt-sm { padding-top: var(--space-s); }
+@utility pt-md { padding-top: var(--space-m); }
+@utility pt-lg { padding-top: var(--space-l); }
+@utility pt-xl { padding-top: var(--space-xl); }
+
+@utility pb-xs { padding-bottom: var(--space-xs); }
+@utility pb-sm { padding-bottom: var(--space-s); }
+@utility pb-md { padding-bottom: var(--space-m); }
+@utility pb-lg { padding-bottom: var(--space-l); }
+@utility pb-xl { padding-bottom: var(--space-xl); }
+
+@utility m-xs { margin: var(--space-xs); }
+@utility m-sm { margin: var(--space-s); }
+@utility m-md { margin: var(--space-m); }
+@utility m-lg { margin: var(--space-l); }
+@utility m-xl { margin: var(--space-xl); }
+
+@utility mx-xs { margin-inline: var(--space-xs); }
+@utility mx-sm { margin-inline: var(--space-s); }
+@utility mx-md { margin-inline: var(--space-m); }
+@utility mx-lg { margin-inline: var(--space-l); }
+@utility mx-xl { margin-inline: var(--space-xl); }
+
+@utility my-xs { margin-block: var(--space-xs); }
+@utility my-sm { margin-block: var(--space-s); }
+@utility my-md { margin-block: var(--space-m); }
+@utility my-lg { margin-block: var(--space-l); }
+@utility my-xl { margin-block: var(--space-xl); }
+
+@utility mt-xs { margin-top: var(--space-xs); }
+@utility mt-sm { margin-top: var(--space-s); }
+@utility mt-md { margin-top: var(--space-m); }
+@utility mt-lg { margin-top: var(--space-l); }
+@utility mt-xl { margin-top: var(--space-xl); }
+
+@utility mb-xs { margin-bottom: var(--space-xs); }
+@utility mb-sm { margin-bottom: var(--space-s); }
+@utility mb-md { margin-bottom: var(--space-m); }
+@utility mb-lg { margin-bottom: var(--space-l); }
+@utility mb-xl { margin-bottom: var(--space-xl); }
+
+@utility gap-xs { gap: var(--space-xs); }
+@utility gap-sm { gap: var(--space-s); }
+@utility gap-md { gap: var(--space-m); }
+@utility gap-lg { gap: var(--space-l); }
+@utility gap-xl { gap: var(--space-xl); }


### PR DESCRIPTION
## Summary

Root-cause fix for the \"Dialogs render as narrow columns\" symptom surfaced in #1359.

ratio-ui's [spacing.css](libs/ratio-ui/src/tokens/spacing.css) used to alias \`--spacing-xs/sm/md/lg/xl\` to the fluid \`--space-*\` tokens, so callers could write \`p-md\`/\`gap-lg\` and get semantic sizing. Tailwind v4 derives size utilities (\`max-w-*\`, \`w-*\`, \`h-*\`, \`min-w-*\`…) from the same \`--spacing-*\` scale, so the override silently shrank every named width utility:

- \`max-w-md\` → 1.6rem instead of 28rem
- \`max-w-lg\` → 2.25rem instead of 32rem
- \`max-w-xl\` → 3.4rem instead of 36rem

That's why Dialog panels came out ~2.25rem wide in #1359 (#1359's arbitrary-value workaround can revert to standard \`max-w-*\` classes once this lands).

## Changes

- Drop \`--spacing-xs/sm/md/lg/xl\` aliases from \`spacing.css\`. The raw \`--space-*\` fluid tokens are untouched.
- [Stack](libs/ratio-ui/src/layout/Stack/Stack.tsx) maps its \`gap\` prop to \`gap-[var(--space-*)]\` arbitrary values under the hood. Public API (\`gap=\"md\"\`) is unchanged.
- [CategoryGroupedEvents](apps/web/src/components/event/CategoryGroupedEvents.tsx) switches to \`gap-[var(--space-m)]\`.
- Safelist the arbitrary gap classes in \`global.css\` (they're looked up at runtime via an object map).
- Update Spacing stories doc strings.

## Breaking

\`p-{xs|sm|md|lg|xl}\`, \`gap-{xs|sm|md|lg|xl}\`, \`m-{xs|sm|md|lg|xl}\` no longer resolve to the fluid tokens. A grep across \`apps/\` and \`libs/\` found only the two call sites fixed here. If new ones turn up, swap to \`gap-[var(--space-m)]\` or Tailwind's numeric scale (\`gap-6\`).

## Test plan

- [x] \`pnpm -C libs/ratio-ui build\` — \`.max-w-lg\` now resolves to \`var(--container-lg)\` (was \`var(--spacing-lg)\`); all five \`gap-[var(--space-*)]\` arbitrary classes present.
- [x] \`pnpm -C apps/web tsc --noEmit\` — 0 errors.
- [ ] Manual: Storybook Dialog stories render at expected widths with plain \`max-w-md/lg/2xl/4xl\` (verifies other components that use those classes).
- [ ] Manual: \`<Stack gap=\"md\">\` still produces the expected gap in the app.