### PR TITLE
refactor(ratio-ui)!: replace onDark/bgDark props with surface token system

### DIFF
--- a/.changeset/surface-tokens.md
+++ b/.changeset/surface-tokens.md
@@ -1,0 +1,65 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+Replace per-component `onDark` / `bgDark` props with a CSS-variable-based surface token system.
+
+### Why
+
+Five components (`Heading`, `Button`, `Link`, `Navbar`, plus a few more transitively) had ad-hoc boolean props for "I am rendered on a dark surface, use light text". This required prop-drilling on every child of a hero/navbar/footer, was easy to forget, and produced inconsistent naming (`onDark` on three components, `bgDark` on `Navbar`).
+
+The new approach uses CSS cascade: a parent declares the surface tone with one className, and any component inside automatically reads the right text color via `var(--text)`.
+
+### New API
+
+```tsx
+// Before
+<Section style={heroBg}>
+  <Heading onDark>Find knowledge</Heading>
+  <Link variant="button-primary" onDark>Get started</Link>
+</Section>
+
+<Navbar bgDark overlay glass>
+  ...
+</Navbar>
+
+// After
+<Section style={heroBg} className="surface-dark">
+  <Heading>Find knowledge</Heading>
+  <Link variant="button-primary">Get started</Link>
+</Section>
+
+<Navbar overlay glass className="surface-dark">
+  ...
+</Navbar>
+```
+
+`surface-dark` and `surface-light` are utility classes that override `--text` for the subtree. They're safelisted in `global.css`.
+
+### What was removed
+
+- `Heading.onDark`
+- `Button.onDark`
+- `Link.onDark`
+- `Navbar.bgDark`
+- The internal `--navbar-color` variable (now reads `--text` directly)
+
+### What changed under the hood
+
+- `Heading` always reads `text-(--text)` (theme-aware default, surface-class overridable)
+- `Button`'s transparent variants (`text`, `outline`) read `text-(--text)`. Filled variants (`primary`, `secondary`, `light`, `danger`) keep their hardcoded text colors.
+- `Link`'s variant-styled links read `text-(--text)`. The default underlined link keeps its blue/blue-400 theme-aware colors. `button-primary` keeps its light-on-primary text.
+- `Navbar`, `Navbar.Brand`, `Navbar.Content` all read `text-(--text)`.
+
+### Migration
+
+Find any callsite passing `onDark` or `bgDark`:
+
+1. Drop the prop.
+2. Add `className="surface-dark"` (or `surface-light`) on the *container* with the colored background — usually a `<Section>`, `<Navbar>`, hero `<div>`, etc.
+
+Internal callsites in `apps/web`, `apps/historia`, and `apps/idem-admin` have been migrated.
+
+### Future direction
+
+Only `--text` is overridden today. The same pattern will extend naturally to `--text-muted`, `--border`, and other tokens as components need them — without growing the prop API of every individual component.

