### PR TITLE
refactor(ratio-ui)!: replace Dialog title prop with compound subcomponents

### DIFF
--- a/.changeset/dialog-compound-api.md
+++ b/.changeset/dialog-compound-api.md
@@ -1,0 +1,36 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+Refactor `Dialog` to a compound API.
+
+The `title` prop is removed. Use `<Dialog.Heading>` instead, and the new `<Dialog.Content>` / `<Dialog.Footer>` slots when you need structured layout.
+
+**Before:**
+
+```tsx
+<Dialog isOpen={open} onClose={close} title="Edit product">
+  <Form>{/* … */}</Form>
+  <div className="flex gap-2">
+    <Button type="submit">Save</Button>
+    <Button variant="secondary" onClick={close}>Cancel</Button>
+  </div>
+</Dialog>
+```
+
+**After:**
+
+```tsx
+<Dialog isOpen={open} onClose={close}>
+  <Dialog.Heading>Edit product</Dialog.Heading>
+  <Dialog.Content>
+    <Form>{/* … */}</Form>
+  </Dialog.Content>
+  <Dialog.Footer>
+    <Button variant="secondary" onClick={close}>Cancel</Button>
+    <Button type="submit">Save</Button>
+  </Dialog.Footer>
+</Dialog>
+```
+
+Also adds an optional `role` prop (`'dialog' | 'alertdialog'`) so prompts that interrupt the user can opt into the correct ARIA role. A higher-level `AlertDialog` wrapper that builds on this primitive will follow in a separate release.

--- a/apps/web/src/app/(admin)/admin/collections/CollectionCreator.tsx
+++ b/apps/web/src/app/(admin)/admin/collections/CollectionCreator.tsx
@@ -62,14 +62,17 @@ const CollectionCreator: React.FC<{ organizationId: number }> = ({ organizationI
       <Button onClick={() => setModalOpen(!modalOpen)}>
         {t('admin.collection.labels.create')}
       </Button>
-      <Dialog isOpen={modalOpen} onClose={() => setModalOpen(false)} title={'Add collection'}>
-        <Form onSubmit={data => handleCreateCollection(data as EventCollectionCreateDto)}>
-          <HiddenInput name="organizationId" value={organizationId.toString()} />
-          <TextField name="name" label={t('common.labels.name')} />
-          <Button type="submit" loading={isSubmitting}>
-            {t('admin.collection.labels.create')}
-          </Button>
-        </Form>
+      <Dialog isOpen={modalOpen} onClose={() => setModalOpen(false)}>
+        <Dialog.Heading>Add collection</Dialog.Heading>
+        <Dialog.Content>
+          <Form onSubmit={data => handleCreateCollection(data as EventCollectionCreateDto)}>
+            <HiddenInput name="organizationId" value={organizationId.toString()} />
+            <TextField name="name" label={t('common.labels.name')} />
+            <Button type="submit" loading={isSubmitting}>
+              {t('admin.collection.labels.create')}
+            </Button>
+          </Form>
+        </Dialog.Content>
       </Dialog>
     </>
   );

--- a/apps/web/src/app/(admin)/admin/events/[id]/products/ProductModal.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/products/ProductModal.tsx
@@ -79,52 +79,55 @@ const ProductModal: React.FC<ProductModalProps> = ({
   };
 
   return (
-    <Dialog isOpen={isOpen} onClose={onClose} title={titleText} size="lg">
-      <Form onSubmit={submitProduct} className="space-y-6" defaultValues={product}>
-        <TextField
-          name="name"
-          label={t('common.products.labels.name')}
-          testId="product-name-input"
-          required
-        />
-        <TextField
-          name="description"
-          label={t('common.products.labels.description')}
-          testId="product-description-input"
-          multiline
-        />
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <NumberInput
-            name="price"
-            label={t('common.products.labels.price')}
-            placeholder="0"
-            testId="product-price-input"
+    <Dialog isOpen={isOpen} onClose={onClose} size="lg">
+      <Dialog.Heading>{titleText}</Dialog.Heading>
+      <Dialog.Content>
+        <Form onSubmit={submitProduct} className="space-y-6" defaultValues={product}>
+          <TextField
+            name="name"
+            label={t('common.products.labels.name')}
+            testId="product-name-input"
             required
           />
-          <NumberInput
-            name="vatPercent"
-            label={t('common.products.labels.vatPercent')}
-            placeholder="0"
-            testId="product-vat-input"
-            defaultValue={0}
-            required
+          <TextField
+            name="description"
+            label={t('common.products.labels.description')}
+            testId="product-description-input"
+            multiline
           />
-          <NumberInput
-            name="minimumQuantity"
-            label={t('common.products.labels.minimumQuantity')}
-            placeholder="0"
-            testId="product-minimum-quantity-input"
-          />
-        </div>
-        <div className="flex gap-2">
-          <Button type="submit" disabled={loading}>
-            {buttonText}
-          </Button>
-          <Button type="reset" variant="secondary" onClick={onClose}>
-            {t('common.buttons.cancel')}
-          </Button>
-        </div>
-      </Form>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <NumberInput
+              name="price"
+              label={t('common.products.labels.price')}
+              placeholder="0"
+              testId="product-price-input"
+              required
+            />
+            <NumberInput
+              name="vatPercent"
+              label={t('common.products.labels.vatPercent')}
+              placeholder="0"
+              testId="product-vat-input"
+              defaultValue={0}
+              required
+            />
+            <NumberInput
+              name="minimumQuantity"
+              label={t('common.products.labels.minimumQuantity')}
+              placeholder="0"
+              testId="product-minimum-quantity-input"
+            />
+          </div>
+          <Dialog.Footer>
+            <Button type="reset" variant="secondary" onClick={onClose}>
+              {t('common.buttons.cancel')}
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {buttonText}
+            </Button>
+          </Dialog.Footer>
+        </Form>
+      </Dialog.Content>
     </Dialog>
   );
 };

--- a/apps/web/src/components/eventuras/EditRegistrationProductsDialog.tsx
+++ b/apps/web/src/components/eventuras/EditRegistrationProductsDialog.tsx
@@ -66,7 +66,6 @@ const EditRegistrationProductsDialog = (props: EditRegistrationProductsDialogPro
         </Button>
       )}
       <Dialog
