### PR TITLE
refactor(ratio-ui): migrate Dialog to RAC ModalOverlay/Modal stack

### DIFF
--- a/.changeset/dialog-rac-modal.md
+++ b/.changeset/dialog-rac-modal.md
@@ -1,0 +1,32 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Migrate `Dialog` to React Aria Components' full `ModalOverlay` / `Modal` / `Dialog` stack.
+
+The previous custom overlay (low-level `@react-aria/overlays` + custom backdrop `<div>` + manual click-outside via `e.target === e.currentTarget` + manual Escape handling) is replaced with RAC's high-level primitives. Visual output is unchanged, but the dialog now ships with proper a11y/UX semantics that were previously missing:
+
+- **Focus trap** — Tab cycles within the dialog and can no longer escape to elements behind the overlay.
+- **Focus restoration** — focus returns to the trigger element when the dialog closes.
+- **Scroll lock** — the body no longer scrolls underneath the open dialog.
+- **Click outside / Escape** are now handled by RAC, with structured `isDismissable` and `isKeyboardDismissDisabled` controls instead of always-on hardcoded behavior.
+- **Portal handling** is built in (no more direct dependency on `@react-aria/overlays`'s `Overlay`).
+
+### New props
+
+```tsx
+<Dialog
+  isOpen={open}
+  onClose={close}
+  isDismissable={false}            // backdrop click no longer closes
+  isKeyboardDismissDisabled        // Escape no longer closes
+>
+  <Dialog.Heading>Confirm something important</Dialog.Heading>
+  <Dialog.Content>...</Dialog.Content>
+  <Dialog.Footer>...</Dialog.Footer>
+</Dialog>
+```
+
+Both new props default to RAC's defaults (`isDismissable: true`, `isKeyboardDismissDisabled: false`), so existing call sites get no behavior change beyond the a11y/UX wins above.
+
+`AlertDialog` automatically inherits these improvements since it composes `Dialog` internally.

--- a/libs/ratio-ui/package.json
+++ b/libs/ratio-ui/package.json
@@ -98,7 +98,6 @@
     "@eventuras/logger": "workspace:*",
     "@internationalized/date": "^3.12.1",
     "@internationalized/number": "^3.6.6",
-    "@react-aria/overlays": "^3.32.0",
     "@react-stately/data": "^3.16.0",
     "clsx": "^2.1.1",
     "lucide-react": "^1.8.0",

--- a/libs/ratio-ui/src/layout/Dialog/Dialog.stories.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/Dialog.stories.tsx
@@ -124,3 +124,34 @@ const LongContentDemo = (args: Omit<DialogProps, 'isOpen' | 'onClose' | 'childre
 export const LongContent: Story = {
   render: args => <LongContentDemo {...args} />,
 };
+
+const NonDismissableDemo = () => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+      <Dialog isOpen={open} onClose={() => setOpen(false)} isDismissable={false}>
+        <Dialog.Heading>Action required</Dialog.Heading>
+        <Dialog.Content>
+          <p>
+            Clicking the backdrop will not close this dialog. Press Escape or click Continue to
+            proceed. Add <code>isKeyboardDismissDisabled</code> too if you also need to disable
+            Escape.
+          </p>
+        </Dialog.Content>
+        <Dialog.Footer>
+          <Button onClick={() => setOpen(false)}>Continue</Button>
+        </Dialog.Footer>
+      </Dialog>
+    </>
+  );
+};
+
+/**
+ * Dialog that can't be closed by clicking the backdrop. Useful for forced
+ * confirmation flows where the user must take an explicit action. Pair with
+ * `isKeyboardDismissDisabled` to also disable Escape.
+ */
+export const NonDismissable: Story = {
+  render: () => <NonDismissableDemo />,
+};

--- a/libs/ratio-ui/src/layout/Dialog/Dialog.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/Dialog.tsx
@@ -1,6 +1,10 @@
-import { Overlay } from '@react-aria/overlays';
 import { ReactNode } from 'react';
-import { Dialog as AriaDialog, Heading as AriaHeading } from 'react-aria-components';
+import {
+  Dialog as AriaDialog,
+  Heading as AriaHeading,
+  Modal,
+  ModalOverlay,
+} from 'react-aria-components';
 import { buildSpacingClasses } from '../../tokens/spacing';
 import { cn } from '../../utils/cn';
 