--- a/apps/historia/src/components/Footer/Component.client.tsx
+++ b/apps/historia/src/components/Footer/Component.client.tsx
@@ -34,7 +34,6 @@ export const FooterClient: React.FC<FooterClientProps> = ({ navigation }) => {
             <Heading
               as="h3"
               className="pb-2 text-sm font-semibold uppercase"
-              onDark
               padding="none"
             >
               {navBlock.title}

--- a/apps/idem-admin/src/components/AdminNavbar.tsx
+++ b/apps/idem-admin/src/components/AdminNavbar.tsx
@@ -16,7 +16,7 @@ type AdminNavbarProps = {
 
 export function AdminNavbar({ user }: Readonly<AdminNavbarProps>) {
   return (
-    <Navbar bgColor="bg-primary-700" bgDark sticky>
+    <Navbar bgColor="bg-primary-700" className="surface-dark" sticky>
       <Navbar.Brand>
         <Link href="/admin" className="text-lg tracking-tight whitespace-nowrap no-underline">
           Idem Admin

--- a/apps/web/src/app/(frontpage)/page.tsx
+++ b/apps/web/src/app/(frontpage)/page.tsx
@@ -109,10 +109,10 @@ export default async function Homepage() {
       {/* Hero section with background image */}
       <Section
         style={buildCoverImageStyle('/assets/images/mountains.jpg')}
-        className="min-h-[30vh] flex flex-col justify-end"
+        className="surface-dark min-h-[30vh] flex flex-col justify-end"
       >
         <Container className="pb-3">
-          <Heading as="h1" onDark paddingBottom="xs" className="text-3xl md:text-4xl lg:text-5xl">
+          <Heading as="h1" paddingBottom="xs" className="text-3xl md:text-4xl lg:text-5xl">
             {site?.frontpage.introduction ?? 'Eventuras for your life!'}
           </Heading>
         </Container>

--- a/apps/web/src/components/eventuras/SiteNavbar.tsx
+++ b/apps/web/src/components/eventuras/SiteNavbar.tsx
@@ -34,7 +34,7 @@ export default async function SiteNavbar({
   return (
     <Navbar
       {...(isDark
-        ? { bgDark: true, overlay: true, glass: true }
+        ? { className: 'surface-dark', overlay: true, glass: true }
         : { bgColor: BG_COLOR_BY_VARIANT[variant], sticky })}
     >
       <Navbar.Brand>

--- a/apps/web/src/components/user/UserEventRegistrationCard.tsx
+++ b/apps/web/src/components/user/UserEventRegistrationCard.tsx
@@ -51,7 +51,6 @@ const UserEventRegistrationCard = ({
         <Link
           href={`/user/events/${eventId}`}
           variant="button-primary"
-          onDark
           linkOverlay
           testId={eventId}
         >

--- a/libs/ratio-ui/src/core/Button/Button.stories.tsx
+++ b/libs/ratio-ui/src/core/Button/Button.stories.tsx
@@ -12,7 +12,6 @@ const meta: Meta<typeof Button> = {
     disabled: false,
     loading: false,
     block: false,
-    onDark: false,
     icon: false,
     children: 'Button',
     onClick: fn(),
@@ -25,7 +24,6 @@ const meta: Meta<typeof Button> = {
     disabled: { control: 'boolean' },
     loading: { control: 'boolean' },
     block: { control: 'boolean' },
-    onDark: { control: 'boolean' },
     icon: {
       control: 'boolean',
       description: 'Toggle to show a Home icon before the label',
@@ -84,7 +82,7 @@ export const AllCombinations = () => {
     'text',
   ];
 
-  const states: { label: string; props: Partial<ButtonProps> }[] = [
+  const states: { label: string; props: Partial<ButtonProps>; onSurfaceDark?: boolean }[] = [
     { label: 'Default', props: {} },
     { label: 'Disabled', props: { disabled: true } },
     { label: 'Loading', props: { loading: true } },
@@ -93,7 +91,7 @@ export const AllCombinations = () => {
       label: 'Icon + Loading',
       props: { icon: <Home strokeWidth={1} />, loading: true },
     },
-    { label: 'On Dark', props: { onDark: true } },
+    { label: 'On Dark Surface', props: {}, onSurfaceDark: true },
   ];
 
   return (
@@ -102,7 +100,7 @@ export const AllCombinations = () => {
         <div key={variant}>
           <h4 className="mb-2 font-semibold">{variant}</h4>
           <div className="flex flex-wrap gap-2">
-            {states.map(({ label, props }) => {
+            {states.map(({ label, props, onSurfaceDark }) => {
               const btn = (
                 <Button
                   key={`${variant}-${label}`}
@@ -113,12 +111,11 @@ export const AllCombinations = () => {
                 </Button>
               );
 
-              // If this is the On Dark case, wrap in a black bg
-              if (props.onDark) {
+              if (onSurfaceDark) {
                 return (
                   <div
                     key={`${variant}-${label}`}
-                    className="bg-black p-2 rounded"
+                    className="surface-dark bg-black p-2 rounded"
                   >
                     {btn}
                   </div>

--- a/libs/ratio-ui/src/core/Button/Button.tsx
+++ b/libs/ratio-ui/src/core/Button/Button.tsx
@@ -23,7 +23,7 @@ export const buttonStyles = {
   text: `bg-transparent hover:bg-primary-200 hover:bg-opacity-20 rounded-full ${ANIMATION_CLASSES}`,
   outline:
     `border border-gray-700 hover:border-primary-500 hover:bg-primary-100/10 dark:hover:bg-primary-900 ` +
-    `dark:text-white rounded-full ${ANIMATION_CLASSES}`,
+    `rounded-full ${ANIMATION_CLASSES}`,
   danger:
     `border font-bold bg-red-600 hover:bg-red-700 dark:bg-red-700 dark:hover:bg-red-600 ` +
     `text-white rounded-full ${ANIMATION_CLASSES}`,
@@ -40,7 +40,6 @@ export interface ButtonProps
   ariaLabel?: string;
   icon?: React.ReactNode;
   loading?: boolean;
-  onDark?: boolean;
   variant?: keyof typeof buttonStyles;
   size?: keyof typeof buttonSizes;
   block?: boolean;
@@ -52,7 +51,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   {
     variant = 'primary',
     size = 'md',
-    onDark = false,
     block = false,
     disabled = false,
     loading = false,
@@ -72,13 +70,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   const displayClass = block ? 'w-full' : '';
   const variantClass = buttonStyles[variant];
 
+  // Transparent variants inherit text color from the surface (--text token,
+  // overridable via .surface-dark / .surface-light on a parent). Filled
+  // variants ship their own text color via buttonStyles.
   const isTransparent = variant === 'text' || variant === 'outline';
-  let textColorClass = '';
-  if (isTransparent) {
-    textColorClass = onDark
-      ? 'text-white'
-      : 'text-black dark:text-white';
-  }
+  const textColorClass = isTransparent ? 'text-(--text)' : '';
 
   const disabledClasses = (disabled || loading) ? 'opacity-75 cursor-not-allowed' : '';
 

--- a/libs/ratio-ui/src/core/Heading/Heading.tsx
+++ b/libs/ratio-ui/src/core/Heading/Heading.tsx
@@ -6,31 +6,28 @@ export interface HeadingProps extends SpacingProps {
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
   children: React.ReactNode;
   className?: string;
-  onDark?: boolean;
   testId?: string;
 }
 
 /**
- * Semantic heading component
- * Styling comes from CSS tokens in typography.css
- * Use className or spacing props to customize
+ * Semantic heading component.
+ *
+ * Text color follows `--text` from the design tokens, which is theme-aware
+ * by default. To force a tone for content rendered on a colored container,
+ * wrap with `<div className="surface-dark">` (or `surface-light`) — see
+ * `Surface tone overrides` in `global.css`.
  */
 export const Heading = ({
   as: HeadingComponent = 'h1',
   children,
   className,
-  onDark = false,
   testId,
   ...spacingProps
-}: HeadingProps) => {
-  const textColor = onDark ? 'text-gray-200' : 'text-gray-800 dark:text-gray-200';
-
-  return (
-    <HeadingComponent
-      className={cn(textColor, buildSpacingClasses(spacingProps), className)}
-      data-testid={testId}
-    >
-      {children}
-    </HeadingComponent>
-  );
-};
+}: HeadingProps) => (
+  <HeadingComponent
+    className={cn('text-(--text)', buildSpacingClasses(spacingProps), className)}
+    data-testid={testId}
+  >
+    {children}
+  </HeadingComponent>
+);

--- a/libs/ratio-ui/src/core/Link/Link.stories.tsx
+++ b/libs/ratio-ui/src/core/Link/Link.stories.tsx
@@ -12,7 +12,6 @@ const meta: Meta<typeof Link> = {
     children: 'Link text',
     variant: undefined,
     block: false,
-    onDark: false,
     linkOverlay: false,
   },
   argTypes: {
@@ -24,7 +23,6 @@ const meta: Meta<typeof Link> = {
       description: 'Style the link as a button',
     },
     block: { control: 'boolean' },
-    onDark: { control: 'boolean' },
     linkOverlay: { control: 'boolean' },
   },
 };
@@ -137,16 +135,14 @@ export const AllVariants = () => {
         </div>
       </div>
 
-      <div className="bg-gray-900 p-4 rounded">
-        <h4 className="mb-2 font-semibold text-white">On Dark Background</h4>
+      <div className="surface-dark bg-gray-900 p-4 rounded">
+        <h4 className="mb-2 font-semibold text-white">On Dark Surface</h4>
         <div className="flex flex-wrap gap-2">
-          <Link href="#" onDark>
-            Text link
-          </Link>
-          <Link href="#" variant="button-primary" onDark>
+          <Link href="#">Text link</Link>
+          <Link href="#" variant="button-primary">
             Primary
           </Link>
-          <Link href="#" variant="button-secondary" onDark>
+          <Link href="#" variant="button-secondary">
             Secondary
           </Link>
         </div>

--- a/libs/ratio-ui/src/core/Link/Link.tsx
+++ b/libs/ratio-ui/src/core/Link/Link.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import type { SpacingProps } from '../../tokens/spacing';
 import { buildSpacingClasses } from '../../tokens/spacing';
+import { cn } from '../../utils/cn';
 import { buttonStyles } from '../Button/Button';
 import './Link.css';
 
@@ -11,7 +12,6 @@ export interface LinkProps extends SpacingProps {
   className?: string;
   variant?: 'button-primary' | 'button-secondary' | 'button-light' | 'button-outline' | 'button-text';
   block?: boolean;
-  onDark?: boolean;
   linkOverlay?: boolean;
   component?: React.ElementType; // e.g. next/link
   componentProps?: Record<string, unknown>;
@@ -26,7 +26,6 @@ export const Link = React.forwardRef<HTMLElement, LinkProps>(
       href,
       children,
       className = '',
-      onDark = false,
       block = false,
       variant,
       linkOverlay = false,
@@ -45,13 +44,12 @@ export const Link = React.forwardRef<HTMLElement, LinkProps>(
       ? 'text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 underline decoration-blue-600/30 hover:decoration-blue-800 underline-offset-2 transition-colors'
       : '';
 
-    // No text color for default links (uses defaultLinkClasses)
-    let textColor = '';
-    if (onDark || variant === 'button-primary') {
-      textColor = 'text-gray-200';
-    } else if (variant) {
-      textColor = 'text-gray-800 dark:text-gray-200';
-    }
+    // Transparent variants (`button-outline`, `button-text`) inherit text
+    // color from `--text` so they react to `surface-dark` / `surface-light`
+    // on a parent. Filled variants keep the text color shipped by their
+    // entry in `buttonStyles`.
+    const isTransparentVariant = variant === 'button-outline' || variant === 'button-text';
+    const textColor = isTransparentVariant ? 'text-(--text)' : '';
 
     const blockClass = block ? 'block' : '';
     let variantClasses = '';
@@ -60,7 +58,7 @@ export const Link = React.forwardRef<HTMLElement, LinkProps>(
       if (buttonStyles[key]) variantClasses = 'px-4 py-2 inline-flex items-center gap-2 whitespace-nowrap ' + buttonStyles[key];
     }
 
-    const classes = [
+    const classes = cn(
       spacingClasses,
       defaultLinkClasses,
       variantClasses,
@@ -68,9 +66,7 @@ export const Link = React.forwardRef<HTMLElement, LinkProps>(
       blockClass,
       linkOverlay && 'link-overlay',
       className,
-    ]
-      .filter(Boolean)
-      .join(' ');
+    );
 
     // For Next.js Link, we need to pass data-testid via componentProps
     const finalComponentProps = testId

--- a/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.stories.tsx
@@ -34,7 +34,7 @@ export const BrandAndContent: Story = {
 
 export const BrandOnly: Story = {
   render: () => (
-    <Navbar bgColor="bg-slate-900" bgDark>
+    <Navbar bgColor="bg-slate-900" className="surface-dark">
       <Navbar.Brand>
         <a href="/" className="text-lg tracking-tight no-underline text-white">
           Ignis
@@ -59,7 +59,7 @@ export const ContentOnly: Story = {
 export const DoubleNavbar: Story = {
   render: () => (
     <div>
-      <Navbar sticky bgColor="bg-slate-900" bgDark>
+      <Navbar sticky bgColor="bg-slate-900" className="surface-dark">
         <Navbar.Brand>
           <a href="/" className="text-lg tracking-tight no-underline text-white">Eventuras</a>
         </Navbar.Brand>
@@ -82,13 +82,13 @@ export const DoubleNavbar: Story = {
 /**
  * Glass navbar floating over a hero section. `overlay` anchors it to the
  * viewport top without reserving layout space; `glass` gives the translucent
- * dark bg + backdrop-blur; `bgDark` makes the text readable over the image.
+ * dark bg + backdrop-blur; the `surface-dark` className makes the text readable over the image.
  * The nav scrolls away with the page (unlike `sticky`, which stays pinned).
  */
 export const OverlayGlass: Story = {
   render: () => (
     <div className="relative">
-      <Navbar overlay glass bgDark>
+      <Navbar overlay glass className="surface-dark">
         <Navbar.Brand>
           <a href="/" className="text-lg tracking-tight no-underline">
             Eventuras

--- a/libs/ratio-ui/src/core/Navbar/Navbar.tsx
+++ b/libs/ratio-ui/src/core/Navbar/Navbar.tsx
@@ -3,8 +3,6 @@ import { cn } from '../../utils/cn';
 
 export interface NavbarProps {
   children?: ReactNode;
-  /** Forces white text for dark backgrounds. */
-  bgDark?: boolean;
   /** Tailwind background class (default `bg-transparent`). */
   bgColor?: string;
   /** Make navbar sticky at the top. Ignored when `overlay` is also set. */
@@ -18,7 +16,8 @@ export interface NavbarProps {
   overlay?: boolean;
   /**
    * Translucent dark background with backdrop-blur. Composes with `overlay`
-   * for a glass hero-overlay look, and with `bgDark` for white text.
+   * for a glass hero-overlay look. Pair with `surface-dark` className when
+   * the resulting background is dark enough that you need light text.
    */
   glass?: boolean;
   className?: string;
@@ -36,7 +35,7 @@ export interface NavbarContentProps {
 
 function NavbarBrand({ children, className }: Readonly<NavbarBrandProps>) {
   return (
-    <div className={cn('flex shrink-0 items-center text-[var(--navbar-color,inherit)]', className)}>
+    <div className={cn('flex shrink-0 items-center text-(--text)', className)}>
       {children}
     </div>
   );
@@ -44,7 +43,7 @@ function NavbarBrand({ children, className }: Readonly<NavbarBrandProps>) {
 
 function NavbarContent({ children, className }: Readonly<NavbarContentProps>) {
   return (
-    <div className={cn('flex grow items-center gap-3 text-[var(--navbar-color,inherit)]', className)}>
+    <div className={cn('flex grow items-center gap-3 text-(--text)', className)}>
       {children}
     </div>
   );
@@ -52,14 +51,12 @@ function NavbarContent({ children, className }: Readonly<NavbarContentProps>) {
 
 const NavbarRoot = ({
   children,
-  bgDark = false,
   bgColor,
   sticky = false,
   overlay = false,
   glass = false,
   className,
 }: Readonly<NavbarProps>) => {
-  const textColor = bgDark ? 'text-light' : 'text-dark dark:text-light';
   // overlay takes precedence over sticky when both are passed.
   const positionClass = overlay
     ? 'absolute top-0 left-0 right-0 z-50'
@@ -67,14 +64,9 @@ const NavbarRoot = ({
       ? 'sticky top-0 z-50'
       : '';
   const glassClass = glass ? 'bg-black/20 dark:bg-white/10  backdrop-blur-md' : '';
-  // CSS custom property so Brand/Content get the resolved color without
-  // React context (which would require 'use client').
-  const navbarColorVar = bgDark
-    ? '[--navbar-color:white]'
-    : '[--navbar-color:var(--text-dark,#1a1a1a)] dark:[--navbar-color:var(--text-light,white)]';
 
   return (
-    <nav className={cn(bgColor, positionClass, glassClass, textColor, navbarColorVar, 'm-0 p-0', className)}>
+    <nav className={cn(bgColor, positionClass, glassClass, 'text-(--text) m-0 p-0', className)}>
       <div className="container flex flex-wrap items-center mx-auto gap-3 py-2 px-3">
         {children}
       </div>

--- a/libs/ratio-ui/src/global.css
+++ b/libs/ratio-ui/src/global.css
@@ -26,12 +26,30 @@
 /* Dialog size variants — safelisted because the class name is looked up
    from the size prop at runtime, not written inline. */
 @source inline("max-w-md max-w-lg max-w-2xl max-w-4xl");
+/* Surface tone utilities — override --text for descendants. Used by
+   components like Heading/Button/Link/Navbar that read `var(--text)`
+   so a parent container can declare "everything inside me is on a
+   dark/light surface" without each child needing a per-component prop. */
+@source inline("surface-dark surface-light");
 
 /* Dark mode variant */
 @custom-variant dark (&:where(html[data-theme="dark"] &, body[data-theme="dark"] &, [data-theme="dark"] *));
 
 /* Design tokens */
 @import "./tokens/index.css";
+
+/* Surface tone overrides. Composes with the theme-aware default `--text`
+   from tokens/theme.css: in unmarked containers `--text` follows the
+   page theme; inside `.surface-dark`/`.surface-light` it's pinned via
+   the semantic `--text-light`/`--text-dark` tokens (so palette changes
+   propagate automatically). */
+.surface-dark {
+  --text: var(--text-light);
+}
+
+.surface-light {
+  --text: var(--text-dark);
+}
 
 /* Base styles */
 @layer base {


### PR DESCRIPTION
## Summary

Replaces five components' ad-hoc `onDark`/`bgDark` boolean props with a CSS-variable-based surface token system.

### Why

Five components had ad-hoc booleans for "I'm rendered on a dark surface, use light text" — three named `onDark`, one named `bgDark`. The naming was inconsistent, required prop-drilling on every child of a hero/navbar/footer, and was easy to forget.

The new approach uses CSS cascade. A parent declares the surface tone with one className; any descendant reads the right text color via `var(--text)` automatically.

### Before / After

```tsx
// Before
<Section style={heroBg}>
  <Heading onDark>Find knowledge</Heading>
  <Link variant="button-primary" onDark>Get started</Link>
</Section>

<Navbar bgDark overlay glass>...</Navbar>

// After
<Section style={heroBg} className="surface-dark">
  <Heading>Find knowledge</Heading>
  <Link variant="button-primary">Get started</Link>
</Section>

<Navbar overlay glass className="surface-dark">...</Navbar>
```

### What was removed

- `Heading.onDark`
- `Button.onDark`
- `Link.onDark`
- `Navbar.bgDark`
- The internal `--navbar-color` variable (now reads `--text` directly)

### Under the hood

- `Heading` always reads `text-(--text)` (theme-aware default; override via surface class).
- `Button`'s transparent variants (`text`, `outline`) read `text-(--text)`. Filled variants keep their hardcoded text colors.
- `Link`'s variant-styled links read `text-(--text)`. The default underlined link keeps its theme-aware blues. `button-primary` keeps its light text.
- `Navbar`, `Navbar.Brand`, `Navbar.Content` all read `text-(--text)`.
- `surface-dark`/`surface-light` are utility classes safelisted in `global.css` that override `--text` for the subtree.

### Migrated callsites

**apps/web**:
- `(frontpage)/page.tsx` — hero Section
- `components/eventuras/SiteNavbar.tsx` — dark variant Navbar
- `components/user/UserEventRegistrationCard.tsx` — Link inside a Card

**apps/idem-admin**:
- `components/AdminNavbar.tsx` — primary-tinted dark Navbar

**apps/historia**:
- `components/Footer/Component.client.tsx` — dropped redundant `onDark` (footer bg is already theme-aware)

### Future direction

Only `--text` is overridden today. The same pattern extends naturally to `--text-muted`, `--border`, and other tokens as components need them — without growing the prop API of every individual component.

### Plan recap

This is the last 2.0 cleanup. With this merged, `@eventuras/ratio-ui@2.0.0` is ready to ship:

- ✅ #1366 Dialog compound refactor
- ✅ #1367 AlertDialog
- ✅ #1368 Remove deprecated InputLabel + Navbar legacy props
- ✅ #1369 Dialog → RAC ModalOverlay/Modal
- ✅ #1370 Drawer → RAC Modal + remove Portal
- ✅ #1371 Drawer/FileDrawer onCancel → onClose
- ⏳ This PR — surface tokens

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`, `apps/web`, `apps/historia`, `apps/idem-admin`
- [x] `pnpm test` in `libs/ratio-ui` — 355 passing
- [x] `pnpm build` succeeds
- [x] No `onDark` or `bgDark` references remain in source
- [ ] Spot-check Storybook:
  - [ ] `Core/Button` → "All Variants & States" — "On Dark Surface" column should show light-text buttons on black
  - [ ] `Core/Link` → "All Variants" — surface-dark block should render readably
  - [ ] `Core/Navbar` → BrandOnly, DoubleNavbar, OverlayGlass — all dark navbars should have light text
- [ ] Manually load each migrated app:
  - [ ] `apps/web` frontpage hero
  - [ ] `apps/web` dark variant SiteNavbar
  - [ ] `apps/idem-admin` AdminNavbar
  - [ ] `apps/historia` footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)