### PR TITLE
refactor(ratio-ui)!: replace brand palette with Linseed/Linen/Ochre

### DIFF
--- a/.changeset/linseed-palette.md
+++ b/.changeset/linseed-palette.md
@@ -1,0 +1,40 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+Replace the brand palette with **Linseed Blue / Linen / Ochre** — a quieter, naturmaling-inspired identity that sits closer to the editorial knowledge-platform voice the system is moving toward.
+
+| Token | Before | After |
+|---|---|---|
+| `--color-primary-*` | Ocean Teal | **Linseed Blue** — chalky pigment, "linoljemaling" |
+| `--color-secondary-*` | Sunny Yellow | **Linen** — warm off-white, low-chroma cream |
+| `--color-accent-*` | Warm Terracotta | **Ochre** — warm clay-yellow |
+
+### Semantic tokens — what changed
+
+The mapping from scales to semantic tokens shifts to match how the new palette wants to be used:
+
+- `--primary` now resolves to `--color-primary-600` (Linseed-600 — AAA contrast on Linen for links/CTAs)
+- `--secondary` resolves to `--color-secondary-200` (Linen-200 — the page surface itself)
+- `--accent` resolves to `--color-accent-700` (Ochre-700 — the warm note, sparingly used)
+- `--text-light` now uses `--color-secondary-100` (warm Linen) instead of cold `--color-neutral-50`
+- `--text-on-primary` and `--text-on-accent` use `--color-secondary-100` for the same reason
+
+### New: `--surface` token
+
+Pages are no longer pure white. A new `--surface` token (`--color-secondary-200` light / `--color-primary-950` dark) is set on `html { background }` so every consumer gets the warm Linen ground in light mode and a deep Linseed-blue ground in dark mode — same DNA, different gravity. Exposed as the `bg-surface` Tailwind utility.
+
+### Dark mode
+
+Anchors lift one step lighter to glow on the dark surface (primary 600→400, accent 700→300). Text stays in the **Linen** family rather than the cold Neutral one — `--text` is `--color-secondary-200` instead of `--color-neutral-50`. Cards lift from the Linseed-950 surface with a pinned `oklch(0.220 0.040 232)` instead of `rgb(0 0 0 / 0.5)`.
+
+### Borders
+
+`--border-1` and `--border-2` now derive from the Linen scale in light mode (Linen-300 / Linen-400) and the Linseed scale in dark mode (Linseed-800 / Linseed-700). Both palettes give borders that belong to their surface rather than fighting it.
+
+### What this means for consumers
+
+- Components using `--color-primary-*`, `--color-secondary-*`, `--color-accent-*` Tailwind utilities (`bg-primary-500`, `text-accent-700`, etc.) keep working — only the actual colors change.
+- Anything using semantic tokens (`var(--primary)`, `bg-primary`, `text-accent`) automatically picks up the new look.
+- Apps that hardcoded the old hex colors anywhere (rare) will need to update.
+- The decorative `body::before` animated gradient in `global.css` is now palette-aware — its rgba values are replaced with `oklch()` stops drawn from the Linseed/Linen/Ochre scales, and its `background-color` references `var(--surface)`. Same effect, but the colors track the active palette instead of being frozen to the old Mediterranean tones.

--- a/libs/ratio-ui/src/global.css
+++ b/libs/ratio-ui/src/global.css
@@ -176,38 +176,38 @@
     will-change: transform;
 
     background-image:
-      /* Organic blob 1 - Ocean teal */
+      /* Organic blob 1 - Linseed Blue */
       radial-gradient(
         ellipse 1200px 800px at 15% 20%,
-        rgba(91, 163, 181, 0.3),
+        oklch(0.625 0.085 224 / 0.3),
         transparent 75%
       ),
 
-      /* Organic blob 2 - Sunny yellow */
+      /* Organic blob 2 - Ochre highlight */
       radial-gradient(
         ellipse 900px 1100px at 85% 15%,
-        rgba(255, 194, 32, 0.22),
+        oklch(0.815 0.125 85 / 0.22),
         transparent 80%
       ),
 
-      /* Warm accent - Terracotta */
+      /* Warm accent - deeper Ochre */
       radial-gradient(
         ellipse 700px 600px at 75% 80%,
-        rgba(244, 137, 109, 0.18),
+        oklch(0.640 0.125 80 / 0.18),
         transparent 85%
       ),
 
