### PR TITLE
chore(vite-config): stop bundling runtime deps and minifying lib output

### DIFF
--- a/.changeset/vite-config-no-bundle-deps.md
+++ b/.changeset/vite-config-no-bundle-deps.md
@@ -1,0 +1,31 @@
+---
+"@eventuras/vite-config": patch
+"@eventuras/fides-auth": patch
+"@eventuras/fides-auth-next": patch
+"@eventuras/ratio-ui": patch
+"@eventuras/ratio-ui-next": patch
+"@eventuras/smartform": patch
+"@eventuras/datatable": patch
+"@eventuras/markdown": patch
+"@eventuras/markdown-plugin-happening": patch
+"@eventuras/scribo": patch
+"@eventuras/mailer": patch
+"@eventuras/notitia-templates": patch
+"@eventuras/logger": patch
+"@eventuras/app-config": patch
+---
+
+Stop bundling runtime dependencies into published library output, and stop minifying.
+
+The vanilla/react/next library presets used to inline every transitive dep (e.g. `oauth4webapi` was bundled into `@eventuras/fides-auth`) and minify class/function names. Two consequences:
+
+- **`instanceof` failed across module boundaries.** A consumer importing `ResponseBodyError` from `openid-client` got a different class than the one a library threw, because the library carried its own bundled+renamed copy.
+- **Stack traces were unreadable** — minified names like `j` instead of `ResponseBodyError`.
+
+The presets now:
+
+- Auto-externalize every entry in the consumer's `dependencies`, `peerDependencies`, and `optionalDependencies` (plus `node:*` built-ins).
+- Set `build.minify: false` (libraries should not minify — consumers minify their own bundle).
+- Emit sourcemaps so consumer stack traces map back to original sources.
+
+No API changes — all affected packages are bumped `patch`. The only observable effect is leaner, more debuggable output: deps are required at install time (already the case via each lib's `dependencies`) instead of duplicated inside the bundle.

--- a/libs/vite-config/src/externals.ts
+++ b/libs/vite-config/src/externals.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import { resolve } from 'node:path';
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+/**
+ * Reads the consumer package's package.json and returns RegExp patterns that
+ * mark every runtime dependency (and its subpaths) as external.
+ *
+ * Bundling runtime deps into a library is harmful: it duplicates code, breaks
+ * `instanceof` checks across module boundaries (the consumer's class identity
+ * differs from the bundled copy), and inflates installed size. Consumers
+ * already install these deps via the lib's own package.json.
+ */
+export function getRuntimeDependencyExternals(cwd: string = process.cwd()): RegExp[] {
+  const pkgPath = resolve(cwd, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as PackageJson;
+
+  const names = [
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ];
+
+  return names.map(name => new RegExp(`^${escapeRegex(name)}(/.*)?$`));
+}
+
+/**
+ * Externalize Node built-ins in both forms — `node:fs` (always matched by the
+ * regex) and the bare `fs` form (matched against the explicit list, since the
+ * names overlap with userland packages and can't be regex-distinguished).
+ */
+export const NODE_BUILTINS_EXTERNAL: (string | RegExp)[] = [
+  /^node:/,
+  ...builtinModules,
+];
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/libs/vite-config/src/next-lib.ts
+++ b/libs/vite-config/src/next-lib.ts
@@ -3,8 +3,8 @@ import { defineReactLibConfig, type ReactLibConfig } from './react-lib.ts';
 
 export interface NextLibConfig extends Omit<ReactLibConfig, 'external'> {
   /**
-   * Additional external dependencies beyond the Next.js defaults.
-   * Next.js, next/image, and next/link are already included.
+   * Additional external dependencies beyond the Next.js defaults and the
+   * package.json auto-externalization (via the underlying React preset).
    */
   external?: (string | RegExp)[];
 }

--- a/libs/vite-config/src/react-lib.ts
+++ b/libs/vite-config/src/react-lib.ts
@@ -6,6 +6,8 @@ import { resolve } from 'node:path';
 import { glob } from 'glob';
 import fs from 'node:fs';
 
+import { getRuntimeDependencyExternals, NODE_BUILTINS_EXTERNAL } from './externals.ts';
+
 /**
  * Plugin to preserve 'use client' directives in React Server Components.
  * This ensures client-side code is properly marked when building for Next.js.
@@ -57,10 +59,11 @@ export interface ReactLibConfig {
   entry: string | Record<string, string>;
 
   /**
-   * Additional external dependencies to exclude from the bundle.
-   * React, react-dom, and react/jsx-runtime are already included.
+   * Additional external dependencies to exclude from the bundle, on top of the
+   * runtime deps read from the consumer's package.json and the React core
+   * externals. Pass `false` to opt out of package.json auto-externalization.
    */
-  external?: (string | RegExp)[];
+  external?: (string | RegExp)[] | false;
 
   /**
    * Enable Tailwind CSS support via @tailwindcss/vite plugin.
@@ -122,7 +125,7 @@ export interface ReactLibConfig {
 export function defineReactLibConfig(config: ReactLibConfig): UserConfig {
   const {
     entry,
-    external = [],
+    external,
     tailwind = false,
     preserveModules = true,
     preserveUseClientDirectives = true,
@@ -130,6 +133,10 @@ export function defineReactLibConfig(config: ReactLibConfig): UserConfig {
     dts: dtsOptions = {},
     viteConfig = {},
   } = config;
+
+  const autoExternals =
+    external === false ? [] : getRuntimeDependencyExternals();
+  const userExternals = Array.isArray(external) ? external : [];
 
   // Determine entry points
   let entryPoints: string | string[] | Record<string, string>;
@@ -192,13 +199,20 @@ export function defineReactLibConfig(config: ReactLibConfig): UserConfig {
       ...viteConfig.resolve,
     },
     build: {
+      minify: false,
+      sourcemap: true,
       lib: {
         entry: entryPoints,
         formats: ['es'],
       },
       rollupOptions: {
         ...viteConfig.build?.rollupOptions,
-        external: [...reactExternals, ...external],
+        external: [
+          ...reactExternals,
+          ...autoExternals,
+          ...NODE_BUILTINS_EXTERNAL,
+          ...userExternals,
+        ],
         output: {
           preserveModules,
           ...(preserveModules && {

--- a/libs/vite-config/src/vanilla-lib.ts
+++ b/libs/vite-config/src/vanilla-lib.ts
@@ -2,6 +2,8 @@ import { defineConfig, type UserConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import { resolve } from 'node:path';
 
+import { getRuntimeDependencyExternals, NODE_BUILTINS_EXTERNAL } from './externals.ts';
+
 export interface VanillaLibConfig {
   /**
    * Library entry point(s). Can be a string or an object with multiple entries.
@@ -16,10 +18,11 @@ export interface VanillaLibConfig {
   name?: string;
 
   /**
-   * Additional external dependencies to exclude from the bundle.
-   * Common dependencies like 'react' and 'react-dom' are already included.
+   * Additional external dependencies to exclude from the bundle, on top of the
+   * runtime deps read from the consumer's package.json. Pass `false` to opt out
+   * of the package.json auto-externalization (rarely what you want).
    */
-  external?: (string | RegExp)[];
+  external?: (string | RegExp)[] | false;
 
   /**
    * Additional Vite configuration to merge.
@@ -29,10 +32,21 @@ export interface VanillaLibConfig {
 
 /**
  * Vite configuration preset for vanilla TypeScript libraries.
- * Includes TypeScript declaration generation and ES module output.
+ *
+ * Defaults that matter for libraries:
+ * - All runtime deps (dependencies + peerDependencies + optionalDependencies)
+ *   are externalized so consumers get one copy from their node_modules instead
+ *   of inlined+mangled copies inside the published bundle.
+ * - Minification is OFF — consumers minify their own bundle, and unminified
+ *   output preserves class names (so `instanceof` and stack traces work).
+ * - Sourcemaps ON for debuggable consumer stack traces.
  */
 export function defineVanillaLibConfig(config: VanillaLibConfig): UserConfig {
-  const { entry, name, external = [], viteConfig = {} } = config;
+  const { entry, name, external, viteConfig = {} } = config;
+
+  const autoExternals =
+    external === false ? [] : getRuntimeDependencyExternals();
+  const userExternals = Array.isArray(external) ? external : [];
 
   return defineConfig({
     plugins: [
@@ -43,20 +57,34 @@ export function defineVanillaLibConfig(config: VanillaLibConfig): UserConfig {
       ...(viteConfig.plugins || []),
     ],
     build: {
+      minify: false,
+      sourcemap: true,
       lib: {
         entry: typeof entry === 'string' ? resolve(process.cwd(), entry) : entry,
         ...(name && { name }),
         formats: ['es'],
-        fileName: (format, entryName) => `${entryName}.js`,
+        fileName: (_format, entryName) => `${entryName}.js`,
       },
       rollupOptions: {
-        external,
+        ...viteConfig.build?.rollupOptions,
+        external: [...autoExternals, ...NODE_BUILTINS_EXTERNAL, ...userExternals],
         output: {
           preserveModules: false,
+          ...viteConfig.build?.rollupOptions?.output,
         },
       },
-      ...viteConfig.build,
+      // Spread other build options from viteConfig except lib and rollupOptions
+      ...Object.fromEntries(
+        Object.entries(viteConfig.build || {}).filter(
+          ([key]) => key !== 'lib' && key !== 'rollupOptions'
+        )
+      ),
     },
-    ...viteConfig,
+    // Spread other viteConfig options except build and plugins
+    ...Object.fromEntries(
+      Object.entries(viteConfig).filter(
+        ([key]) => key !== 'build' && key !== 'plugins'
+      )
+    ),
   });
 }


### PR DESCRIPTION
## Summary

- Auto-externalize all entries from each consumer lib's `package.json` (`dependencies` + `peerDependencies` + `optionalDependencies`, plus `node:*` built-ins) in `defineVanillaLibConfig`, `defineReactLibConfig`, and (transitively) `defineNextLibConfig`.
- Turn off minification (`build.minify: false`) and enable sourcemaps for library output.
- New helper `libs/vite-config/src/externals.ts` reads the consumer's package.json at build-time.

## Why

The vanilla/react presets used to inline transitive runtime deps and minify identifiers. That had two real consequences:

1. **`instanceof` failed across module boundaries.** `oauth4webapi`'s `ResponseBodyError` was bundled into `@eventuras/fides-auth` and renamed (`class j` in stack traces). Consumers importing `ResponseBodyError` from `openid-client` got a different class identity than the one fides-auth was throwing — so `err instanceof ResponseBodyError` silently returned `false`.
2. **Unreadable stack traces** in production logs (`at j (build-nL2--iMi.js:992)`).

After this change, `dist/oauth.js` of fides-auth went from inlining the entire `oauth4webapi` library (the 34 kB hashed `build-*.js` chunk plus a handful of `decode_jwt-*`/`decrypt-*`/`deflate-*` chunks) to a single ~13 kB file with clean external imports:

```js
import { decodeJwt } from "jose";
import * as openid from "openid-client";
```

Consumers already declared these as `dependencies`, so no install-time impact — just one canonical copy at runtime.

## Verified

- `@eventuras/fides-auth`: 148 tests pass; `dist/` no longer contains hashed inline-bundle chunks; class/function names preserved.
- `@eventuras/ratio-ui`: builds clean; `react-aria-components` (previously bundled inline) is now externalized.
- `@eventuras/fides-auth-next` (next-lib preset): builds clean; workspace deps externalized.
- All 20 lib builds pass except the pre-existing `@eventuras/markdown` TS error on `MarkdownContent.tsx:134` (unrelated to this change — present on `main`).

## Test plan

- [ ] `pnpm -r --filter "./libs/*" build` succeeds locally
- [ ] Spot-check `dist/` of one vanilla lib (e.g. `fides-auth`) — no hashed chunks, deps imported externally
- [ ] Spot-check `dist/` of one react lib (e.g. `ratio-ui`) — `react-aria-components` and other deps imported externally
- [ ] `pnpm test` in `libs/fides-auth` passes (148 tests)
- [ ] CI green

## Notes

- Affects ~14 publishable packages (all bumped `patch`). No API surface changes; only build output changes.
- Consumers can opt out of package.json auto-externalization by passing `external: false` to the vanilla/react preset (rarely useful — only relevant if a package needs to ship a vendored copy of a dep on purpose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)