### PR TITLE
refactor(ratio-ui)!: remove deprecated InputLabel and Navbar legacy props

### DIFF
--- a/.changeset/remove-deprecated.md
+++ b/.changeset/remove-deprecated.md
@@ -1,0 +1,28 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+Remove deprecated APIs ahead of the 2.0 cut.
+
+**`InputLabel`** — removed. Use `Label` instead. The export was a deprecated re-alias that has lived alongside `Label` since the form-field rewrite.
+
+**`Navbar` legacy shorthand props** — `title`, `titleHref`, and `LinkComponent` are removed. Use the compound `<Navbar.Brand>` slot instead, which lets you pick your own link element (Next `<Link>`, plain `<a>`, etc.) and gives full control over markup and styling:
+
+```tsx
+// Before
+<Navbar title="My App" titleHref="/" LinkComponent={Link}>
+  {children}
+</Navbar>
+
+// After
+<Navbar>
+  <Navbar.Brand>
+    <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
+      My App
+    </Link>
+  </Navbar.Brand>
+  <Navbar.Content className="justify-end">{children}</Navbar.Content>
+</Navbar>
+```
+
+The four internal callsites (`apps/dev-docs`, `apps/idem-admin`, `apps/historia`, ratio-ui's own `Page` story) have been migrated.

--- a/apps/dev-docs/app/layout.tsx
+++ b/apps/dev-docs/app/layout.tsx
@@ -1,12 +1,13 @@
-import type { Metadata } from 'next';
 import React from 'react';
+import type { Metadata } from 'next';
 
 import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
 
-import './globals.css';
 import { ThemeProvider } from './providers';
 import { SearchButton } from './search-wrapper';
 import { DocsThemeToggle } from './theme-toggle';
+
+import './globals.css';
 
 export const metadata: Metadata = {
   title: {
@@ -28,11 +29,16 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       </head>
       <body className="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
         <ThemeProvider>
-          <Navbar title="Eventuras Docs" titleHref="/" sticky>
-            <div className="flex items-center gap-2">
+          <Navbar sticky>
+            <Navbar.Brand>
+              <a href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
+                Eventuras Docs
+              </a>
+            </Navbar.Brand>
+            <Navbar.Content className="justify-end">
               <SearchButton />
               <DocsThemeToggle />
-            </div>
+            </Navbar.Content>
           </Navbar>
           <div className="min-h-screen">
             {children}

--- a/apps/historia/src/Header/Component.client.tsx
+++ b/apps/historia/src/Header/Component.client.tsx
@@ -34,13 +34,17 @@ export const HeaderClient: React.FC<HeaderClientProps> = ({ title }) => {
 
   return (
     <header className="relative z-20" data-theme={theme ?? undefined}>
-      <Navbar
-        title={title}
-        titleHref="/"
-        LinkComponent={Link}
-        bgColor="bg-transparent"
-      >
-        <CartButton locale={locale} />
+      <Navbar bgColor="bg-transparent">
+        {title && (
+          <Navbar.Brand>
+            <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
+              {title}
+            </Link>
+          </Navbar.Brand>
+        )}
+        <Navbar.Content className="justify-end">
+          <CartButton locale={locale} />
+        </Navbar.Content>
       </Navbar>
     </header>
   );

--- a/apps/idem-admin/src/components/AdminNavbar.tsx
+++ b/apps/idem-admin/src/components/AdminNavbar.tsx
@@ -16,15 +16,15 @@ type AdminNavbarProps = {
 
 export function AdminNavbar({ user }: Readonly<AdminNavbarProps>) {
   return (
-    <Navbar
-      title="Idem Admin"
-      titleHref="/admin"
-      bgColor="bg-primary-700"
-      bgDark
-      sticky
-      LinkComponent={Link}
-    >
-      <UserMenu user={user} />
+    <Navbar bgColor="bg-primary-700" bgDark sticky>
+      <Navbar.Brand>
+        <Link href="/admin" className="text-lg tracking-tight whitespace-nowrap no-underline">
+          Idem Admin
+        </Link>
+      </Navbar.Brand>
+      <Navbar.Content className="justify-end">
+        <UserMenu user={user} />
+      </Navbar.Content>
     </Navbar>
   );
 }

--- a/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
@@ -107,21 +107,3 @@ export const OverlayGlass: Story = {
   ),
 };
 
-/** Legacy API — still works, renders identically to the old Navbar. */
-export const LegacyTitle: Story = {
-  args: {
-    title: 'Eventuras Inc.',
-    sticky: true,
-  },
-};
-
-/** Legacy API with children. */
-export const LegacyWithChildren: Story = {
-  render: (args) => (
-    <Navbar {...args}>
-      <a href="/about" className="px-3">About</a>
-      <button type="button" className="btn-primary ml-2">Sign up</button>
-    </Navbar>
-  ),
-  args: { title: 'Acme Inc.' },
-};

--- a/libs/ratio-ui/src/core/Navbar/Navbar.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import { cn } from '../../utils/cn';
 
 export interface NavbarProps {
@@ -22,19 +22,6 @@ export interface NavbarProps {
    */
   glass?: boolean;
   className?: string;
-
-  // ── Legacy shorthand props (still supported, prefer Navbar.Brand) ──
-
-  /** @deprecated Use `<Navbar.Brand>` instead. */
-  title?: string;
-  /** @deprecated Use `<Navbar.Brand>` instead. */
-  titleHref?: string;
-  /** @deprecated Use `<Navbar.Brand>` instead. */
-  LinkComponent?: React.ComponentType<{
-    href: string;
-    children: ReactNode;
-    className?: string;
-  }>;
 }
 
 export interface NavbarBrandProps {
@@ -71,12 +58,6 @@ const NavbarRoot = ({
   overlay = false,
   glass = false,
   className,
-  // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
-  title,
-  // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
-  titleHref = '/',
-  // eslint-disable-next-line deprecation/deprecation -- backward-compat bridge
-  LinkComponent,
 }: Readonly<NavbarProps>) => {
   const textColor = bgDark ? 'text-light' : 'text-dark dark:text-light';
   // overlay takes precedence over sticky when both are passed.
@@ -92,27 +73,9 @@ const NavbarRoot = ({
     ? '[--navbar-color:white]'
     : '[--navbar-color:var(--text-dark,#1a1a1a)] dark:[--navbar-color:var(--text-light,white)]';
 
-  const hasLegacyTitle = typeof title === 'string' && title !== '';
-  const LinkTag = LinkComponent ?? ('a' as React.ElementType);
-
   return (
     <nav className={cn(bgColor, positionClass, glassClass, textColor, navbarColorVar, 'm-0 p-0', className)}>
-      <div
-        className={cn(
-          'container flex flex-wrap items-center mx-auto gap-3 py-2 px-3',
-          hasLegacyTitle && 'justify-between',
-        )}
-      >
-        {hasLegacyTitle && (
-          <NavbarBrand>
-            <LinkTag
-              href={titleHref}
-              className={cn('text-lg tracking-tight whitespace-nowrap no-underline', textColor)}
-            >
-              {title}
-            </LinkTag>
-          </NavbarBrand>
-        )}
+      <div className="container flex flex-wrap items-center mx-auto gap-3 py-2 px-3">
         {children}
       </div>
     </nav>

--- a/libs/ratio-ui/src/forms/common/Label.tsx
+++ b/libs/ratio-ui/src/forms/common/Label.tsx
@@ -50,8 +50,3 @@ export function Label({ children, className, ...props }: ComponentProps<typeof A
     </AriaLabel>
   );
 }
-
-/**
- * @deprecated Use `Label` instead. This export is kept for backward compatibility.
- */
-export const InputLabel = Label;

--- a/libs/ratio-ui/src/forms/index.ts
+++ b/libs/ratio-ui/src/forms/index.ts
@@ -2,7 +2,7 @@ export { Checkbox, CheckBoxDescription, CheckBoxLabel } from './Input/Checkbox';
 export { Fieldset } from './common/Fieldset';
 export { Form } from './common/Form';
 export { formStyles } from './styles/formStyles';
-export { Label, InputLabel } from './common/Label';
+export { Label } from './common/Label';
 export { ListBox, ListBoxItem } from './ListBox';
 export type { ListBoxProps, ListBoxItemProps } from './ListBox';
 export { SearchField } from './SearchField';

--- a/libs/ratio-ui/src/pages/Page/Page.stories.tsx
+++ b/libs/ratio-ui/src/pages/Page/Page.stories.tsx
@@ -8,21 +8,18 @@ import { Section } from '../../layout/Section/Section';
 import { Container } from '../../layout/Container';
 import { Button } from '../../core/Button';
 
-const AnchorLink = ({
-  href,
-  children,
-  ...rest
-}: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
-  <a href={href} {...rest}>{children}</a>
-);
-
 const PageDemo: React.FC<{ title: string }> = ({ title }) => (
   <div className="min-h-screen flex flex-col">
-    <Navbar title={title} bgColor="bg-transparent w-full py-1" LinkComponent={AnchorLink}>
-      <nav className="flex gap-4 ml-auto">
+    <Navbar bgColor="bg-transparent w-full py-1">
+      <Navbar.Brand>
+        <a href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
+          {title}
+        </a>
+      </Navbar.Brand>
+      <Navbar.Content className="justify-end">
         <a href="#hero" className="hover:underline">Home</a>
         <a href="#features" className="hover:underline">Features</a>
-      </nav>
+      </Navbar.Content>
     </Navbar>
 
     <main className="flex-1">


### PR DESCRIPTION
## Summary

Drops two long-deprecated APIs from `@eventuras/ratio-ui` ahead of the 2.0 release.

### Removals

**`InputLabel`** — was a deprecated re-alias of `Label` since the form-field rewrite. No internal callers.

**`Navbar` legacy shorthand props** — `title`, `titleHref`, and `LinkComponent` are removed in favor of the compound `<Navbar.Brand>` slot, which lets callers pick their own link element (Next `<Link>`, plain `<a>`, etc.) and styling.

### Migrations

Four callsites moved from legacy to compound:
- `libs/ratio-ui/src/pages/Page/Page.stories.tsx`
- `apps/dev-docs/app/layout.tsx`
- `apps/idem-admin/src/components/AdminNavbar.tsx`
- `apps/historia/src/Header/Component.client.tsx`

```tsx
// Before
<Navbar title="My App" titleHref="/" LinkComponent={Link}>
  {children}
</Navbar>

// After
<Navbar>
  <Navbar.Brand>
    <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
      My App
    </Link>
  </Navbar.Brand>
  <Navbar.Content className="justify-end">{children}</Navbar.Content>
</Navbar>
```

`LegacyTitle` and `LegacyWithChildren` Navbar stories were removed.

### Plan recap

- ✅ PR1 (#1366, merged) — Dialog compound refactor
- ✅ PR2 (#1367, merged) — AlertDialog
- ✅ PR3 (this) — Sweep `@deprecated` exports/props
- 🔜 PR4 — Migrate Dialog to RAC's full `ModalOverlay`/`Modal` stack (focus trap, scroll lock, focus restoration)

All three breaking PRs collapse into a single `2.0.0` release for `@eventuras/ratio-ui` since none have been version-bumped yet.

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`, `apps/dev-docs`, `apps/idem-admin`, `apps/historia`, `apps/web`
- [x] `pnpm test` in `libs/ratio-ui` — 357 passing
- [x] `pnpm build` in `libs/ratio-ui` succeeds
- [x] No `@deprecated`, `InputLabel`, `titleHref`, or `LinkComponent` references remain in source
- [ ] Spot-check Storybook (`Core/Navbar` — BrandAndContent, BrandOnly, ContentOnly, DoubleNavbar, OverlayGlass)
- [ ] Manually verify each migrated app's navbar renders correctly:
  - [ ] dev-docs site header
  - [ ] idem-admin header
  - [ ] historia header

🤖 Generated with [Claude Code](https://claude.com/claude-code)