### PR TITLE
feat(ratio-ui): add AlertDialog

### DIFF
--- a/.changeset/alert-dialog.md
+++ b/.changeset/alert-dialog.md
@@ -1,0 +1,25 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add `AlertDialog` for prompts that interrupt the user (confirmations, destructive actions, errors).
+
+API mirrors React Spectrum's `AlertDialog`:
+
+```tsx
+<AlertDialog
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  variant="destructive"
+  title="Delete event?"
+  primaryActionLabel="Delete"
+  cancelLabel="Cancel"
+  onPrimaryAction={handleDelete}
+>
+  This will permanently remove the event and all registrations. This cannot be undone.
+</AlertDialog>
+```
+
+Variants: `'confirmation' | 'information' | 'destructive' | 'error' | 'warning'`. `destructive` and `error` render the primary button in the new `danger` style and auto-focus `Cancel` for safety. `autoFocusButton` overrides the focus heuristic when needed.
+
+Built on top of the compound `Dialog` primitive with `role="alertdialog"` so it picks up the correct ARIA semantics. A new `danger` variant on `Button` ships with this release.

--- a/libs/ratio-ui/src/core/Button/Button.tsx
+++ b/libs/ratio-ui/src/core/Button/Button.tsx
@@ -24,6 +24,9 @@ export const buttonStyles = {
   outline:
     `border border-gray-700 hover:border-primary-500 hover:bg-primary-100/10 dark:hover:bg-primary-900 ` +
     `dark:text-white rounded-full ${ANIMATION_CLASSES}`,
+  danger:
+    `border font-bold bg-red-600 hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600 ` +
+    `text-white rounded-full ${ANIMATION_CLASSES}`,
 };
 
 export const buttonSizes = {

--- a/libs/ratio-ui/src/layout/Dialog/AlertDialog.stories.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/AlertDialog.stories.tsx
@@ -1,0 +1,154 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import { AlertDialog, AlertDialogProps, AlertDialogVariant } from './AlertDialog';
+import { Button } from '../../core/Button';
+
+const meta: Meta<AlertDialogProps> = {
+  title: 'Layout/AlertDialog',
+  component: AlertDialog,
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    onPrimaryAction: () => {},
+    title: 'Publish Document',
+    children: 'Would you like to publish this document?',
+    variant: 'confirmation',
+    primaryActionLabel: 'Publish',
+    secondaryActionLabel: 'Save Draft',
+    cancelLabel: 'Cancel',
+  },
+};
+export default meta;
+
+type Story = StoryObj<AlertDialogProps>;
+
+type StatefulAlertDialogProps = Omit<
+  AlertDialogProps,
+  'isOpen' | 'onClose' | 'onPrimaryAction' | 'onSecondaryAction' | 'onCancel'
+>;
+
+const StatefulAlertDialog = (args: StatefulAlertDialogProps) => {
+  const [open, setOpen] = useState(false);
+  const [lastAction, setLastAction] = useState<string | null>(null);
+  return (
+    <div className="flex flex-col gap-3">
+      <Button onClick={() => setOpen(true)}>Open AlertDialog</Button>
+      {lastAction && <p className="text-sm text-gray-600">Last action: {lastAction}</p>}
+      <AlertDialog
+        {...args}
+        isOpen={open}
+        onClose={() => setOpen(false)}
+        onPrimaryAction={() => setLastAction('primary')}
+        onSecondaryAction={
+          args.secondaryActionLabel ? () => setLastAction('secondary') : undefined
+        }
+        onCancel={() => setLastAction('cancel')}
+      />
+    </div>
+  );
+};
+
+export const Confirmation: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+};
+
+export const Destructive: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    variant: 'destructive',
+    title: 'Delete event?',
+    children: 'This will permanently remove the event and all registrations. This cannot be undone.',
+    primaryActionLabel: 'Delete',
+    secondaryActionLabel: undefined,
+    cancelLabel: 'Cancel',
+  },
+};
+
+export const Information: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    variant: 'information',
+    title: 'Heads up',
+    children: 'Your subscription will renew on May 1st.',
+    primaryActionLabel: 'OK',
+    secondaryActionLabel: undefined,
+    cancelLabel: undefined,
+  },
+};
+
+export const Warning: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    variant: 'warning',
+    title: 'Unsaved changes',
+    children: 'You have unsaved changes that will be lost if you continue.',
+    primaryActionLabel: 'Discard',
+    cancelLabel: 'Keep editing',
+    secondaryActionLabel: undefined,
+  },
+};
+
+const VariantsDemo = () => {
+  const variants: AlertDialogVariant[] = [
+    'confirmation',
+    'information',
+    'destructive',
+    'error',
+    'warning',
+  ];
+  return (
+    <div className="flex flex-wrap gap-3">
+      {variants.map(v => (
+        <StatefulAlertDialog
+          key={v}
+          variant={v}
+          title={`Variant: ${v}`}
+          primaryActionLabel="Confirm"
+          cancelLabel="Cancel"
+        >
+          <p>This is an alert dialog with variant=&quot;{v}&quot;.</p>
+        </StatefulAlertDialog>
+      ))}
+    </div>
+  );
+};
+
+export const Variants: Story = {
+  render: () => <VariantsDemo />,
+};
+
+export const ThreeButtons: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    title: 'Publish Document',
+    children: 'Would you like to publish this document?',
+    primaryActionLabel: 'Publish',
+    secondaryActionLabel: 'Save Draft',
+    cancelLabel: 'Cancel',
+  },
+};
+
+export const PrimaryDisabled: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    title: 'Confirm action',
+    children: 'The primary action is disabled in this story.',
+    primaryActionLabel: 'Confirm',
+    cancelLabel: 'Cancel',
+    secondaryActionLabel: undefined,
+    isPrimaryActionDisabled: true,
+  },
+};
+
+export const AutoFocusCancel: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    variant: 'confirmation',
+    title: 'Are you sure?',
+    children: 'Cancel is auto-focused regardless of variant.',
+    primaryActionLabel: 'Continue',
+    cancelLabel: 'Cancel',
+    secondaryActionLabel: undefined,
+    autoFocusButton: 'cancel',
+  },
+};