-        title="Edit Orders"
         isOpen={editorOpen}
         testId="edit-orders-dialog"
         onClose={() => {
@@ -76,20 +75,23 @@ const EditRegistrationProductsDialog = (props: EditRegistrationProductsDialogPro
           }
         }}
       >
-        <div className="mt-2">
-          <p>
-            {props.description ??
-              `Go ahead and edit your orders below. Please note that mandatory products of an event
+        <Dialog.Heading>Edit Orders</Dialog.Heading>
+        <Dialog.Content>
+          <div className="mt-2">
+            <p>
+              {props.description ??
+                `Go ahead and edit your orders below. Please note that mandatory products of an event
             cannot be changed directly, please contact an administrator instead.`}
-          </p>
-        </div>
-        <div>
-          <RegistrationProductsCustomize
-            products={props.eventProducts}
-            selectedProducts={props.currentRegistration.products!}
-            onSubmit={onSubmit}
-          />
-        </div>
+            </p>
+          </div>
+          <div>
+            <RegistrationProductsCustomize
+              products={props.eventProducts}
+              selectedProducts={props.currentRegistration.products!}
+              onSubmit={onSubmit}
+            />
+          </div>
+        </Dialog.Content>
       </Dialog>
     </>
   );

--- a/apps/web/src/components/eventuras/EditUserRegistrationDialog.tsx
+++ b/apps/web/src/components/eventuras/EditUserRegistrationDialog.tsx
@@ -6,14 +6,16 @@ export type EditUserRegistrationDialogProps = {
 
 const EditUserRegistrationDialog = (props: EditUserRegistrationDialogProps) => {
   return (
-    <Dialog title="Edit Participant" isOpen={props.editorOpen} onClose={() => {}}>
-      <div className="mt-2">
-        <p className="text-sm text-gray-500">
-          Go ahead and edit your orders below. Please note that mandatory products of an event
-          cannot be changed directly, please contact an administrator instead.
-        </p>
-      </div>
-      <div></div>
+    <Dialog isOpen={props.editorOpen} onClose={() => {}}>
+      <Dialog.Heading>Edit Participant</Dialog.Heading>
+      <Dialog.Content>
+        <div className="mt-2">
+          <p className="text-sm text-gray-500">
+            Go ahead and edit your orders below. Please note that mandatory products of an event
+            cannot be changed directly, please contact an administrator instead.
+          </p>
+        </div>
+      </Dialog.Content>
     </Dialog>
   );
 };

--- a/libs/ratio-ui/src/layout/Dialog/Dialog.stories.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/Dialog.stories.tsx
@@ -7,60 +7,68 @@ const meta: Meta<DialogProps> = {
   title: 'Layout/Dialog',
   component: Dialog,
   args: {
-    title: 'Example Dialog',
-    children: <p>This is a dialog body.</p>,
     isOpen: true,
+    onClose: () => {},
   },
 };
 export default meta;
 
 type Story = StoryObj<DialogProps>;
 
-/**
- * Helper wrapper to handle open/close state
- */
-const StatefulDialog = (args: Omit<DialogProps, 'isOpen' | 'onClose'>) => {
+const StatefulDialog = (args: Omit<DialogProps, 'isOpen' | 'onClose' | 'children'>) => {
   const [open, setOpen] = useState(false);
-
   return (
     <div>
-      {/* Open dialog button */}
       <Button onClick={() => setOpen(true)}>Open Dialog</Button>
-
-      {/* Dialog with state control */}
-      <Dialog {...args} isOpen={open} onClose={() => setOpen(false)} />
+      <Dialog {...args} isOpen={open} onClose={() => setOpen(false)}>
+        <Dialog.Heading>Interactive Dialog</Dialog.Heading>
+        <Dialog.Content>
+          <p>Click outside or press ESC to close.</p>
+          <p>You can put any JSX inside here.</p>
+        </Dialog.Content>
+      </Dialog>
     </div>
   );
 };
 
-/**
- * Default open dialog
- */
 export const Default: Story = {
-  args: {
-    title: 'Default Dialog',
-    children: (
-      <div>
+  render: args => (
+    <Dialog {...args}>
+      <Dialog.Heading>Default Dialog</Dialog.Heading>
+      <Dialog.Content>
         <p>This is the default dialog content.</p>
-      </div>
-    ),
-  },
+      </Dialog.Content>
+    </Dialog>
+  ),
 };
 
-/**
- * Dialog opened via button click
- */
 export const WithTriggerButton: Story = {
   render: args => <StatefulDialog {...args} />,
-  args: {
-    title: 'Interactive Dialog',
-    children: (
-      <>
-        <p>Click outside or press ESC to close.</p>
-        <p>You can put any JSX inside here.</p>
-      </>
-    ),
-  },
+};
+
+const FooterDemo = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+      <Dialog isOpen={open} onClose={() => setOpen(false)}>
+        <Dialog.Heading>Save changes?</Dialog.Heading>
+        <Dialog.Content>
+          <p>Your edits will be applied to all participants.</p>
+        </Dialog.Content>
+        <Dialog.Footer>
+          <Button variant="secondary" onClick={() => setOpen(false)}>
+            Cancel
+          </Button>
+          <Button onClick={() => setOpen(false)}>Save</Button>
+        </Dialog.Footer>
+      </Dialog>
+    </>
+  );
+};
+
+export const WithFooter: Story = {
+  render: () => <FooterDemo />,
 };
 
 /**
@@ -75,13 +83,11 @@ export const Sizes: Story = {
       return (
         <>
           <Button onClick={() => setOpen(true)}>size=&quot;{size}&quot;</Button>
-          <Dialog
-            isOpen={open}
-            onClose={() => setOpen(false)}
-            title={`Dialog (${size})`}
-            size={size}
-          >
-            <p>This panel uses size=&quot;{size}&quot;.</p>
+          <Dialog isOpen={open} onClose={() => setOpen(false)} size={size}>
+            <Dialog.Heading>Dialog ({size})</Dialog.Heading>
+            <Dialog.Content>
+              <p>This panel uses size=&quot;{size}&quot;.</p>
+            </Dialog.Content>
           </Dialog>
         </>
       );
@@ -96,19 +102,25 @@ export const Sizes: Story = {
   },
 };
 
-/**
- * Dialog with long scrolling content
- */
+const LongContentDemo = (args: Omit<DialogProps, 'isOpen' | 'onClose' | 'children'>) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+      <Dialog {...args} isOpen={open} onClose={() => setOpen(false)}>
+        <Dialog.Heading>Dialog with Long Content</Dialog.Heading>
+        <Dialog.Content>
+          <div className="space-y-4">
+            {[...Array(20)].map((_, i) => (
+              <p key={i}>This is line {i + 1} inside a long dialog.</p>
+            ))}
+          </div>
+        </Dialog.Content>
+      </Dialog>
+    </>
+  );
+};
+
 export const LongContent: Story = {
-  render: args => <StatefulDialog {...args} />,
-  args: {
-    title: 'Dialog with Long Content',
-    children: (
-      <div className="space-y-4">
-        {[...Array(20)].map((_, i) => (
-          <p key={i}>This is line {i + 1} inside a long dialog.</p>
-        ))}
-      </div>
-    ),
-  },
+  render: args => <LongContentDemo {...args} />,
 };

--- a/libs/ratio-ui/src/layout/Dialog/Dialog.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/Dialog.tsx
@@ -1,7 +1,8 @@
-import { Heading } from '../../core/Heading';
 import { Overlay } from '@react-aria/overlays';
-import React, { ReactNode } from 'react';
-import { Dialog as AriaDialog } from 'react-aria-components';
+import { ReactNode } from 'react';
+import { Dialog as AriaDialog, Heading as AriaHeading } from 'react-aria-components';
+import { buildSpacingClasses } from '../../tokens/spacing';
+import { cn } from '../../utils/cn';
 
 export type DialogSize = 'sm' | 'md' | 'lg' | 'xl';
 
@@ -16,77 +17,87 @@ const sizeClasses: Record<DialogSize, string> = {
   xl: 'max-w-4xl',
 };
 
-export type DialogProps = {
+export interface DialogProps {
   isOpen: boolean;
   onClose: () => void;
-  title: string;
   children: ReactNode;
   /** Max width of the dialog panel. Defaults to 'md' (~512px). */
   size?: DialogSize;
   testId?: string;
-};
-
-export const Dialog = (props: DialogProps) => {
-  return (
-    <DialogModal
-      isOpen={props.isOpen}
-      testId={props.testId}
-      onClickOutside={props.onClose}
-      size={props.size}
-    >
-      <AriaDialog className="relative z-10">
-        <Heading as="h3" paddingBottom="xs">
-          {props.title}
-        </Heading>
-        {props.children}
-      </AriaDialog>
-    </DialogModal>
-  );
-};
-
-interface DialogModalProps {
-  children: React.ReactNode;
-  isOpen: boolean;
-  onClickOutside?: () => void;
-  size?: DialogSize;
-  testId?: string;
+  /** Sets `role="alertdialog"` for prompts that interrupt the user. */
+  role?: 'dialog' | 'alertdialog';
 }
 
-function DialogModal(props: Readonly<DialogModalProps>) {
-  if (!props.isOpen) {
+const DialogRoot = ({
+  isOpen,
+  onClose,
+  children,
+  size,
+  testId,
+  role = 'dialog',
+}: Readonly<DialogProps>) => {
+  if (!isOpen) {
     return null;
   }
 
-  const panelWidth = sizeClasses[props.size ?? 'md'];
+  const panelWidth = sizeClasses[size ?? 'md'];
 
   return (
     <Overlay>
       <div
-        data-testid={props.testId}
+        data-testid={testId}
         className="flex min-h-full min-w-full items-start justify-center p-4 text-center fixed inset-0 z-100 overflow-auto h-full bg-black/50"
-        id="underlay"
-        role="button"
-        style={{
-          zIndex: 100,
-        }}
+        role="presentation"
         onClick={e => {
-          const t = e.target as any;
-          if (t['id'] === 'underlay') {
-            if (props.onClickOutside) props.onClickOutside();
-          }
+          if (e.target === e.currentTarget) onClose();
         }}
         onKeyDown={e => {
-          if (e.key === 'Escape') {
-            if (props.onClickOutside) props.onClickOutside();
-          }
+          if (e.key === 'Escape') onClose();
         }}
       >
         <div
           className={`w-full ${panelWidth} transform overflow-hidden rounded-2xl bg-white dark:bg-slate-700 dark:text-white p-6 text-left align-middle shadow-xl transition-all`}
         >
-          {props.children}
+          <AriaDialog role={role} className="relative z-10">
+            {children}
+          </AriaDialog>
         </div>
       </div>
     </Overlay>
   );
+};
+
+interface DialogSlotProps {
+  children?: ReactNode;
+  className?: string;
 }
+
+function DialogHeading({ children, className }: Readonly<DialogSlotProps>) {
+  return (
+    <AriaHeading
+      slot="title"
+      level={3}
+      className={cn(
+        'text-gray-800 dark:text-gray-200',
+        buildSpacingClasses({ paddingBottom: 'xs' }),
+        className,
+      )}
+    >
+      {children}
+    </AriaHeading>
+  );
+}
+
+function DialogContent({ children, className }: Readonly<DialogSlotProps>) {
+  return <div className={className}>{children}</div>;
+}
+
+function DialogFooter({ children, className }: Readonly<DialogSlotProps>) {
+  return <div className={cn('mt-4 flex justify-end gap-2', className)}>{children}</div>;
+}
+
+export const Dialog = Object.assign(DialogRoot, {
+  Heading: DialogHeading,
+  Content: DialogContent,
+  Footer: DialogFooter,
+});

--- a/libs/ratio-ui/src/layout/Dialog/index.ts
+++ b/libs/ratio-ui/src/layout/Dialog/index.ts
@@ -1,2 +1,2 @@
 export { Dialog } from './Dialog';
-export type { DialogProps } from './Dialog';
+export type { DialogProps, DialogSize } from './Dialog';


### PR DESCRIPTION
## Summary

- Drop the `title` prop on `Dialog`. Use `<Dialog.Heading>`, `<Dialog.Content>`, and `<Dialog.Footer>` to compose headings, body, and action rows. Mirrors React Aria / React Spectrum's compound `Dialog` shape.
- Add an optional `role` prop (`'dialog' | 'alertdialog'`) on `Dialog` so the forthcoming `AlertDialog` wrapper can opt into the right ARIA role on the same primitive.
- Migrate the four `apps/web` callsites to the new API.
- Update Storybook stories.
- Major changeset for `@eventuras/ratio-ui`.

This is PR1 of three:
- **PR1 (this one)**: Dialog refactor + 2.0.0 bump
- **PR2**: New `AlertDialog` with Spectrum-mirrored props (`primaryActionLabel`, `secondaryActionLabel`, `cancelLabel`, `variant`, `autoFocusButton`, …) built on top of compound `Dialog`
- **PR3**: Sweep existing `@deprecated` exports/props (Label legacy export, Navbar legacy `title`/`titleHref`/`LinkComponent`) since we're already cutting a major

## Before / After

```tsx
// Before
<Dialog isOpen={open} onClose={close} title="Edit product">
  <Form>{/* … */}</Form>
  <div className="flex gap-2">
    <Button type="submit">Save</Button>
    <Button variant="secondary" onClick={close}>Cancel</Button>
  </div>
</Dialog>

// After
<Dialog isOpen={open} onClose={close}>
  <Dialog.Heading>Edit product</Dialog.Heading>
  <Dialog.Content>
    <Form>{/* … */}</Form>
  </Dialog.Content>
  <Dialog.Footer>
    <Button variant="secondary" onClick={close}>Cancel</Button>
    <Button type="submit">Save</Button>
  </Dialog.Footer>
</Dialog>
```

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui` and `apps/web`
- [x] `pnpm test` in `libs/ratio-ui` — 351 tests passing
- [x] `pnpm lint` in `apps/web` — 0 errors (pre-existing warnings only)
- [x] `pnpm build` in `libs/ratio-ui` succeeds
- [ ] Spot-check Storybook (`Layout/Dialog` → Default, WithTriggerButton, WithFooter, Sizes, LongContent)
- [ ] Manually open each migrated callsite in the running app:
  - [ ] Admin → Events → Products: add/edit product modal
  - [ ] Admin → Collections: "Add collection" modal
  - [ ] Edit registration products dialog
  - [ ] Edit user registration dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)