@@ -26,6 +30,13 @@ export interface DialogProps {
   testId?: string;
   /** Sets `role="alertdialog"` for prompts that interrupt the user. */
   role?: 'dialog' | 'alertdialog';
+  /**
+   * Whether clicking the backdrop closes the dialog. Defaults to true.
+   * Pair with `isKeyboardDismissDisabled` to fully prevent dismissal.
+   */
+  isDismissable?: boolean;
+  /** When true, Escape no longer closes the dialog. Defaults to false. */
+  isKeyboardDismissDisabled?: boolean;
 }
 
 const DialogRoot = ({
@@ -35,35 +46,35 @@ const DialogRoot = ({
   size,
   testId,
   role = 'dialog',
+  isDismissable = true,
+  isKeyboardDismissDisabled = false,
 }: Readonly<DialogProps>) => {
-  if (!isOpen) {
-    return null;
-  }
-
   const panelWidth = sizeClasses[size ?? 'md'];
 
   return (
-    <Overlay>
-      <div
-        data-testid={testId}
-        className="flex min-h-full min-w-full items-start justify-center p-4 text-center fixed inset-0 z-100 overflow-auto h-full bg-black/50"
-        role="presentation"
-        onClick={e => {
-          if (e.target === e.currentTarget) onClose();
-        }}
-        onKeyDown={e => {
-          if (e.key === 'Escape') onClose();
-        }}
+    <ModalOverlay
+      isOpen={isOpen}
+      onOpenChange={open => {
+        if (!open) onClose();
+      }}
+      isDismissable={isDismissable}
+      isKeyboardDismissDisabled={isKeyboardDismissDisabled}
+      data-testid={testId}
+      className="flex min-h-full min-w-full items-start justify-center p-4 text-center fixed inset-0 z-100 overflow-auto h-full bg-black/50"
+    >
+      <Modal
+        className={cn(
+          'w-full',
+          panelWidth,
+          'transform overflow-hidden rounded-2xl bg-white dark:bg-slate-700 dark:text-white',
+          'p-6 text-left align-middle shadow-xl transition-all',
+        )}
       >
-        <div
-          className={`w-full ${panelWidth} transform overflow-hidden rounded-2xl bg-white dark:bg-slate-700 dark:text-white p-6 text-left align-middle shadow-xl transition-all`}
-        >
-          <AriaDialog role={role} className="relative z-10">
-            {children}
-          </AriaDialog>
-        </div>
-      </div>
-    </Overlay>
+        <AriaDialog role={role} className="relative z-10 outline-hidden">
+          {children}
+        </AriaDialog>
+      </Modal>
+    </ModalOverlay>
   );
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1431,9 +1431,6 @@ importers:
       '@internationalized/number':
         specifier: ^3.6.6
         version: 3.6.6
-      '@react-aria/overlays':
-        specifier: ^3.32.0
-        version: 3.32.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@react-stately/data':
         specifier: ^3.16.0
         version: 3.16.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -5161,12 +5158,6 @@ packages:
 
   '@react-aria/overlays@3.31.2':
     resolution: {integrity: sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  '@react-aria/overlays@3.32.0':
-    resolution: {integrity: sha512-H9meBB14/M0bDwk8gZl8Fu8bwZN2El9LDlk5cNkgAozbEiRuQvTFOeE3RoP6XI6bwEnSBvb0ovPmx3/kNyOehQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -18184,13 +18175,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@react-aria/overlays@3.32.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@swc/helpers': 0.5.21
-      react: 19.2.5
-      react-aria: 3.48.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react-dom: 19.2.5(react@19.2.5)
-
   '@react-aria/progress@3.4.27(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@react-aria/i18n': 3.12.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -21207,9 +21191,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -21279,7 +21263,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.12.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(happy-dom@20.9.0)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -24402,7 +24386,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
## Summary

Replaces `Dialog`'s hand-rolled overlay with React Aria Components' high-level `ModalOverlay` / `Modal` / `Dialog` primitives. Visual output is identical; what changes is the a11y/UX behavior the dialog now ships with for free.

### Before

- `@react-aria/overlays` low-level `<Overlay>` rendered the panel.
- Custom backdrop `<div>` with manual `onClick` + `e.target === e.currentTarget` for click-outside.
- Custom `onKeyDown` for Escape.
- No focus trap → Tab could escape to elements behind the dialog.
- No focus restoration → focus didn't return to the trigger after close.
- No scroll lock → background page scrolled under the dialog.

### After

```tsx
<ModalOverlay isOpen={isOpen} onOpenChange={...} isDismissable isKeyboardDismissDisabled={...}>
  <Modal className="...panel styling...">
    <AriaDialog role={role}>
      {children}
    </AriaDialog>
  </Modal>
</ModalOverlay>
```

RAC handles all of the above out of the box. Two new optional props expose the controls:

- `isDismissable?: boolean` (default `true`) — backdrop click closes
- `isKeyboardDismissDisabled?: boolean` (default `false`) — Escape closes

Both default to RAC's defaults so existing callers see only the a11y/UX wins. Added a `NonDismissable` Storybook story.

`AlertDialog` automatically inherits the improvements since it composes `Dialog`.

### Dependency cleanup

Drops `@react-aria/overlays` from direct dependencies. Its primitives are now consumed transitively via `react-aria-components`.

### Plan recap

- ✅ PR1 (#1366, merged) — Dialog compound refactor
- ✅ PR2 (#1367, merged) — AlertDialog
- ✅ PR3 (#1368, merged) — Sweep `@deprecated` exports/props
- ✅ PR4 (this) — Migrate Dialog to RAC `ModalOverlay`/`Modal` stack
- 🔜 PR5 — Migrate `Drawer` to RAC `Modal` (with side positioning) and remove the now-orphaned `Portal` primitive

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui` and `apps/web`
- [x] `pnpm test` in `libs/ratio-ui` — 358 passing (+1 NonDismissable story)
- [x] `pnpm build` succeeds
- [x] `@react-aria/overlays` no longer in `dependencies`
- [ ] Spot-check Storybook (`Layout/Dialog` — Default, WithTriggerButton, WithFooter, Sizes, LongContent, **NonDismissable**, AlertDialog stories)
- [ ] In a running app: verify focus is trapped, returns to trigger on close, and body doesn't scroll under the dialog
- [ ] Click outside closes by default; clicking outside a `NonDismissable` dialog does not close it

🤖 Generated with [Claude Code](https://claude.com/claude-code)