--- a/libs/ratio-ui/src/layout/Dialog/AlertDialog.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/AlertDialog.tsx
@@ -1,0 +1,149 @@
+import { ReactNode, useEffect, useRef } from 'react';
+import { Button } from '../../core/Button';
+import { Dialog, DialogProps, DialogSize } from './Dialog';
+
+export type AlertDialogVariant =
+  | 'confirmation'
+  | 'information'
+  | 'destructive'
+  | 'error'
+  | 'warning';
+
+export type AlertDialogAutoFocus = 'primary' | 'secondary' | 'cancel';
+
+export interface AlertDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  children: ReactNode;
+  variant?: AlertDialogVariant;
+  size?: DialogSize;
+  testId?: string;
+
+  primaryActionLabel: string;
+  secondaryActionLabel?: string;
+  cancelLabel?: string;
+
+  isPrimaryActionDisabled?: boolean;
+  isSecondaryActionDisabled?: boolean;
+
+  autoFocusButton?: AlertDialogAutoFocus;
+
+  onPrimaryAction: () => void;
+  onSecondaryAction?: () => void;
+  onCancel?: () => void;
+}
+
+const variantPrimaryStyle: Record<AlertDialogVariant, 'primary' | 'danger'> = {
+  confirmation: 'primary',
+  information: 'primary',
+  warning: 'primary',
+  destructive: 'danger',
+  error: 'danger',
+};
+
+export const AlertDialog = ({
+  isOpen,
+  onClose,
+  title,
+  children,
+  variant = 'confirmation',
+  size = 'sm',
+  testId,
+  primaryActionLabel,
+  secondaryActionLabel,
+  cancelLabel,
+  isPrimaryActionDisabled,
+  isSecondaryActionDisabled,
+  autoFocusButton,
+  onPrimaryAction,
+  onSecondaryAction,
+  onCancel,
+}: Readonly<AlertDialogProps>) => {
+  const primaryRef = useRef<HTMLButtonElement>(null);
+  const secondaryRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // Default focus: cancel for destructive/error (safer), primary otherwise.
+  // `autoFocusButton` overrides the heuristic; either way we fall back to
+  // the first rendered + enabled action so we never try to focus a button
+  // that doesn't exist or can't receive focus.
+  const desiredFocus: AlertDialogAutoFocus =
+    autoFocusButton ??
+    (variant === 'destructive' || variant === 'error' ? 'cancel' : 'primary');
+
+  const isFocusable: Record<AlertDialogAutoFocus, boolean> = {
+    primary: !isPrimaryActionDisabled,
+    secondary: Boolean(secondaryActionLabel) && !isSecondaryActionDisabled,
+    cancel: Boolean(cancelLabel),
+  };
+
+  const fallbackOrder: AlertDialogAutoFocus[] = [
+    desiredFocus,
+    'cancel',
+    'primary',
+    'secondary',
+  ];
+  const focusTarget = fallbackOrder.find(t => isFocusable[t]);
+
+  useEffect(() => {
+    if (!isOpen || !focusTarget) return;
+    const refs = { primary: primaryRef, secondary: secondaryRef, cancel: cancelRef };
+    refs[focusTarget].current?.focus();
+  }, [isOpen, focusTarget]);
+
+  const handleCancel = () => {
+    onCancel?.();
+    onClose();
+  };
+
+  const handlePrimary = () => {
+    onPrimaryAction();
+    onClose();
+  };
+
+  const handleSecondary = () => {
+    onSecondaryAction?.();
+    onClose();
+  };
+
+  const dialogProps: Pick<DialogProps, 'isOpen' | 'onClose' | 'size' | 'testId' | 'role'> = {
+    isOpen,
+    onClose: handleCancel,
+    size,
+    testId,
+    role: 'alertdialog',
+  };
+
+  return (
+    <Dialog {...dialogProps}>
+      <Dialog.Heading>{title}</Dialog.Heading>
+      <Dialog.Content>{children}</Dialog.Content>
+      <Dialog.Footer>
+        {cancelLabel && (
+          <Button ref={cancelRef} variant="secondary" onClick={handleCancel}>
+            {cancelLabel}
+          </Button>
+        )}
+        {secondaryActionLabel && (
+          <Button
+            ref={secondaryRef}
+            variant="secondary"
+            disabled={isSecondaryActionDisabled}
+            onClick={handleSecondary}
+          >
+            {secondaryActionLabel}
+          </Button>
+        )}
+        <Button
+          ref={primaryRef}
+          variant={variantPrimaryStyle[variant]}
+          disabled={isPrimaryActionDisabled}
+          onClick={handlePrimary}
+        >
+          {primaryActionLabel}
+        </Button>
+      </Dialog.Footer>
+    </Dialog>
+  );
+};

