### PR TITLE
refactor(ratio-ui)!: split Footer into shell + Footer.Classic (stacked on #1373)

### DIFF
--- a/.changeset/footer-shell.md
+++ b/.changeset/footer-shell.md
@@ -1,0 +1,28 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+Refactor `Footer` to a thin shell + `Footer.Classic` backward-compat wrapper.
+
+`Footer` is now a shell that renders the standard `<footer>` element with bg, padding, and a `Container` — anything goes inside. The pre-2.0 fixed layout (siteTitle + publisher block on the left, children on the right via `md:flex`) lives on as `Footer.Classic` for callers that want it.
+
+```tsx
+// Before
+<Footer siteTitle={site.name} publisher={site.publisher}>
+  <List>...</List>
+</Footer>
+
+// After (no behavior change — just renamed)
+<Footer.Classic siteTitle={site.name} publisher={site.publisher}>
+  <List>...</List>
+</Footer.Classic>
+
+// New: shell mode for fully custom layouts
+<Footer dark>
+  <YourCustomFooterContent />
+</Footer>
+```
+
+This is a structural change — no UI difference for existing call sites — that opens up the `Footer` namespace for additive subcomponents (`Footer.Brand`, `Footer.Content`, `Footer.Publisher`, …) in a future minor release. We didn't ship them now to avoid locking in a design before a real layout need surfaces.
+
+The four `apps/web` layouts, `apps/historia`'s Footer, and the ratio-ui Page story have all been migrated to `Footer.Classic` (mechanical rename, no behavior change).

--- a/apps/historia/src/components/Footer/Component.tsx
+++ b/apps/historia/src/components/Footer/Component.tsx
@@ -45,8 +45,8 @@ export async function Footer() {
       : undefined;
 
   return (
-    <FooterUI siteTitle={website.title} publisher={publisher}>
+    <FooterUI.Classic siteTitle={website.title} publisher={publisher}>
       <FooterClient navigation={website.siteSettings?.footer?.navigation} />
-    </FooterUI>
+    </FooterUI.Classic>
   );
 }

--- a/apps/web/src/app/(admin)/layout.tsx
+++ b/apps/web/src/app/(admin)/layout.tsx
@@ -35,7 +35,7 @@ export default async function AdminLayout({ children }: Readonly<{ children: Rea
 
       <main id="main-content">{children}</main>
 
-      <Footer siteTitle={site?.name} publisher={site?.publisher}>
+      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
         <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
           {site?.footerLinks?.map((link, idx) => (
             <List.Item key={link.href ?? idx} className="mb-4">
@@ -43,7 +43,7 @@ export default async function AdminLayout({ children }: Readonly<{ children: Rea
             </List.Item>
           ))}
         </List>
-      </Footer>
+      </Footer.Classic>
     </>
   );
 }

--- a/apps/web/src/app/(frontpage)/layout.tsx
+++ b/apps/web/src/app/(frontpage)/layout.tsx
@@ -21,7 +21,7 @@ export default async function FrontpageLayout({ children }: Readonly<{ children:
         {children}
       </main>
 
-      <Footer siteTitle={site?.name} publisher={site?.publisher}>
+      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
         <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
           {site?.footerLinks?.map((link, idx) => (
             <List.Item key={link.href ?? idx} className="mb-4">
@@ -29,7 +29,7 @@ export default async function FrontpageLayout({ children }: Readonly<{ children:
             </List.Item>
           ))}
         </List>
-      </Footer>
+      </Footer.Classic>
     </>
   );
 }

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -21,7 +21,7 @@ export default async function PublicLayout({ children }: Readonly<{ children: Re
 
       <main id="main-content">{children}</main>
 
-      <Footer siteTitle={site?.name} publisher={site?.publisher}>
+      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
         <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
           {site?.footerLinks?.map((link, idx) => (
             <List.Item key={link.href ?? idx} className="mb-4">
@@ -29,7 +29,7 @@ export default async function PublicLayout({ children }: Readonly<{ children: Re
             </List.Item>
           ))}
         </List>
-      </Footer>
+      </Footer.Classic>
     </>
   );
 }

--- a/apps/web/src/app/(user)/layout.tsx
+++ b/apps/web/src/app/(user)/layout.tsx
@@ -25,7 +25,7 @@ export default async function UserLayout({ children }: Readonly<{ children: Reac
 
       <main id="main-content">{children}</main>
 
-      <Footer siteTitle={site?.name} publisher={site?.publisher}>
+      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
         <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
           {site?.footerLinks?.map((link, idx) => (
             <List.Item key={link.href ?? idx} className="mb-4">
@@ -33,7 +33,7 @@ export default async function UserLayout({ children }: Readonly<{ children: Reac
             </List.Item>
           ))}
         </List>
-      </Footer>
+      </Footer.Classic>
     </>
   );
 }

--- a/libs/ratio-ui/src/core/Footer/Footer.stories.tsx
+++ b/libs/ratio-ui/src/core/Footer/Footer.stories.tsx
@@ -10,193 +10,75 @@ export default meta;
 
 type FooterStory = StoryFn<typeof Footer>;
 
-export const Playground: FooterStory = args => <Footer {...args} />;
-
-export const Basic: FooterStory = () => <Footer siteTitle="Eventuras" />;
-
-export const WithPublisher: FooterStory = () => {
-  const publisher: Publisher = {
-    name: 'Example Organization',
-    address: '123 Main Street, Oslo',
-    phone: '+47 123 45 678',
-    email: 'contact@example.com',
-    organizationNumber: '123456789',
-  };
-
-  return <Footer siteTitle="Eventuras" publisher={publisher} />;
+const samplePublisher: Publisher = {
+  name: 'Example Organization',
+  address: '123 Main Street, Oslo',
+  phone: '+47 123 45 678',
+  email: 'contact@example.com',
+  organizationNumber: '123456789',
 };
 
-export const WithChildren: FooterStory = () => (
-  <Footer siteTitle="Eventuras">
+/**
+ * The plain `<Footer>` is a thin shell — the `<footer>` element with the
+ * standard background, padding, and a `Container` wrapper. Compose your
+ * own layout inside.
+ */
+export const Shell: FooterStory = () => (
+  <Footer>
+    <p>Compose anything you want inside the shell.</p>
+  </Footer>
+);
+
+/**
+ * `dark` flips the surface tone, so plain text and any descendants that
+ * read `var(--text)` switch to the light value.
+ */
+export const DarkShell: FooterStory = () => (
+  <Footer dark className="bg-slate-900">
+    <p>Plain text inside the dark footer inherits the light surface tone.</p>
+  </Footer>
+);
+
+/**
+ * `Footer.Classic` is the pre-2.0 fixed layout — siteTitle and an
+ * optional publisher block on the left, children on the right via
+ * `md:flex md:justify-between`. Kept for backward compatibility.
+ */
+export const Classic: FooterStory = () => (
+  <Footer.Classic siteTitle="Eventuras" publisher={samplePublisher} />
+);
+
+export const ClassicWithChildren: FooterStory = () => (
+  <Footer.Classic siteTitle="Eventuras" publisher={samplePublisher}>
     <div className="grid grid-cols-2 gap-6 sm:grid-cols-3">
       <div>
         <h3 className="mb-2 font-semibold">Resources</h3>
         <ul className="space-y-1">
-          <li>
-            <a href="/docs" className="hover:underline">
-              Documentation
-            </a>
-          </li>
-          <li>
-            <a href="/api" className="hover:underline">
-              API
-            </a>
-          </li>
-          <li>
-            <a href="/support" className="hover:underline">
-              Support
-            </a>
-          </li>
+          <li><a href="/docs" className="hover:underline">Documentation</a></li>
+          <li><a href="/api" className="hover:underline">API</a></li>
+          <li><a href="/support" className="hover:underline">Support</a></li>
         </ul>
       </div>
       <div>
         <h3 className="mb-2 font-semibold">Company</h3>
         <ul className="space-y-1">
-          <li>
-            <a href="/about" className="hover:underline">
-              About
-            </a>
-          </li>
-          <li>
-            <a href="/contact" className="hover:underline">
-              Contact
-            </a>
-          </li>
-          <li>
-            <a href="/privacy" className="hover:underline">
-              Privacy
-            </a>
-          </li>
+          <li><a href="/about" className="hover:underline">About</a></li>
+          <li><a href="/contact" className="hover:underline">Contact</a></li>
+          <li><a href="/privacy" className="hover:underline">Privacy</a></li>
         </ul>
       </div>
       <div>
         <h3 className="mb-2 font-semibold">Legal</h3>
         <ul className="space-y-1">
-          <li>
-            <a href="/terms" className="hover:underline">
-              Terms
-            </a>
-          </li>
-          <li>
-            <a href="/privacy-policy" className="hover:underline">
-              Privacy Policy
-            </a>
-          </li>
-          <li>
-            <a href="/cookie-policy" className="hover:underline">
-              Cookie Policy
-            </a>
-          </li>
+          <li><a href="/terms" className="hover:underline">Terms</a></li>
+          <li><a href="/privacy-policy" className="hover:underline">Privacy Policy</a></li>
+          <li><a href="/cookie-policy" className="hover:underline">Cookie Policy</a></li>
         </ul>
       </div>
     </div>
-  </Footer>
+  </Footer.Classic>
 );
 
-export const Complete: FooterStory = () => {
-  const publisher: Publisher = {
-    name: 'Eventuras AS',
-    address: 'Karl Johans gate 1, 0154 Oslo',
-    phone: '+47 22 33 44 55',
-    email: 'post@eventuras.com',
-    organizationNumber: '987654321',
-  };
-
-  return (
-    <Footer siteTitle="Eventuras" publisher={publisher}>
-      <div className="grid grid-cols-2 gap-6 sm:grid-cols-4">
-        <div>
-          <h3 className="mb-2 font-semibold dark:text-white">Events</h3>
-          <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-            <li>
-              <a href="/events" className="hover:underline">
-                Upcoming Events
-              </a>
-            </li>
-            <li>
-              <a href="/events/past" className="hover:underline">
-                Past Events
-              </a>
-            </li>
-            <li>
-              <a href="/events/create" className="hover:underline">
-                Create Event
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="mb-2 font-semibold dark:text-white">Resources</h3>
-          <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-            <li>
-              <a href="/docs" className="hover:underline">
-                Documentation
-              </a>
-            </li>
-            <li>
-              <a href="/api" className="hover:underline">
-                API
-              </a>
-            </li>
-            <li>
-              <a href="/support" className="hover:underline">
-                Support
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="mb-2 font-semibold dark:text-white">Company</h3>
-          <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-            <li>
-              <a href="/about" className="hover:underline">
-                About Us
-              </a>
-            </li>
-            <li>
-              <a href="/contact" className="hover:underline">
-                Contact
-              </a>
-            </li>
-            <li>
-              <a href="/careers" className="hover:underline">
-                Careers
-              </a>
-            </li>
-          </ul>
-        </div>
-        <div>
-          <h3 className="mb-2 font-semibold dark:text-white">Legal</h3>
-          <ul className="space-y-1 text-gray-600 dark:text-gray-400">
-            <li>
-              <a href="/terms" className="hover:underline">
-                Terms of Service
-              </a>
-            </li>
-            <li>
-              <a href="/privacy-policy" className="hover:underline">
-                Privacy Policy
-              </a>
-            </li>
-            <li>
-              <a href="/cookie-policy" className="hover:underline">
-                Cookie Policy
-              </a>
-            </li>
-          </ul>
-        </div>
-      </div>
-    </Footer>
-  );
-};
-
-export const MinimalWithPublisher: FooterStory = () => {
-  const publisher: Publisher = {
-    name: 'Simple Company',
-    address: 'Oslo, Norway',
-    phone: '+47 123 45 678',
-    email: 'hello@simple.com',
-  };
-
-  return <Footer siteTitle="Simple Site" publisher={publisher} />;
-};
+export const ClassicMinimal: FooterStory = () => (
+  <Footer.Classic siteTitle="Simple Site" publisher={samplePublisher} />
+);

--- a/libs/ratio-ui/src/core/Footer/Footer.tsx
+++ b/libs/ratio-ui/src/core/Footer/Footer.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import { Container } from '../../layout/Container';
 import { cn } from '../../utils/cn';
 import { ObfuscatedEmail } from '../ObfuscatedEmail';
@@ -10,10 +12,9 @@ export interface Publisher {
   organizationNumber?: string;
 }
 
-interface FooterProps {
-  siteTitle?: string;
-  publisher?: Publisher;
+export interface FooterProps {
   children?: React.ReactNode;
+  className?: string;
   /**
    * Marks the footer as a dark surface so child text uses the light
    * `var(--text)` color. Use when the footer is rendered against a
@@ -22,34 +23,80 @@ interface FooterProps {
   dark?: boolean;
 }
 
-export const Footer = (props: FooterProps) => {
-  return (
-    <footer className={cn('p-3 pt-10 bg-black/10 dark:bg-white/10', props.dark && 'surface-dark')}>
-      <Container>
-        <div className="md:flex md:justify-between">
-          {props.siteTitle && (
-            <div className="mb-6 md:mb-0">
-              <span className="self-center text-xl font-semibold whitespace-nowrap dark:text-white">
-                {props.siteTitle}
-              </span>
-              {props.publisher && (
-                <div className="mt-2 font-light leading-tight">
-                  <p>{props.publisher.name}</p>
-                  <p>{props.publisher.address}</p>
-                  <p>{props.publisher.phone}</p>
-                  {props.publisher.email && (
-                    <ObfuscatedEmail email={props.publisher.email} className="block" />
-                  )}
-                  {props.publisher.organizationNumber && (
-                    <p>Org.nr. {props.publisher.organizationNumber}</p>
-                  )}
-                </div>
+export interface FooterClassicProps extends FooterProps {
+  siteTitle?: string;
+  publisher?: Publisher;
+}
+
+interface FooterComponent extends React.FC<FooterProps> {
+  Classic: React.FC<FooterClassicProps>;
+}
+
+/**
+ * Thin `<footer>` shell with the standard background, padding, and
+ * `Container` wrapper. Compose your own layout inside — see
+ * `Footer.Classic` for the legacy fixed layout (siteTitle + publisher
+ * block on the left, children on the right). Subcomponents
+ * (`Footer.Brand`, `Footer.Content`, …) are planned for a future minor
+ * release; for now use plain markup.
+ */
+const FooterRoot: FooterComponent = (({ children, className, dark }: FooterProps) => (
+  <footer
+    className={cn(
+      'p-3 pt-10 bg-black/10 dark:bg-white/10',
+      dark && 'surface-dark',
+      className,
+    )}
+  >
+    <Container>{children}</Container>
+  </footer>
+)) as FooterComponent;
+
+/**
+ * Pre-2.0 Footer layout — siteTitle and an optional publisher block on
+ * the left, children stacked next to it via `md:flex md:justify-between`.
+ *
+ * Renders the `Footer` shell underneath so wrapper styles (background,
+ * padding, surface tone, Container) live in exactly one place.
+ *
+ * Kept as a backward-compat wrapper for the four `apps/web` layouts and
+ * `apps/historia` that already shipped with this exact shape. New code
+ * should use the `<Footer>` shell directly and lay out its own content.
+ */
+const FooterClassic: React.FC<FooterClassicProps> = ({
+  siteTitle,
+  publisher,
+  children,
+  className,
+  dark,
+}) => (
+  <FooterRoot className={className} dark={dark}>
+    <div className="md:flex md:justify-between">
+      {siteTitle && (
+        <div className="mb-6 md:mb-0">
+          <span className="self-center text-xl font-semibold whitespace-nowrap">
+            {siteTitle}
+          </span>
+          {publisher && (
+            <div className="mt-2 font-light leading-tight">
+              <p>{publisher.name}</p>
+              <p>{publisher.address}</p>
+              <p>{publisher.phone}</p>
+              {publisher.email && (
+                <ObfuscatedEmail email={publisher.email} className="block" />
+              )}
+              {publisher.organizationNumber && (
+                <p>Org.nr. {publisher.organizationNumber}</p>
               )}
             </div>
           )}
-          {props.children && <div>{props.children}</div>}
         </div>
-      </Container>
-    </footer>
-  );
-};
+      )}
+      {children && <div>{children}</div>}
+    </div>
+  </FooterRoot>
+);
+
+FooterRoot.Classic = FooterClassic;
+
+export const Footer = FooterRoot;

--- a/libs/ratio-ui/src/pages/Page/Page.stories.tsx
+++ b/libs/ratio-ui/src/pages/Page/Page.stories.tsx
@@ -68,12 +68,12 @@ const PageDemo: React.FC<{ title: string }> = ({ title }) => (
       </Section>
     </main>
 
-    <Footer siteTitle={title}>
+    <Footer.Classic siteTitle={title}>
       <List>
         <List.Item className="mb-2"><a href="/">Home</a></List.Item>
         <List.Item className="mb-2"><a href="/privacy">Privacy</a></List.Item>
       </List>
-    </Footer>
+    </Footer.Classic>
   </div>
 );
 


### PR DESCRIPTION
## Summary

Splits `Footer` into a thin shell + `Footer.Classic` backward-compat wrapper. **Stacked on #1373** — base is `feat/ratio-ui-surface-prop`. Will auto-retarget to main once #1373 merges.

The pre-2.0 `Footer` hardcoded a `md:flex md:justify-between` layout with `siteTitle` + `publisher` block on the left and children on the right. That works fine for the six existing callsites, but it locks the component — any caller wanting a different shape has to fight the API. This restructure opens `Footer` for free composition while preserving the existing layout behind a tiny rename.

```tsx
// Before
<Footer siteTitle={site.name} publisher={site.publisher}>
  <List>...</List>
</Footer>

// After (same UI — just renamed)
<Footer.Classic siteTitle={site.name} publisher={site.publisher}>
  <List>...</List>
</Footer.Classic>

// New: shell mode for fully custom layouts
<Footer dark>
  <YourCustomFooterContent />
</Footer>
```

### Why split now instead of doing full compound

The current 6 callsites all use the same `siteTitle + publisher + children` pattern, so there's no concrete pain point that justifies designing a full `Footer.Brand` / `Footer.Content` / `Footer.Publisher` API today — picking the API blind risks locking in something we'd regret. Splitting now achieves two things:

1. **Frees the `Footer` namespace** so subcomponents can ship additively in 2.x without a breaking change.
2. **Confirms in code** that the rigid layout is legacy (`Classic`) rather than the canonical shape — future readers will understand the direction.

### Migrated callsites

- `apps/web/src/app/(user)/layout.tsx`
- `apps/web/src/app/(public)/layout.tsx`
- `apps/web/src/app/(frontpage)/layout.tsx`
- `apps/web/src/app/(admin)/layout.tsx`
- `apps/historia/src/components/Footer/Component.tsx`
- `libs/ratio-ui/src/pages/Page/Page.stories.tsx`

All mechanical `Footer` → `Footer.Classic` renames; no behavior change.

### Plan recap

Final 2.0 PR. With this merged, `@eventuras/ratio-ui@2.0.0` ships with:

- ✅ #1366 Dialog compound
- ✅ #1367 AlertDialog
- ✅ #1368 Removed deprecated APIs
- ✅ #1369 Dialog → RAC ModalOverlay/Modal
- ✅ #1370 Drawer → RAC Modal + Portal removed
- ✅ #1371 onCancel → onClose
- ✅ #1372 Surface token system
- ⏳ #1373 `dark` prop on Section/Container/Navbar/Footer
- ⏳ #1374 (this) Footer shell + Footer.Classic

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`, `apps/web`, `apps/historia`
- [x] `pnpm test` in `libs/ratio-ui` — 355 passing
- [x] `pnpm build` succeeds
- [ ] Spot-check Storybook (`Core/Footer` — Shell, DarkShell, Classic, ClassicWithChildren, ClassicMinimal)
- [ ] Manually verify each migrated app's footer renders unchanged:
  - [ ] apps/web `/`, `/user`, `/admin`, `/public`
  - [ ] apps/historia frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)