### PR TITLE
refactor(ratio-ui)!: rename Drawer/FileDrawer onCancel prop to onClose (stacked on #1370)

### DIFF
--- a/.changeset/drawer-onclose.md
+++ b/.changeset/drawer-onclose.md
@@ -1,0 +1,19 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+Rename `Drawer`/`FileDrawer` `onCancel` prop to `onClose` for consistency with `Dialog` and `AlertDialog`.
+
+```tsx
+// Before
+<Drawer isOpen={open} onCancel={close}>...</Drawer>
+<FileDrawer isOpen={open} onCancel={close} ... />
+
+// After
+<Drawer isOpen={open} onClose={close}>...</Drawer>
+<FileDrawer isOpen={open} onClose={close} ... />
+```
+
+`AlertDialog`'s `onCancel` is intentionally kept — it represents a distinct user action ("clicked Cancel") separate from `onClose` ("dialog dismissed for any reason"). On `Drawer`/`FileDrawer` the two semantics were always conflated, so the rename loses no information.
+
+All internal callsites in `apps/web` and `apps/historia` have been migrated.

--- a/apps/historia/src/components/cart/CartDrawer.tsx
+++ b/apps/historia/src/components/cart/CartDrawer.tsx
@@ -51,7 +51,7 @@ export function CartDrawer({ isOpen, onClose, locale }: Readonly<CartDrawerProps
 
 
   return (
-    <Drawer isOpen={isOpen} onCancel={onClose}>
+    <Drawer isOpen={isOpen} onClose={onClose}>
       <Drawer.Header as="h2">Handlekurv</Drawer.Header>
 
       <Drawer.Body>

--- a/apps/web/src/app/(admin)/admin/events/AddUserToEvent.tsx
+++ b/apps/web/src/app/(admin)/admin/events/AddUserToEvent.tsx
@@ -40,7 +40,7 @@ type AddUserToEventFormValues = {
 type AddUserCardProps = {
   user: UserDto;
   eventinfo: EventDto;
-  onUseradded: (user: UserDto) => void;
+  onUserAdded: (user: UserDto) => void;
   products: ProductDto[];
   onRemove: (u: UserDto) => void;
 };
@@ -78,7 +78,7 @@ const AddUserCard: React.FC<AddUserCardProps> = ({
   eventinfo,
   products,
   onRemove,
-  onUseradded,
+  onUserAdded,
 }) => {
   const toast = useToast();
   const t = useTranslations();
@@ -110,7 +110,7 @@ const AddUserCard: React.FC<AddUserCardProps> = ({
       if (result.success) {
         logger.info({ userId: user.id }, 'User successfully added to the event!');
         toast.success(result.message || 'User successfully added to the event!');
-        onUseradded(user);
+        onUserAdded(user);
       } else {
         logger.error({ error: result.error, userId: user.id }, 'Failed to add user to event');
         toast.error(result.error.message);
@@ -208,21 +208,21 @@ const AddUserCard: React.FC<AddUserCardProps> = ({
 export type AddUserToEventDrawerProps = {
   eventinfo: EventDto;
   eventProducts: ProductDto[];
-  onUseradded: (user: UserDto) => void;
-  isOpen?: boolean;
-  onCancel?: () => void;
+  onUserAdded: (user: UserDto) => void;
+  isOpen: boolean;
+  onClose?: () => void;
 };
 const AddUserToEventDrawer: React.FC<AddUserToEventDrawerProps> = ({
   eventinfo,
   eventProducts,
-  onUseradded,
+  onUserAdded,
   isOpen,
-  onCancel,
+  onClose,
 }) => {
   const [usersToAdd, setUsersToAdd] = useState<UserDto[]>([]);
 
   return (
-    <Drawer isOpen={isOpen!} onCancel={onCancel}>
+    <Drawer isOpen={isOpen} onClose={onClose}>
       <Drawer.Header as="h2">Add users to event</Drawer.Header>
 
       <Drawer.Body>
@@ -236,9 +236,9 @@ const AddUserToEventDrawer: React.FC<AddUserToEventDrawerProps> = ({
           {usersToAdd.map(user => (
             <AddUserCard
               user={user}
-              onUseradded={u => {
+              onUserAdded={u => {
                 setUsersToAdd([...usersToAdd].filter(us => u.id !== us.id));
-                onUseradded(u);
+                onUserAdded(u);
               }}
               onRemove={u => {
                 setUsersToAdd([...usersToAdd].filter(us => u.id !== us.id));
@@ -288,8 +288,8 @@ const AddUserToEvent: React.FC<AddUserToEventProps> = props => {
       <AddUserToEventDrawer
         eventinfo={props.eventinfo}
         eventProducts={props.eventProducts}
-        onUseradded={handleUserAdded}
-        onCancel={() => {
+        onUserAdded={handleUserAdded}
+        onClose={() => {
           setIsOpen(false);
         }}
         isOpen={isOpen}

--- a/apps/web/src/app/(admin)/admin/events/AdminCertificatesActionsMenu.tsx
+++ b/apps/web/src/app/(admin)/admin/events/AdminCertificatesActionsMenu.tsx
@@ -108,14 +108,14 @@ export const AdminCertificatesActionsMenu: React.FC<AdminCertificatesActionsMenu
 
       <FileDrawer
         isOpen={!!previewHtml}
-        onCancel={() => setPreviewHtml(null)}
+        onClose={() => setPreviewHtml(null)}
         title={t('admin.labels.previewCertificate')}
         content={previewHtml ?? undefined}
         downloadFilename={`certificate-${eventinfo.slug ?? eventinfo.id}-preview.html`}
         closeLabel={t('common.buttons.cancel')}
       />
 
-      <Drawer isOpen={certificateDrawerOpen} onCancel={() => setCertificateDrawerOpen(false)}>
+      <Drawer isOpen={certificateDrawerOpen} onClose={() => setCertificateDrawerOpen(false)}>
         <Drawer.Header>
           <Heading as="h2">Certificate details</Heading>
         </Drawer.Header>

--- a/apps/web/src/app/(admin)/admin/events/EventParticipantList.tsx
+++ b/apps/web/src/app/(admin)/admin/events/EventParticipantList.tsx
@@ -210,7 +210,7 @@ const EventParticipantList: React.FC<AdminEventListProps> = ({
 
       {/* Email notification drawer */}
       {registrationOpen && (
-        <Drawer isOpen={true} onCancel={() => setRegistrationOpen(null)}>
+        <Drawer isOpen={true} onClose={() => setRegistrationOpen(null)}>
           <Drawer.Header as="h3" className="text-black">
             <p>Mailer</p>
           </Drawer.Header>

--- a/apps/web/src/app/(admin)/admin/events/[id]/CommunicationSection.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/CommunicationSection.tsx
@@ -53,7 +53,7 @@ export default function CommunicationSection({
         </div>
       </div>
 
-      <Drawer isOpen={emailDrawerOpen} onCancel={() => setEmailDrawerOpen(false)}>
+      <Drawer isOpen={emailDrawerOpen} onClose={() => setEmailDrawerOpen(false)}>
         <Drawer.Header as="h3" className="text-black">
           {t('admin.eventNotifier.title')}
         </Drawer.Header>
@@ -70,7 +70,7 @@ export default function CommunicationSection({
         </Drawer.Footer>
       </Drawer>
 
-      <Drawer isOpen={SMSDrawerOpen} onCancel={() => setSMSDrawerOpen(false)}>
+      <Drawer isOpen={SMSDrawerOpen} onClose={() => setSMSDrawerOpen(false)}>
         <Drawer.Header as="h3" className="text-black">
           SMS
         </Drawer.Header>

--- a/apps/web/src/app/(admin)/admin/events/[id]/NotificationDetailsDrawer.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/NotificationDetailsDrawer.tsx
@@ -85,7 +85,7 @@ export default function NotificationDetailsDrawer({
   }, [isOpen, notification.notificationId]);
 
   return (
-    <Drawer isOpen={isOpen} onCancel={onClose}>
+    <Drawer isOpen={isOpen} onClose={onClose}>
       <Drawer.Header as="h3" className="text-black">
         Notification Details
       </Drawer.Header>

--- a/apps/web/src/app/(admin)/admin/orders/OrderActionsMenu.tsx
+++ b/apps/web/src/app/(admin)/admin/orders/OrderActionsMenu.tsx
@@ -90,7 +90,7 @@ export const OrderActionsMenu = ({ order }: OrderActionsMenuProps) => {
           {t('admin.labels.invoice')}
         </Button>
       )}
-      <Drawer isOpen={invoiceDrawerOpen} onCancel={() => setInvoiceDrawerOpen(false)}>
+      <Drawer isOpen={invoiceDrawerOpen} onClose={() => setInvoiceDrawerOpen(false)}>
         <Drawer.Header as="h2">Invoice</Drawer.Header>
         <div>
           <DescriptionList>

--- a/apps/web/src/app/(admin)/admin/organizations/[id]/AddMemberDrawer.tsx
+++ b/apps/web/src/app/(admin)/admin/organizations/[id]/AddMemberDrawer.tsx
@@ -66,7 +66,7 @@ const AddMemberDrawer: React.FC<AddMemberDrawerProps> = ({
     }
   };
   return (
-    <Drawer isOpen={isOpen} onCancel={handleClose}>
+    <Drawer isOpen={isOpen} onClose={handleClose}>
       <Drawer.Header as="h2">
         Add New Member
         {organizationName && (

--- a/apps/web/src/app/(admin)/admin/registrations/RegistrationDrawer.tsx
+++ b/apps/web/src/app/(admin)/admin/registrations/RegistrationDrawer.tsx
@@ -63,7 +63,7 @@ export default function RegistrationDrawer({
   }, [isOpen, registrationId]);
 
   return (
-    <Drawer isOpen={isOpen} onCancel={onClose}>
+    <Drawer isOpen={isOpen} onClose={onClose}>
       <Drawer.Header as="h3" className="text-black">
         {t('common.registrations.detailsPage.title')}
       </Drawer.Header>

--- a/apps/web/src/app/(admin)/admin/users/UserDrawer.tsx
+++ b/apps/web/src/app/(admin)/admin/users/UserDrawer.tsx
@@ -15,7 +15,7 @@ const UserDrawer: React.FC = () => {
   return (
     <>
       <Button onClick={showDrawer}>{t('admin.users.labels.createUser')}</Button>
-      <Drawer isOpen={visible} onCancel={onClose}>
+      <Drawer isOpen={visible} onClose={onClose}>
         <UserEditor adminMode />
       </Drawer>
     </>

--- a/libs/ratio-ui/src/layout/Drawer/Drawer.stories.tsx
+++ b/libs/ratio-ui/src/layout/Drawer/Drawer.stories.tsx
@@ -29,7 +29,7 @@ const OpenDrawerComponent: React.FC = () => {
   return (
     <div>
       <p>{getRandomHipsterIpsum()}</p>
-      <Drawer isOpen={isOpen} onCancel={() => setIsOpen(false)}>
+      <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)}>
         <Drawer.Header>
           <Drawer.Heading>Drawer Header</Drawer.Heading>
         </Drawer.Header>
@@ -51,7 +51,7 @@ const ClosedDrawerComponent: React.FC = () => {
     <div>
       <p>This is some content before the drawer.</p>
       <button onClick={() => setIsOpen(true)}>Open Drawer</button>
-      <Drawer isOpen={isOpen} onCancel={() => setIsOpen(false)}>
+      <Drawer isOpen={isOpen} onClose={() => setIsOpen(false)}>
         <Drawer.Header>
           <Drawer.Heading>Drawer Header sample</Drawer.Heading>
         </Drawer.Header>
@@ -69,17 +69,17 @@ export const ClosedDrawer = () => <ClosedDrawerComponent />;
 const DrawerWithActionsComponent: React.FC = () => {
   const [isOpen, setIsOpen] = useState(true);
 
-  const handleCancel = () => {
-    alert('Cancel action triggered!');
+  const handleClose = () => {
+    alert('Close action triggered!');
     setIsOpen(false);
   };
 
   return (
     <div>
       <button onClick={() => setIsOpen(true)}>Open Drawer</button>
-      <Drawer isOpen={isOpen} onCancel={handleCancel}>
+      <Drawer isOpen={isOpen} onClose={handleClose}>
         <Drawer.Header>
-          <Drawer.Heading>Drawer With Cancel</Drawer.Heading>
+          <Drawer.Heading>Drawer With Close</Drawer.Heading>
         </Drawer.Header>
         <Drawer.Body>
           <p>{getRandomHipsterIpsum()}</p>
@@ -89,4 +89,4 @@ const DrawerWithActionsComponent: React.FC = () => {
   );
 };
 
-export const DrawerWithCancel = () => <DrawerWithActionsComponent />;
+export const DrawerWithClose = () => <DrawerWithActionsComponent />;

--- a/libs/ratio-ui/src/layout/Drawer/Drawer.tsx
+++ b/libs/ratio-ui/src/layout/Drawer/Drawer.tsx
@@ -12,7 +12,7 @@ import { cn } from '../../utils/cn';
 
 export interface DrawerProps {
   isOpen: boolean;
-  onCancel?: () => void;
+  onClose?: () => void;
   children: ReactNode;
   /** Whether clicking the backdrop closes the drawer. Defaults to true. */
   isDismissable?: boolean;
@@ -49,7 +49,7 @@ interface DrawerComponent extends React.FC<DrawerProps> {
 
 const Drawer: DrawerComponent = ({
   isOpen,
-  onCancel,
+  onClose,
   children,
   isDismissable = true,
   isKeyboardDismissDisabled = false,
@@ -58,7 +58,7 @@ const Drawer: DrawerComponent = ({
     <ModalOverlay
       isOpen={isOpen}
       onOpenChange={open => {
-        if (!open) onCancel?.();
+        if (!open) onClose?.();
       }}
       isDismissable={isDismissable}
       isKeyboardDismissDisabled={isKeyboardDismissDisabled}
@@ -66,9 +66,9 @@ const Drawer: DrawerComponent = ({
     >
       <Modal className="fixed top-0 right-0 h-full w-11/12 md:w-10/12 lg:w-7/12 2xl:w-8/12 bg-gray-100 dark:bg-slate-950 overflow-auto">
         <AriaDialog className="relative flex flex-col p-6 outline-hidden h-full">
-          {onCancel && (
+          {onClose && (
             <Button
-              onClick={onCancel}
+              onClick={onClose}
               className="absolute top-0 right-0 m-4"
               variant="secondary"
               ariaLabel="Close drawer"

--- a/libs/ratio-ui/src/layout/FileDrawer/FileDrawer.stories.tsx
+++ b/libs/ratio-ui/src/layout/FileDrawer/FileDrawer.stories.tsx
@@ -41,7 +41,7 @@ export const WithHtmlContent: Story = {
     title: 'Certificate Preview',
     content: sampleHtml,
     closeLabel: 'Close',
-    onCancel: () => {},
+    onClose: () => {},
   },
 };
 
@@ -53,7 +53,7 @@ export const WithDownload: Story = {
     downloadFilename: 'certificate.html',
     downloadLabel: 'Download',
     closeLabel: 'Close',
-    onCancel: () => {},
+    onClose: () => {},
   },
 };
 
@@ -65,7 +65,7 @@ const InteractiveExample = () => {
       <Button onClick={() => setHtml(sampleHtml)}>Preview Certificate</Button>
       <FileDrawer
         isOpen={!!html}
-        onCancel={() => setHtml(null)}
+        onClose={() => setHtml(null)}
         title="Certificate Preview"
         content={html ?? undefined}
       />

--- a/libs/ratio-ui/src/layout/FileDrawer/FileDrawer.tsx
+++ b/libs/ratio-ui/src/layout/FileDrawer/FileDrawer.tsx
@@ -5,7 +5,7 @@ import { Drawer } from '../Drawer/Drawer';
 
 export interface FileDrawerProps {
   isOpen: boolean;
-  onCancel: () => void;
+  onClose: () => void;
   title: string;
   /** Raw file content (HTML string, SVG, etc.) */
   content?: string;
@@ -28,7 +28,7 @@ export interface FileDrawerProps {
  */
 export const FileDrawer = ({
   isOpen,
-  onCancel,
+  onClose,
   title,
   content,
   contentType = 'text/html',
@@ -59,7 +59,7 @@ export const FileDrawer = ({
   }, [iframeSrc, downloadFilename]);
 
   return (
-    <Drawer isOpen={isOpen} onCancel={onCancel}>
+    <Drawer isOpen={isOpen} onClose={onClose}>
       <Drawer.Header>
         <Drawer.Heading>{title}</Drawer.Heading>
       </Drawer.Header>
@@ -79,7 +79,7 @@ export const FileDrawer = ({
             {downloadLabel}
           </Button>
         )}
-        <Button onClick={onCancel} variant="secondary">
+        <Button onClick={onClose} variant="secondary">
           {closeLabel}
         </Button>
       </Drawer.Footer>


### PR DESCRIPTION
## Summary

Aligns `Drawer` and `FileDrawer` with `Dialog` and `AlertDialog` — all four now use `onClose` for the dismissal callback. **Stacked on #1370** — base is `refactor/ratio-ui-drawer-rac-modal`. Will auto-retarget to main once #1370 merges.

```tsx
// Before
<Drawer isOpen={open} onCancel={close}>...</Drawer>
<FileDrawer isOpen={open} onCancel={close} ... />

// After
<Drawer isOpen={open} onClose={close}>...</Drawer>
<FileDrawer isOpen={open} onClose={close} ... />
```

`AlertDialog`'s `onCancel` is intentionally kept — it represents a distinct user action ("clicked the Cancel button") separate from `onClose` ("dialog dismissed for any reason"). On `Drawer`/`FileDrawer` the two semantics were always conflated, so the rename loses no information.

### Migrated callsites

**apps/web** (10 files):
- `(admin)/admin/orders/OrderActionsMenu.tsx`
- `(admin)/admin/users/UserDrawer.tsx`
- `(admin)/admin/organizations/[id]/AddMemberDrawer.tsx`
- `(admin)/admin/events/EventParticipantList.tsx`
- `(admin)/admin/events/AddUserToEvent.tsx` (also propagated through internal `AddUserToEventDrawer` props)
- `(admin)/admin/events/AdminCertificatesActionsMenu.tsx` (FileDrawer)
- `(admin)/admin/events/[id]/CommunicationSection.tsx`
- `(admin)/admin/events/[id]/NotificationDetailsDrawer.tsx`
- `(admin)/admin/registrations/RegistrationDrawer.tsx`

**apps/historia** (1 file):
- `src/components/cart/CartDrawer.tsx`

### Plan recap

- ✅ PR1 (#1366, merged) — Dialog compound refactor
- ✅ PR2 (#1367, merged) — AlertDialog
- ✅ PR3 (#1368, merged) — Sweep `@deprecated` exports/props
- ⏳ PR4 (#1369) — Migrate Dialog to RAC `ModalOverlay`/`Modal`
- ⏳ PR5 (#1370) — Migrate Drawer + remove Portal
- ✅ PR6 (this) — Rename `onCancel` → `onClose` for symmetry

After this lands, `@eventuras/ratio-ui@2.0.0` ships with a coherent dismissal API across `Dialog`, `AlertDialog`, `Drawer`, and `FileDrawer`.

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`, `apps/web`, `apps/historia`
- [x] `pnpm test` in `libs/ratio-ui` — 355 passing
- [x] `pnpm build` succeeds
- [x] No `Drawer`/`FileDrawer` callsite still uses `onCancel`
- [ ] Spot-check Storybook (`Layout/Drawer`, `Layout/FileDrawer`)
- [ ] Manually open at least one drawer per app and verify backdrop click + Escape both close

🤖 Generated with [Claude Code](https://claude.com/claude-code)