### PR TITLE
feat(fides-auth): expose granted OAuth scopes on Session

### DIFF
--- a/.changeset/fides-auth-session-scopes.md
+++ b/.changeset/fides-auth-session-scopes.md
@@ -1,0 +1,11 @@
+---
+"@eventuras/fides-auth": minor
+---
+
+Surface granted scopes as a first-class field on `Session`.
+
+- Added `scopes?: string[]` to the `Session` interface in `types.ts`
+- `buildSessionFromTokens` now populates `session.scopes` by splitting the space-separated `tokens.scope` string (empty/missing scope leaves the field `undefined`)
+- Added `hasScope(session, scope)` convenience helper in `utils.ts`
+
+Backwards-compatible — `scopes` is optional and existing consumers compile and run unchanged.

--- a/libs/fides-auth/src/oauth.build-session.test.ts
+++ b/libs/fides-auth/src/oauth.build-session.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { SignJWT } from 'jose';
+import { buildSessionFromTokens } from './oauth';
+import type { TokenEndpointResponse } from 'openid-client';
+
+async function createIdToken(claims: Record<string, unknown>): Promise<string> {
+  const secret = new TextEncoder().encode('test-secret-at-least-32-bytes!!');
+  return new SignJWT(claims)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(secret);
+}
+
+async function makeTokenResponse(
+  extra?: Partial<TokenEndpointResponse>,
+): Promise<TokenEndpointResponse> {
+  const idToken = await createIdToken({
+    sub: 'user-123',
+    name: 'Ola Nordmann',
+    email: 'ola@example.com',
+  });
+  return {
+    access_token: 'access-token',
+    token_type: 'Bearer',
+    id_token: idToken,
+    ...extra,
+  } as TokenEndpointResponse;
+}
+
+describe('buildSessionFromTokens — scopes', () => {
+  it('populates scopes from a space-separated scope string', async () => {
+    const tokens = await makeTokenResponse({ scope: 'openid profile email' });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toEqual(['openid', 'profile', 'email']);
+  });
+
+  it('leaves scopes undefined when scope field is absent', async () => {
+    const tokens = await makeTokenResponse();
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toBeUndefined();
+  });
+
+  it('leaves scopes undefined when scope is an empty string', async () => {
+    const tokens = await makeTokenResponse({ scope: '' });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toBeUndefined();
+  });
+
+  it('leaves scopes undefined when scope contains only whitespace', async () => {
+    const tokens = await makeTokenResponse({ scope: '   ' });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toBeUndefined();
+  });
+
+  it('leaves scopes undefined when scope field is not a string', async () => {
+    const tokens = await makeTokenResponse({ scope: 123 as unknown as string });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toBeUndefined();
+  });
+
+  it('handles multiple consecutive spaces by filtering empty strings', async () => {
+    const tokens = await makeTokenResponse({ scope: 'openid  profile   email' });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toEqual(['openid', 'profile', 'email']);
+  });
+
+  it('handles a single scope value', async () => {
+    const tokens = await makeTokenResponse({ scope: 'openid' });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.scopes).toEqual(['openid']);
+  });
+
+  it('still populates user and tokens alongside scopes', async () => {
+    const tokens = await makeTokenResponse({ scope: 'openid profile' });
+    const session = buildSessionFromTokens(tokens);
+    expect(session.user?.email).toBe('ola@example.com');
+    expect(session.tokens?.accessToken).toBe('access-token');
+    expect(session.scopes).toEqual(['openid', 'profile']);
+  });
+});