-      /* Support color - subtle sage */
+      /* Support - warm Linen */
       radial-gradient(
         ellipse 1000px 700px at 25% 75%,
-        rgba(159, 183, 176, 0.15),
+        oklch(0.928 0.022 85 / 0.20),
         transparent 88%
       ),
 
-      /* Spotlight effect (subtle white glow) */
+      /* Spotlight effect (subtle warm glow) */
       radial-gradient(
         circle 600px at 50% 10%,
-        rgba(255, 255, 255, 0.14),
+        oklch(0.985 0.004 88 / 0.14),
         transparent 75%
       ),
 
@@ -221,7 +221,7 @@
     background-size: auto, auto, auto, auto, auto, 5px 5px;
     background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat, repeat;
     background-blend-mode: normal, normal, normal, normal, screen, multiply;
-    background-color: #f0f2f4;
+    background-color: var(--surface);
 
     /* Elegant mask to blend edges */
     -webkit-mask-image: radial-gradient(
@@ -239,38 +239,38 @@
   /* Dark mode variant - more dramatic and moody */
   :root[data-theme="dark"] body::before {
     background-image:
-      /* Ocean teal - deeper */
+      /* Linseed deep */
       radial-gradient(
         ellipse 1300px 900px at 12% 18%,
-        rgba(58, 114, 135, 0.35),
+        oklch(0.330 0.058 230 / 0.35),
         transparent 78%
       ),
 
-      /* Sunny yellow - warmer glow */
+      /* Ochre warm glow */
       radial-gradient(
         ellipse 800px 1000px at 88% 12%,
-        rgba(187, 99, 9, 0.25),
+        oklch(0.405 0.085 76 / 0.25),
         transparent 82%
       ),
 
-      /* Terracotta - warm bottom accent */
+      /* Linseed deepest - bottom accent */
       radial-gradient(
         ellipse 800px 700px at 72% 85%,
-        rgba(200, 93, 63, 0.22),
+        oklch(0.245 0.044 232 / 0.22),
         transparent 84%
       ),
 
-      /* Support sage - subtle atmospheric */
+      /* Ochre subtle - atmospheric */
       radial-gradient(
         ellipse 1100px 800px at 28% 78%,
-        rgba(76, 101, 96, 0.18),
+        oklch(0.295 0.060 75 / 0.18),
         transparent 86%
       ),
 
-      /* Subtle highlight */
+      /* Subtle warm highlight */
       radial-gradient(
         circle 500px at 50% 8%,
-        rgba(255, 255, 255, 0.06),
+        oklch(0.985 0.004 88 / 0.06),
         transparent 78%
       ),
 
@@ -284,7 +284,7 @@
     background-size: auto, auto, auto, auto, auto, 5px 5px;
     background-repeat: no-repeat, no-repeat, no-repeat, no-repeat, no-repeat, repeat;
     background-blend-mode: normal, normal, normal, normal, screen, screen;
-    background-color: #08141a;
+    background-color: var(--surface);
   }
 
   /* Smooth organic drift animation */

--- a/libs/ratio-ui/src/pages/Page/Page.stories.tsx
+++ b/libs/ratio-ui/src/pages/Page/Page.stories.tsx
@@ -1,69 +1,131 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Navbar } from '../../core/Navbar/Navbar';
-import { Footer } from '../../core/Footer/Footer';
-import { List } from '../../core/List/List';
-import { Section } from '../../layout/Section/Section';
-import { Container } from '../../layout/Container';
 import { Button } from '../../core/Button';