--- a/libs/ratio-ui/src/layout/Dialog/index.ts
+++ b/libs/ratio-ui/src/layout/Dialog/index.ts
@@ -1,2 +1,4 @@
 export { Dialog } from './Dialog';
 export type { DialogProps, DialogSize } from './Dialog';
+export { AlertDialog } from './AlertDialog';
+export type { AlertDialogProps, AlertDialogVariant, AlertDialogAutoFocus } from './AlertDialog';


### PR DESCRIPTION
## Summary

Adds `AlertDialog` to ratio-ui — a higher-level wrapper for prompts that interrupt the user (confirmations, destructive actions, errors). API mirrors React Spectrum's `AlertDialog` so it's familiar to anyone who has used Spectrum.

**Stacked on #1366** — base is `refactor/ratio-ui-dialog-compound`, not `main`. Merge #1366 first, then this rebases onto `main` automatically.

## API

```tsx
<AlertDialog
  isOpen={open}
  onClose={() => setOpen(false)}
  variant="destructive"
  title="Delete event?"
  primaryActionLabel="Delete"
  cancelLabel="Cancel"
  onPrimaryAction={handleDelete}
>
  This will permanently remove the event and all registrations. This cannot be undone.
</AlertDialog>
```

Spectrum-mirrored props: `title`, `children`, `variant`, `size`, `primaryActionLabel`, `secondaryActionLabel`, `cancelLabel`, `isPrimaryActionDisabled`, `isSecondaryActionDisabled`, `autoFocusButton`. Plus controlled `isOpen`/`onClose` and `onPrimaryAction`/`onSecondaryAction`/`onCancel` callbacks.

## Behavior

- Built on the compound `Dialog` primitive with `role="alertdialog"` so it picks up correct ARIA semantics.
- Variant determines primary button styling: `confirmation`/`information`/`warning` → `primary`, `destructive`/`error` → `danger`.
- Auto-focus heuristic: cancel for `destructive`/`error` (safer default), primary otherwise. Overridable via `autoFocusButton`.
- Each action callback closes the dialog automatically (matches Spectrum).
- Adds a new `danger` variant to `buttonStyles` (red).

## Future extension

The screenshot in the design discussion mentioned `confirmationPhrase` ("type DELETE to delete") as a future need. The current props don't preclude adding it later — it would just disable the primary action until the typed input matches.

## Plan recap

- ✅ PR1 (#1366) — Dialog compound refactor (major)
- ✅ PR2 (this) — AlertDialog (minor)
- 🔜 PR3 — Sweep existing `@deprecated` exports (Label legacy, Navbar legacy props)
- 🔜 PR4 — Migrate Dialog to RAC's full `ModalOverlay`/`Modal` stack for focus trap, scroll lock, focus restoration

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`
- [x] `pnpm test` — 359 passing (8 new auto-generated story tests, no new warnings)
- [x] `pnpm build` succeeds
- [ ] Spot-check Storybook (`Layout/AlertDialog` → Confirmation, Destructive, Information, Warning, Variants, ThreeButtons, PrimaryDisabled, AutoFocusCancel)
- [ ] Verify focus heuristic: open destructive variant → Cancel should be focused on open
- [ ] Verify Escape closes the dialog (calls `onCancel` then `onClose`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)