--- a/libs/fides-auth/src/oauth.ts
+++ b/libs/fides-auth/src/oauth.ts
@@ -353,6 +353,12 @@ export function buildSessionFromTokens(
 
   const userInfo = extractUserFromTokens(tokens, rolesClaim);
 
+  let scopes: string[] | undefined;
+  if (typeof tokens.scope === 'string') {
+    const parsed = tokens.scope.split(' ').filter(s => s.length > 0);
+    if (parsed.length > 0) scopes = parsed;
+  }
+
   return {
     tokens: {
       accessToken: tokens.access_token,
@@ -366,6 +372,7 @@ export function buildSessionFromTokens(
       email: userInfo.email,
       roles: userInfo.roles,
     },
+    scopes,
   };
 }
 

--- a/libs/fides-auth/src/session-validation.test.ts
+++ b/libs/fides-auth/src/session-validation.test.ts
@@ -74,6 +74,19 @@ describe('session lifecycle: create → validate', () => {
     expect((result.session as any).data).toEqual({ orgId: 42, plan: 'enterprise' });
   });
 
+  it('preserves scopes through the round-trip', async () => {
+    const session: Session = {
+      ...testSession,
+      scopes: ['openid', 'profile', 'operations.read'],
+    };
+
+    const jwt = await createEncryptedJWT({ ...session }, SECRET);
+    const result = await validateSessionJwt(jwt, SECRET);
+
+    expect(result.status).toBe('VALID');
+    expect(result.session?.scopes).toEqual(['openid', 'profile', 'operations.read']);
+  });
+
   it('handles a minimal session with only user info', async () => {
     const minimalSession: Session = {
       user: { name: 'Min', email: 'min@test.no' },

--- a/libs/fides-auth/src/types.ts
+++ b/libs/fides-auth/src/types.ts
@@ -14,6 +14,8 @@ export interface Session<TData = Record<string, unknown>> {
     email: string;
     roles?: string[];
   };
+  /** OAuth scopes granted to this session (e.g. ["openid", "profile", "email"]). */
+  scopes?: string[];
   /** Application-specific data stored alongside the session. */
   data?: TData;
 }

--- a/libs/fides-auth/src/utils.test.ts
+++ b/libs/fides-auth/src/utils.test.ts
@@ -12,6 +12,7 @@ import {
   accessTokenExpires,
   getSessionSecret,
   getSessionSecretUint8Array,
+  hasScope,
 } from './utils';
 
 /** 32-byte (256-bit) AES key — 64 hex characters */
@@ -379,5 +380,25 @@ describe('getSessionSecretUint8Array', () => {
   it('throws when SESSION_SECRET is not set', () => {
     vi.stubEnv('SESSION_SECRET', '');
     expect(() => getSessionSecretUint8Array()).toThrow('SESSION_SECRET is not defined');
+  });
+});
+
+describe('hasScope', () => {
+  const session = { scopes: ['openid', 'profile', 'operations.read'] };
+
+  it('returns true when the scope is present', () => {
+    expect(hasScope(session, 'operations.read')).toBe(true);
+  });
+
+  it('returns false when the scope is absent', () => {
+    expect(hasScope(session, 'admin.write')).toBe(false);
+  });
+
+  it('returns false when session.scopes is undefined', () => {
+    expect(hasScope({}, 'openid')).toBe(false);
+  });
+
+  it('is case-sensitive', () => {
+    expect(hasScope(session, 'OPENID')).toBe(false);
   });
 });

--- a/libs/fides-auth/src/utils.ts
+++ b/libs/fides-auth/src/utils.ts
@@ -1,6 +1,7 @@
 import * as jose from 'jose';
 
 import { createLogger } from './logger';
+import type { Session } from './types';
 
 const logger = createLogger({ namespace: 'fides-auth:utils' });
 
@@ -272,3 +273,13 @@ export const accessTokenExpires = (
     return true;
   }
 };
+
+/**
+ * Returns true if the session was granted the given scope.
+ *
+ * @param session - The session to check
+ * @param scope - The scope string to look for (e.g. "operations.read")
+ */
+export function hasScope(session: Session, scope: string): boolean {
+  return session.scopes?.includes(scope) ?? false;
+}


### PR DESCRIPTION
Add `scopes?: string[]` to the Session type and populate it from the space-separated `tokens.scope` field in `buildSessionFromTokens`. Introduce `hasScope(session, scope)` helper for call-site checks.

Backwards-compatible — field is optional and absent scope leaves it undefined.