+import { Footer } from '../../core/Footer/Footer';
+import { Heading } from '../../core/Heading';
+import { List } from '../../core/List/List';
+import { Navbar } from '../../core/Navbar/Navbar';
+import { Container } from '../../layout/Container';
+import { Section } from '../../layout/Section/Section';
 
 const PageDemo: React.FC<{ title: string }> = ({ title }) => (
   <div className="min-h-screen flex flex-col">
-    <Navbar bgColor="bg-transparent w-full py-1">
+    <Navbar sticky>
       <Navbar.Brand>
         <a href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
           {title}
         </a>
       </Navbar.Brand>
       <Navbar.Content className="justify-end">
-        <a href="#hero" className="hover:underline">Home</a>
+        <a href="#about" className="hover:underline">About</a>
         <a href="#features" className="hover:underline">Features</a>
+        <Button variant="primary">Sign in</Button>
       </Navbar.Content>
     </Navbar>
 
     <main className="flex-1">
-      <Section
-        paddingY="xl"
-        className="bg-linear-to-b from-slate-50 to-white dark:from-slate-900 dark:to-slate-950 border-b"
-      >
+      {/* Editorial hero — Linseed-toned title with italic accents and a stat panel on the right */}
+      <Section paddingY="xl">
         <Container>
-          <h1 className="text-3xl md:text-4xl font-bold mb-4">Find knowledge. Fast.</h1>
-          <p className="text-lg mb-6 text-gray-600 dark:text-gray-300">
-            Search across spaces, pages, discussions and files.
-          </p>
-          <Button variant="primary">Get Started</Button>
-        </Container>
-      </Section>
-
-      <Section paddingY="lg">
-        <Container>
-          <div className="grid md:grid-cols-2 gap-10 items-center">
+          <div className="grid lg:grid-cols-[1.4fr_1fr] gap-12 items-center">
             <div>
-              <h2 className="text-2xl font-semibold mb-4">Spaces keep teams aligned</h2>
-              <p>Organize knowledge by domain. Govern access, templates, and review cycles.</p>
+              <p className="font-mono text-xs uppercase tracking-[0.16em] text-(--accent) font-bold mb-5">
+                Knowledge platform · Sentence case is the norm
+              </p>
+              <Heading as="h1" className="font-serif font-normal !text-5xl lg:!text-6xl !leading-[1.05] !tracking-tight">
+                Find knowledge —{' '}
+                <em className="not-italic font-serif italic text-(--primary)">considered</em>,{' '}
+                <em className="not-italic font-serif italic text-(--accent)">measured</em>,
+                ours.
+              </Heading>
+              <p className="text-lg max-w-[44ch] text-(--text-muted) mt-6">
+                A design system built on clarity, proportion, and composable components. Use it
+                to build event sites, knowledge bases, and editorial surfaces that hold up under
+                use.
+              </p>
+              <div className="flex gap-3 flex-wrap mt-8">
+                <Button variant="primary" size="lg">Get started</Button>
+                <Button variant="outline" size="lg">Read the source</Button>
+              </div>
             </div>
-            <img src="https://placehold.co/800x500/png" alt="Spaces" className="w-full rounded shadow" />
+
+            {/* Stat panel — divider on the left, three numbers, serif italic accent */}
+            <div className="border-l border-(--border-2) pl-10 grid gap-7 hidden lg:grid">
+              <div>
+                <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
+                  <em className="not-italic italic text-(--accent)">11</em>-step scales
+                </div>
+                <div className="text-sm text-(--text-muted) mt-1.5">
+                  Linseed, Linen, Ochre — three voices, eleven stops each
+                </div>
+              </div>
+              <div>
+                <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
+                  2 <em className="not-italic italic text-(--accent)">families</em>
+                </div>
+                <div className="text-sm text-(--text-muted) mt-1.5">
+                  Source Serif 4 + Source Sans 3, self-hosted
+                </div>
+              </div>
+              <div>
+                <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
+                  1 <em className="not-italic italic text-(--accent)">surface</em>
+                </div>
+                <div className="text-sm text-(--text-muted) mt-1.5">
+                  Linen-200 by default, Linseed-950 in dark mode
+                </div>
+              </div>
+            </div>
           </div>
         </Container>
       </Section>
 
-      <Section paddingY="lg" color="neutral">
+      {/* Three-up feature cards — neutral surface */}
+      <Section paddingY="lg" color="neutral" id="features">
         <Container>
+          <Heading as="h2" className="!mb-2">What's inside</Heading>
+          <p className="text-(--text-muted) max-w-[60ch] mb-10">
+            Tokens, primitives, and patterns ready to compose. Every piece is documented in
+            Storybook with the source you actually ship.
+          </p>
           <div className="grid md:grid-cols-3 gap-6">
-            <div className="p-5 rounded border">
-              <h4 className="font-semibold mb-2">Verification</h4>
-              <p>Verified badge with expiry and review reminders.</p>
+            <div className="p-6 rounded-lg border border-(--border-1) bg-(--card)">
+              <Heading as="h4" className="!mb-2">Tokens</Heading>
+              <p className="text-sm text-(--text-muted)">
+                Color scales, typography, spacing, borders, status — all theme-aware via CSS
+                variables.
+              </p>
             </div>
-            <div className="p-5 rounded border">
-              <h4 className="font-semibold mb-2">Permissions</h4>
-              <p>Space-level roles with full audit trail.</p>
+            <div className="p-6 rounded-lg border border-(--border-1) bg-(--card)">
+              <Heading as="h4" className="!mb-2">Primitives</Heading>
+              <p className="text-sm text-(--text-muted)">
+                Dialog, Drawer, Navbar, Footer — built on React Aria for keyboard and screen
+                reader support.
+              </p>
             </div>
-            <div className="p-5 rounded border">
-              <h4 className="font-semibold mb-2">AI Assist</h4>
-              <p>Answers from verified sources only.</p>
+            <div className="p-6 rounded-lg border border-(--border-1) bg-(--card)">
+              <Heading as="h4" className="!mb-2">Patterns</Heading>
+              <p className="text-sm text-(--text-muted)">
+                Compound APIs (Heading, Content, Footer slots) for the shapes that show up over
+                and over.
+              </p>
             </div>
           </div>
+        </Container>
+      </Section>
+
+      {/* Dark surface CTA — shows the surface-token system in action */}
+      <Section dark paddingY="xl" className="bg-(--color-primary-900)">
+        <Container className="text-center">
+          <Heading as="h2" className="!mb-3">
+            Built for content that <em className="not-italic font-serif italic text-(--accent)">lasts</em>
+          </Heading>
+          <p className="max-w-[56ch] mx-auto mb-8 text-(--text-muted)">
+            The system is open source, MIT licensed, and shipped from the same monorepo as
+            Eventuras itself. No build step required, just install and import.
+          </p>
+          <Button variant="primary" size="lg">View on GitHub</Button>
         </Container>
       </Section>
     </main>
@@ -71,6 +133,7 @@ const PageDemo: React.FC<{ title: string }> = ({ title }) => (
     <Footer.Classic siteTitle={title}>
       <List>
         <List.Item className="mb-2"><a href="/">Home</a></List.Item>
+        <List.Item className="mb-2"><a href="/docs">Documentation</a></List.Item>
         <List.Item className="mb-2"><a href="/privacy">Privacy</a></List.Item>
       </List>
     </Footer.Classic>
@@ -81,7 +144,7 @@ const meta = {
   title: 'Pages/Page Demo',
   component: PageDemo,
   parameters: { layout: 'fullscreen' },
-  args: { title: 'Eventuras' },
+  args: { title: 'Ratio UI' },
 } satisfies Meta<typeof PageDemo>;
 
 export default meta;

--- a/libs/ratio-ui/src/tokens/Colors.stories.tsx
+++ b/libs/ratio-ui/src/tokens/Colors.stories.tsx
@@ -10,7 +10,7 @@ type ScaleConfig = {
 /* Tailwind classes must be written out statically so the scanner picks them up */
 const scales: Record<string, ScaleConfig> = {
   primary: {
-    label: 'Primary — Ocean Teal',
+    label: 'Primary — Linseed Blue',
     steps: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950],
     bg: {
       50: 'bg-primary-50', 100: 'bg-primary-100', 200: 'bg-primary-200', 300: 'bg-primary-300',
@@ -19,7 +19,7 @@ const scales: Record<string, ScaleConfig> = {
     },
   },
   secondary: {
-    label: 'Secondary — Sunny Yellow',
+    label: 'Secondary — Linen',
     steps: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950],
     bg: {
       50: 'bg-secondary-50', 100: 'bg-secondary-100', 200: 'bg-secondary-200', 300: 'bg-secondary-300',
@@ -28,7 +28,7 @@ const scales: Record<string, ScaleConfig> = {
     },
   },
   accent: {
-    label: 'Accent — Warm Terracotta',
+    label: 'Accent — Ochre',
     steps: [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950],
     bg: {
       50: 'bg-accent-50', 100: 'bg-accent-100', 200: 'bg-accent-200', 300: 'bg-accent-300',

--- a/libs/ratio-ui/src/tokens/theme.css
+++ b/libs/ratio-ui/src/tokens/theme.css
@@ -13,44 +13,44 @@
    Tailwind v4 theme: color scales (oklch)
    -------------------------------------------- */
 @theme {
-  /* Primary - Ocean Teal */
-  --color-primary-50: oklch(0.9898 0.0026 229.9);
-  --color-primary-100: oklch(0.9282 0.0203 216.4);
-  --color-primary-200: oklch(0.8659 0.0390 215.1);
-  --color-primary-300: oklch(0.7743 0.0618 216.3);
-  --color-primary-400: oklch(0.6753 0.0768 215.9);
-  --color-primary-500: oklch(0.6096 0.0745 218.3);
-  --color-primary-600: oklch(0.5227 0.0675 224.9);
-  --color-primary-700: oklch(0.4578 0.0567 219.2);
-  --color-primary-800: oklch(0.3412 0.0399 221.7);
-  --color-primary-900: oklch(0.2736 0.0317 219.8);
-  --color-primary-950: oklch(0.1831 0.0213 231.0);
+  /* Primary - Linseed Blue (classic linoljemaling, chalky pigment) */
+  --color-primary-50: oklch(0.985 0.004 232);
+  --color-primary-100: oklch(0.948 0.018 230);
+  --color-primary-200: oklch(0.895 0.038 228);
+  --color-primary-300: oklch(0.820 0.060 226);
+  --color-primary-400: oklch(0.730 0.078 224);
+  --color-primary-500: oklch(0.625 0.085 224);
+  --color-primary-600: oklch(0.520 0.082 226);
+  --color-primary-700: oklch(0.420 0.072 228);
+  --color-primary-800: oklch(0.330 0.058 230);
+  --color-primary-900: oklch(0.245 0.044 232);
+  --color-primary-950: oklch(0.165 0.030 234);
 
-  /* Secondary - Sunny Yellow */
-  --color-secondary-50: oklch(0.9964 0.0066 97.5);
-  --color-secondary-100: oklch(0.9645 0.0603 96.2);
-  --color-secondary-200: oklch(0.9257 0.1174 94.9);
-  --color-secondary-300: oklch(0.8836 0.1564 91.1);
-  --color-secondary-400: oklch(0.8466 0.1677 84.6);
-  --color-secondary-500: oklch(0.8247 0.1474 73.0);
-  --color-secondary-600: oklch(0.7093 0.1551 67.2);
-  --color-secondary-700: oklch(0.5913 0.1415 56.2);
-  --color-secondary-800: oklch(0.4355 0.1019 57.1);
-  --color-secondary-900: oklch(0.3217 0.0714 60.2);
-  --color-secondary-950: oklch(0.1904 0.0373 65.9);
+  /* Secondary - Linen (warm off-white, low-chroma cream) */
+  --color-secondary-50: oklch(0.992 0.002 90);
+  --color-secondary-100: oklch(0.985 0.004 88);
+  --color-secondary-200: oklch(0.962 0.012 88);
+  --color-secondary-300: oklch(0.928 0.022 85);
+  --color-secondary-400: oklch(0.880 0.025 82);
+  --color-secondary-500: oklch(0.785 0.028 82);
+  --color-secondary-600: oklch(0.640 0.030 82);
+  --color-secondary-700: oklch(0.495 0.030 84);
+  --color-secondary-800: oklch(0.378 0.024 86);
+  --color-secondary-900: oklch(0.275 0.018 88);
+  --color-secondary-950: oklch(0.175 0.012 90);
 
-  /* Accent - Warm Terracotta */
-  --color-accent-50: oklch(0.9931 0.0034 38.5);
-  --color-accent-100: oklch(0.9503 0.0228 41.3);
-  --color-accent-200: oklch(0.8957 0.0517 40.6);
-  --color-accent-300: oklch(0.8226 0.0911 39.2);
-  --color-accent-400: oklch(0.7402 0.1370 35.6);
-  --color-accent-500: oklch(0.6878 0.1331 35.8);
-  --color-accent-600: oklch(0.6047 0.1438 36.5);
-  --color-accent-700: oklch(0.5251 0.1305 34.4);
-  --color-accent-800: oklch(0.3861 0.0934 33.9);
-  --color-accent-900: oklch(0.2670 0.0572 34.1);
-  --color-accent-950: oklch(0.1712 0.0273 32.6);
+  /* Accent - Ochre (warm clay-yellow, the playful note) */
+  --color-accent-50: oklch(0.988 0.012 92);
+  --color-accent-100: oklch(0.965 0.040 90);
+  --color-accent-200: oklch(0.928 0.075 88);
+  --color-accent-300: oklch(0.880 0.105 88);
+  --color-accent-400: oklch(0.815 0.125 85);
+  --color-accent-500: oklch(0.745 0.130 82);
+  --color-accent-600: oklch(0.640 0.125 80);
+  --color-accent-700: oklch(0.520 0.105 78);
+  --color-accent-800: oklch(0.405 0.085 76);
+  --color-accent-900: oklch(0.295 0.060 75);
+  --color-accent-950: oklch(0.180 0.038 74);
 
   /* Neutral */
   --color-neutral-50: oklch(0.9851 0.0001 263.3);
@@ -154,6 +154,7 @@
   /* Surfaces */
   --color-card: var(--card);
   --color-card-hover: var(--card-hover);
+  --color-surface: var(--surface);
 
   /* Overlays */
   --color-overlay-hover: var(--overlay-hover);
@@ -193,22 +194,25 @@
    Semantic tokens (light)
    -------------------------------------------- */
 :root {
-  --primary: var(--color-primary-500);
-  --secondary: var(--color-secondary-500);
-  --accent: var(--color-accent-500);
+  /* Linseed-600 picks up AAA contrast on Linen for links/CTAs.
+     Page surface is Linen-200 — never pure white — so the warm
+     naturmaling temperature carries through everywhere. */
+  --primary: var(--color-primary-600);
+  --secondary: var(--color-secondary-200);
+  --accent: var(--color-accent-700);
 
   --text: var(--color-neutral-900);
   --text-muted: var(--color-neutral-700);
   --text-subtle: var(--color-neutral-500);
-  --text-light: var(--color-neutral-50);
+  --text-light: var(--color-secondary-100);
   --text-dark: var(--color-neutral-900);
 
-  --text-on-primary: var(--color-neutral-50);
-  --text-on-secondary: #1A1405;
-  --text-on-accent: var(--color-neutral-50);
+  --text-on-primary: var(--color-secondary-100);
+  --text-on-secondary: var(--color-neutral-900);
+  --text-on-accent: var(--color-secondary-100);
 
-  --border-1: var(--color-neutral-200);
-  --border-2: var(--color-neutral-300);
+  --border-1: var(--color-secondary-300);
+  --border-2: var(--color-secondary-400);
 
   --alpha-1: 0.04;
   --alpha-2: 0.08;
@@ -219,10 +223,11 @@
   --overlay-press: rgba(var(--overlay-ink), var(--alpha-2));
   --overlay-drag: rgba(var(--overlay-ink), var(--alpha-3));
 
-  --card: rgb(255 255 255 / 0.5);
-  --card-hover: rgb(255 255 255 / 0.65);
+  --card: rgb(255 255 255 / 0.55);
+  --card-hover: rgb(255 255 255 / 0.75);
+  --surface: var(--color-secondary-200);
 
-  --focus-ring: rgba(74, 142, 161, 0.45);
+  --focus-ring: oklch(0.520 0.082 226 / 0.45);
 
   /* Status */
   --success-solid: #2E9A62;
@@ -254,22 +259,25 @@
    Semantic tokens (dark)
    -------------------------------------------- */
 :root[data-theme="dark"] {
+  /* Surface = Linseed-950, not black. Same DNA, different gravity.
+     Anchors lift one step lighter so they glow on the dark surface:
+     primary 600→400, accent 700→300. Text stays in the Linen family. */
   --primary: var(--color-primary-400);
-  --secondary: var(--color-secondary-400);
-  --accent: var(--color-accent-400);
+  --secondary: var(--color-primary-900);
+  --accent: var(--color-accent-300);
 
-  --text: var(--color-neutral-50);
-  --text-muted: var(--color-neutral-200);
-  --text-subtle: var(--color-neutral-400);
-  --text-light: var(--color-neutral-50);
+  --text: var(--color-secondary-200);
+  --text-muted: var(--color-secondary-600);
+  --text-subtle: var(--color-secondary-700);
+  --text-light: var(--color-secondary-100);
   --text-dark: var(--color-neutral-900);
 
-  --text-on-primary: #071114;
-  --text-on-secondary: #1A1405;
-  --text-on-accent: #160B08;
+  --text-on-primary: var(--color-primary-950);
+  --text-on-secondary: var(--color-secondary-200);
+  --text-on-accent: var(--color-accent-950);
 
-  --border-1: rgba(250, 247, 243, 0.10);
-  --border-2: rgba(250, 247, 243, 0.16);
+  --border-1: var(--color-primary-800);
+  --border-2: var(--color-primary-700);
 
   --alpha-1: 0.06;
   --alpha-2: 0.10;
@@ -280,10 +288,11 @@
   --overlay-press: rgba(var(--overlay-ink), var(--alpha-2));
   --overlay-drag: rgba(var(--overlay-ink), var(--alpha-3));
 
-  --card: rgb(0 0 0 / 0.5);
-  --card-hover: rgb(0 0 0 / 0.65);
+  --card: oklch(0.220 0.040 232);
+  --card-hover: oklch(0.260 0.046 232);
+  --surface: var(--color-primary-950);
 
-  --focus-ring: rgba(91, 163, 181, 0.55);
+  --focus-ring: oklch(0.730 0.078 224 / 0.45);
 
   /* Status (dark) */
   --success-bg: rgba(46, 154, 98, 0.16);
@@ -308,4 +317,5 @@
    -------------------------------------------- */
 html {
   color: var(--text);
+  background-color: var(--surface);
 }


### PR DESCRIPTION
## Summary

Adopts the **Linseed Blue / Linen / Ochre** palette from the new design direction — a quieter, naturmaling-inspired identity for the editorial knowledge-platform voice the system is moving toward. Replaces the previous Mediterranean Ocean Teal / Sunny Yellow / Terracotta palette.

This is the first of three PRs implementing the design handoff:
- **PR1 (this)** — Color palette replacement
- **PR2** — Self-host Source Serif 4 + Source Sans 3 (drop Google Fonts CDN dep)
- **PR3** — `<Hero>` block component for editorial split layouts (post-2.0)

## Palette change

| Token | Before | After |
|---|---|---|
| `--color-primary-*` | Ocean Teal | **Linseed Blue** — chalky pigment, "linoljemaling" |
| `--color-secondary-*` | Sunny Yellow | **Linen** — warm off-white, low-chroma cream |
| `--color-accent-*` | Warm Terracotta | **Ochre** — warm clay-yellow |

Status scales (success / warning / error / info), neutral, and support are unchanged.

## Semantic token mapping changes

The new palette wants to be used differently — Linseed-600 for AAA contrast on Linen, Linen-200 as page surface, Ochre-700 sparingly:

```diff
- --primary:   var(--color-primary-500);
+ --primary:   var(--color-primary-600);   /* Linseed-600 — AAA on Linen */

- --secondary: var(--color-secondary-500);
+ --secondary: var(--color-secondary-200); /* Linen-200 — page surface */

- --accent:    var(--color-accent-500);
+ --accent:    var(--color-accent-700);    /* Ochre-700 — the warm note */
```

`--text-light`, `--text-on-primary`, and `--text-on-accent` now use the warm `--color-secondary-100` (Linen) instead of the cold `--color-neutral-50`, so "white text on a colored surface" stays in the warm family.

## New: `--surface` token

Pages are no longer pure white. A new `--surface` token is set on `html { background }`:
- Light mode: `--color-secondary-200` (Linen-200) — warm off-white
- Dark mode: `--color-primary-950` (Linseed-950) — same DNA, different gravity

Exposed as the `bg-surface` Tailwind utility for consumers.

## Dark mode

- Anchors lift one step lighter to glow on the dark surface (primary 600→400, accent 700→300)
- Text stays in the **Linen** family rather than cold Neutral — `--text` is `--color-secondary-200`
- Borders come from the Linseed scale (Linseed-800 / Linseed-700) rather than fixed RGBA whites
- Cards lift from the Linseed-950 surface with a pinned `oklch(0.220 0.040 232)` for a clean cool-blue lift instead of the previous `rgb(0 0 0 / 0.5)` translucent black

## Plan recap

This is the foundation. Two follow-up PRs:
- PR2 self-hosts the brand fonts (already used, just dropping the Google CDN dependency)
- PR3 adds a `<Hero>` block for the editorial split layouts the design uses

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui` and `apps/web`
- [x] `pnpm test` in `libs/ratio-ui` — 355 passing
- [x] `pnpm build` succeeds
- [ ] Spot-check Storybook color stories (`Tokens/Colors`) — verify Primary/Secondary/Accent labels and swatches reflect the new palette
- [ ] Spot-check a few component stories (`Core/Button`, `Layout/Section dark`, `Core/Navbar dark`) — should look on-brand without code changes
- [ ] Open `apps/web` in light + dark mode — text contrast on Linen should be comfortable; CTAs should pop in Linseed-600

🤖 Generated with [Claude Code](https://claude.com/claude-code)