### PR TITLE
feat(ratio-ui): add Hero block for editorial page openings (stacked on #1376)

### DIFF
--- a/.changeset/hero-block.md
+++ b/.changeset/hero-block.md
@@ -1,0 +1,43 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add `<Hero>` block — an editorial-pattern section for the top of a page.
+
+Compose with `Hero.Main` (left column with eyebrow, title, lead, actions) and optionally `Hero.Side` (right column for stats, asides, secondary CTAs). When `Hero.Side` is omitted the layout collapses to a single column. Pairs with the surface-token system via `dark`.
+
+```tsx
+import { Hero } from '@eventuras/ratio-ui/blocks/Hero';
+
+<Hero>
+  <Hero.Main>
+    <Hero.Eyebrow>A knowledge platform</Hero.Eyebrow>
+    <Hero.Title>
+      Build something <em className="font-serif text-(--primary)">considered</em>,{' '}
+      <em className="font-serif text-(--accent)">curated</em>, and worth coming back to.
+    </Hero.Title>
+    <Hero.Lead>A place for long-form articles and editorial collections ...</Hero.Lead>
+    <Hero.Actions>
+      <Button variant="primary" size="lg">Browse the library</Button>
+    </Hero.Actions>
+  </Hero.Main>
+  <Hero.Side>
+    {/* freeform — stat blocks, image, supplementary content */}
+  </Hero.Side>
+</Hero>
+```
+
+### Subcomponents
+
+- `Hero.Main` — left column wrapper
+- `Hero.Side` — right column wrapper (border-left divider, hidden on mobile)
+- `Hero.Eyebrow` — small mono-font ochre kicker line above the title
+- `Hero.Title` — large serif heading, `<h1>` by default (configurable via `as`). Accepts rich children — wrap accent words in `<em>` with a color class for the editorial italic look.
+- `Hero.Lead` — body lead paragraph, muted text, `max-w-[44ch]`
+- `Hero.Actions` — flex row of CTA buttons
+
+### Why a block, not just classes
+
+The hero pattern (eyebrow + serif title + lead + actions, optionally with a stat panel divider on the right) shows up across multiple Eventuras-platform tenants. Codifying it as a compound block means the editorial proportions (line-height 1.05, balanced text, `--space-2xl` padding, `1.4fr/1fr` grid) are preserved across consumers without each one re-implementing them.
+
+The `Pages/Page Demo` story is updated to use `<Hero>` rather than hand-rolling the layout.

--- a/libs/ratio-ui/src/blocks/Hero/Hero.stories.tsx
+++ b/libs/ratio-ui/src/blocks/Hero/Hero.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Button } from '../../core/Button';
+import { Hero } from './Hero';
+
+const meta: Meta<typeof Hero> = {
+  title: 'Blocks/Hero',
+  component: Hero,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof Hero>;
+
+/**
+ * Two-column editorial hero with eyebrow, italic-accented serif title,
+ * lead paragraph, CTAs, and a stat panel on the right with a divider.
+ */
+export const WithStatPanel: Story = {
+  render: () => (
+    <Hero>
+      <Hero.Main>
+        <Hero.Eyebrow>A knowledge platform</Hero.Eyebrow>
+        <Hero.Title>
+          Build something{' '}
+          <em className="font-serif text-(--primary)">considered</em>,{' '}
+          <em className="font-serif text-(--accent)">curated</em>, and worth coming back to.
+        </Hero.Title>
+        <Hero.Lead>
+          A place for long-form articles, study guides, and editorial collections — with the
+          tooling to organize them, the typography to make them read, and the design system to
+          keep it all consistent.
+        </Hero.Lead>
+        <Hero.Actions>
+          <Button variant="primary" size="lg">Browse the library</Button>
+          <Button variant="outline" size="lg">Read the manifesto</Button>
+        </Hero.Actions>
+      </Hero.Main>
+      <Hero.Side>
+        <div>
+          <div className="font-serif text-4xl leading-none text-(--color-primary-800) tracking-tight">
+            <em className="italic text-(--accent)">240+</em> articles
+          </div>
+          <div className="text-sm text-(--text-muted) mt-1.5">
+            Across reading, writing, research, and craft
+          </div>
+        </div>
+        <div>
+          <div className="font-serif text-4xl leading-none text-(--color-primary-800) tracking-tight">
+            12 <em className="italic text-(--accent)">collections</em>
+          </div>
+          <div className="text-sm text-(--text-muted) mt-1.5">
+            Editorial reading lists curated by topic
+          </div>
+        </div>
+        <div>
+          <div className="font-serif text-4xl leading-none text-(--color-primary-800) tracking-tight">
+            1 <em className="italic text-(--accent)">subscription</em>
+          </div>
+          <div className="text-sm text-(--text-muted) mt-1.5">
+            Open access, free for the curious, supported by patrons
+          </div>
+        </div>
+      </Hero.Side>
+    </Hero>
+  ),
+};
+
+/**
+ * Single-column hero — `Hero.Side` omitted. The grid collapses to one column
+ * and the main content keeps a comfortable max-width via `Hero.Lead`.
+ */
+export const SingleColumn: Story = {
+  render: () => (
+    <Hero>
+      <Hero.Main>
+        <Hero.Eyebrow>The reading room</Hero.Eyebrow>
+        <Hero.Title>
+          Find knowledge —{' '}
+          <em className="font-serif text-(--primary)">considered</em>,{' '}
+          <em className="font-serif text-(--accent)">measured</em>, ours.
+        </Hero.Title>
+        <Hero.Lead>
+          A design system built on clarity, proportion, and composable components. Use it to
+          build editorial surfaces, knowledge bases, and reading-first interfaces that hold up
+          under use.
+        </Hero.Lead>
+        <Hero.Actions>
+          <Button variant="primary" size="lg">Start reading</Button>
+          <Button variant="outline" size="lg">View the source</Button>
+        </Hero.Actions>
+      </Hero.Main>
+    </Hero>
+  ),
+};
+
+/**
+ * Dark hero — `dark` prop applies `surface-dark`, so descendants reading
+ * `var(--text)` switch to the light tone. Pair with a colored or
+ * photographic background.
+ */
+export const DarkSurface: Story = {
+  render: () => (
+    <Hero dark className="bg-(--color-primary-900)">
+      <Hero.Main>
+        <Hero.Eyebrow>The winter issue</Hero.Eyebrow>
+        <Hero.Title>
+          Slow knowledge for{' '}
+          <em className="font-serif text-(--accent)">long evenings</em>.
+        </Hero.Title>
+        <Hero.Lead>
+          Twelve essays on memory, attention, and the practice of reading — selected for the
+          months when the light fades early and there's time to sit with a thought.
+        </Hero.Lead>
+        <Hero.Actions>
+          <Button variant="primary" size="lg">Open the issue</Button>
+          <Button variant="outline" size="lg">Subscribe</Button>
+        </Hero.Actions>
+      </Hero.Main>
+    </Hero>
+  ),
+};

--- a/libs/ratio-ui/src/blocks/Hero/Hero.tsx
+++ b/libs/ratio-ui/src/blocks/Hero/Hero.tsx
@@ -1,0 +1,154 @@
+import React, { type ReactNode } from 'react';
+
+import { Container } from '../../layout/Container';
+import { cn } from '../../utils/cn';
+
+export interface HeroProps {
+  children?: ReactNode;
+  className?: string;
+  /**
+   * Marks the hero as a dark surface (applies `surface-dark` className) so
+   * descendants reading `var(--text)` pick up the light tone. Useful for
+   * heroes with photo backgrounds or strongly colored fills.
+   */
+  dark?: boolean;
+}
+
+interface HeroSlotProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+interface HeroTitleProps extends HeroSlotProps {
+  /** Heading level. Defaults to 1 — heroes are usually the page's primary heading. */
+  as?: 'h1' | 'h2';
+}
+
+interface HeroComponent extends React.FC<HeroProps> {
+  Main: React.FC<HeroSlotProps>;
+  Side: React.FC<HeroSlotProps>;
+  Eyebrow: React.FC<HeroSlotProps>;
+  Title: React.FC<HeroTitleProps>;
+  Lead: React.FC<HeroSlotProps>;
+  Actions: React.FC<HeroSlotProps>;
+}
+
+/**
+ * Editorial hero block — opinionated section for the top of a page.
+ *
+ * Compose with `Hero.Main` (left column) and optionally `Hero.Side` (right
+ * column for stats, asides, secondary CTAs). Each slot is layout-only; the
+ * children determine what goes in. When `Hero.Side` is omitted the main
+ * content uses the full width.
+ *
+ * @example
+ * ```tsx
+ * <Hero>
+ *   <Hero.Main>
+ *     <Hero.Eyebrow>A knowledge platform</Hero.Eyebrow>
+ *     <Hero.Title>
+ *       Build something <em className="text-(--primary)">considered</em> —
+ *       <em className="text-(--accent)">curated</em>, and worth coming back to.
+ *     </Hero.Title>
+ *     <Hero.Lead>A place for long-form articles and editorial collections ...</Hero.Lead>
+ *     <Hero.Actions>
+ *       <Button variant="primary" size="lg">Browse the library</Button>
+ *     </Hero.Actions>
+ *   </Hero.Main>
+ *   <Hero.Side>
+ *     {/* stat blocks, image, anything *\/}
+ *   </Hero.Side>
+ * </Hero>
+ * ```
+ */
+const HeroRoot: HeroComponent = (({ children, className, dark }: HeroProps) => {
+  // Detect whether the consumer included a Hero.Side so we can drop the
+  // second grid column when there's nothing to put in it. Without this
+  // the main content would float in the left half on lg+ with empty
+  // space on the right.
+  const hasSide = React.Children.toArray(children).some(
+    child => React.isValidElement(child) && child.type === HeroSide,
+  );
+
+  return (
+    <section
+      className={cn(
+        'py-(--space-2xl) border-b border-(--border-1) relative overflow-hidden',
+        dark && 'surface-dark',
+        className,
+      )}
+    >
+      <Container>
+        <div
+          className={cn(
+            'grid gap-12 items-center',
+            hasSide ? 'lg:grid-cols-[1.4fr_1fr]' : 'lg:grid-cols-1',
+          )}
+        >
+          {children}
+        </div>
+      </Container>
+    </section>
+  );
+}) as HeroComponent;
+
+const HeroMain: React.FC<HeroSlotProps> = ({ children, className }) => (
+  <div className={className}>{children}</div>
+);
+
+const HeroSide: React.FC<HeroSlotProps> = ({ children, className }) => (
+  <div
+    className={cn(
+      'hidden lg:grid lg:border-l lg:border-(--border-2) lg:pl-10 gap-7',
+      className,
+    )}
+  >
+    {children}
+  </div>
+);
+
+const HeroEyebrow: React.FC<HeroSlotProps> = ({ children, className }) => (
+  <p
+    className={cn(
+      'font-mono text-xs uppercase tracking-[0.16em] text-(--accent) font-bold mb-5',
+      className,
+    )}
+  >
+    {children}
+  </p>
+);
+
+const HeroTitle: React.FC<HeroTitleProps> = ({ children, className, as: Component = 'h1' }) => (
+  <Component
+    className={cn(
+      'font-serif font-normal text-5xl lg:text-6xl leading-[1.05] tracking-tight text-balance text-(--primary)',
+      className,
+    )}
+  >
+    {children}
+  </Component>
+);
+
+const HeroLead: React.FC<HeroSlotProps> = ({ children, className }) => (
+  <p
+    className={cn(
+      'text-lg leading-[1.55] text-(--text-muted) max-w-[44ch] mt-6',
+      className,
+    )}
+  >
+    {children}
+  </p>
+);
+
+const HeroActions: React.FC<HeroSlotProps> = ({ children, className }) => (
+  <div className={cn('flex gap-3 flex-wrap mt-8', className)}>{children}</div>
+);
+
+HeroRoot.Main = HeroMain;
+HeroRoot.Side = HeroSide;
+HeroRoot.Eyebrow = HeroEyebrow;
+HeroRoot.Title = HeroTitle;
+HeroRoot.Lead = HeroLead;
+HeroRoot.Actions = HeroActions;
+
+export const Hero = HeroRoot;

--- a/libs/ratio-ui/src/blocks/Hero/index.ts
+++ b/libs/ratio-ui/src/blocks/Hero/index.ts
@@ -1,0 +1,2 @@
+export { Hero } from './Hero';
+export type { HeroProps } from './Hero';

--- a/libs/ratio-ui/src/pages/Page/Page.stories.tsx
+++ b/libs/ratio-ui/src/pages/Page/Page.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
+import { Hero } from '../../blocks/Hero';
 import { Button } from '../../core/Button';
 import { Footer } from '../../core/Footer/Footer';
 import { Heading } from '../../core/Heading';
@@ -25,61 +26,50 @@ const PageDemo: React.FC<{ title: string }> = ({ title }) => (
     </Navbar>
 
     <main className="flex-1">
-      {/* Editorial hero — Linseed-toned title with italic accents and a stat panel on the right */}
-      <Section paddingY="xl">
-        <Container>
-          <div className="grid lg:grid-cols-[1.4fr_1fr] gap-12 items-center">
-            <div>
-              <p className="font-mono text-xs uppercase tracking-[0.16em] text-(--accent) font-bold mb-5">
-                Knowledge platform · Sentence case is the norm
-              </p>
-              <Heading as="h1" className="font-serif font-normal !text-5xl lg:!text-6xl !leading-[1.05] !tracking-tight">
-                Find knowledge —{' '}
-                <em className="not-italic font-serif italic text-(--primary)">considered</em>,{' '}
-                <em className="not-italic font-serif italic text-(--accent)">measured</em>,
-                ours.
-              </Heading>
-              <p className="text-lg max-w-[44ch] text-(--text-muted) mt-6">
-                A design system built on clarity, proportion, and composable components. Use it
-                to build event sites, knowledge bases, and editorial surfaces that hold up under
-                use.
-              </p>
-              <div className="flex gap-3 flex-wrap mt-8">
-                <Button variant="primary" size="lg">Get started</Button>
-                <Button variant="outline" size="lg">Read the source</Button>
-              </div>
+      <Hero>
+        <Hero.Main>
+          <Hero.Eyebrow>Knowledge platform · Sentence case is the norm</Hero.Eyebrow>
+          <Hero.Title>
+            Find knowledge —{' '}
+            <em className="font-serif text-(--primary)">considered</em>,{' '}
+            <em className="font-serif text-(--accent)">measured</em>, ours.
+          </Hero.Title>
+          <Hero.Lead>
+            A design system built on clarity, proportion, and composable components. Use it to
+            build event sites, knowledge bases, and editorial surfaces that hold up under use.
+          </Hero.Lead>
+          <Hero.Actions>
+            <Button variant="primary" size="lg">Get started</Button>
+            <Button variant="outline" size="lg">Read the source</Button>
+          </Hero.Actions>
+        </Hero.Main>
+        <Hero.Side>
+          <div>
+            <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
+              <em className="italic text-(--accent)">11</em>-step scales
             </div>
-
-            {/* Stat panel — divider on the left, three numbers, serif italic accent */}
-            <div className="border-l border-(--border-2) pl-10 grid gap-7 hidden lg:grid">
-              <div>
-                <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
-                  <em className="not-italic italic text-(--accent)">11</em>-step scales
-                </div>
-                <div className="text-sm text-(--text-muted) mt-1.5">
-                  Linseed, Linen, Ochre — three voices, eleven stops each
-                </div>
-              </div>
-              <div>
-                <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
-                  2 <em className="not-italic italic text-(--accent)">families</em>
-                </div>
-                <div className="text-sm text-(--text-muted) mt-1.5">
-                  Source Serif 4 + Source Sans 3, self-hosted
-                </div>
-              </div>
-              <div>
-                <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
-                  1 <em className="not-italic italic text-(--accent)">surface</em>
-                </div>
-                <div className="text-sm text-(--text-muted) mt-1.5">
-                  Linen-200 by default, Linseed-950 in dark mode
-                </div>
-              </div>
+            <div className="text-sm text-(--text-muted) mt-1.5">
+              Linseed, Linen, Ochre — three voices, eleven stops each
             </div>
           </div>
-        </Container>
-      </Section>
+          <div>
+            <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
+              2 <em className="italic text-(--accent)">families</em>
+            </div>
+            <div className="text-sm text-(--text-muted) mt-1.5">
+              Source Serif 4 + Source Sans 3, self-hosted
+            </div>
+          </div>
+          <div>
+            <div className="font-serif text-4xl leading-none text-(--primary) tracking-tight">
+              1 <em className="italic text-(--accent)">surface</em>
+            </div>
+            <div className="text-sm text-(--text-muted) mt-1.5">
+              Linen-200 by default, Linseed-950 in dark mode
+            </div>
+          </div>
+        </Hero.Side>
+      </Hero>
 
       {/* Three-up feature cards — neutral surface */}
       <Section paddingY="lg" color="neutral" id="features">
@@ -119,7 +109,7 @@ const PageDemo: React.FC<{ title: string }> = ({ title }) => (
       <Section dark paddingY="xl" className="bg-(--color-primary-900)">
         <Container className="text-center">
           <Heading as="h2" className="!mb-3">
-            Built for content that <em className="not-italic font-serif italic text-(--accent)">lasts</em>
+            Built for content that <em className="font-serif text-(--accent)">lasts</em>
           </Heading>
           <p className="max-w-[56ch] mx-auto mb-8 text-(--text-muted)">
             The system is open source, MIT licensed, and shipped from the same monorepo as


### PR DESCRIPTION
## Summary

Adds a `<Hero>` compound block — an editorial-pattern section for the top of a page. **Stacked on #1376** (self-host fonts) — base is `refactor/ratio-ui-self-host-fonts`.

This is the third and final PR implementing the design handoff:
- ✅ #1375 Linseed/Linen/Ochre palette
- ✅ #1376 Self-hosted Source Serif 4 + Source Sans 3
- ⏳ #1377 (this) Hero block

## Why a block, not just classes

The hero pattern (eyebrow + serif title + lead + actions, optionally with a stat panel divider on the right) is recurring enough across editorial pages that codifying it as a compound block keeps the proportions consistent across consumers — `--space-2xl` padding, `1.4fr/1fr` grid, `text-balance`, line-height 1.05 — without each one re-implementing them.

## API

```tsx
import { Hero } from '@eventuras/ratio-ui/blocks/Hero';

<Hero>
  <Hero.Main>
    <Hero.Eyebrow>A knowledge platform</Hero.Eyebrow>
    <Hero.Title>
      Build something <em className="font-serif text-(--primary)">considered</em>,{' '}
      <em className="font-serif text-(--accent)">curated</em>, and worth coming back to.
    </Hero.Title>
    <Hero.Lead>A place for long-form articles and editorial collections ...</Hero.Lead>
    <Hero.Actions>
      <Button variant="primary" size="lg">Browse the library</Button>
      <Button variant="outline" size="lg">Read the manifesto</Button>
    </Hero.Actions>
  </Hero.Main>
  <Hero.Side>
    {/* freeform — stat blocks, image, supplementary content */}
  </Hero.Side>
</Hero>
```

When `Hero.Side` is omitted the layout collapses to a single column. The `dark` prop applies `surface-dark` for heroes with photo backgrounds or strongly colored fills.

## Subcomponents

- `Hero.Main` — left column wrapper
- `Hero.Side` — right column wrapper (border-left divider, hidden on mobile so the editorial text stays uncluttered)
- `Hero.Eyebrow` — small mono-font ochre kicker line above the title
- `Hero.Title` — large serif heading (`h1` default, configurable via `as`). Accepts rich children — wrap accent words in `<em>` with a color class for the editorial italic look.
- `Hero.Lead` — body lead paragraph, muted text, `max-w-[44ch]`
- `Hero.Actions` — flex row of CTA buttons

`Hero.Title` does not enforce italic-accent colors itself. Callers wrap whichever words they want to highlight in `<em className="font-serif text-(--primary)">word</em>` (or `text-(--accent)`). Keeps the API simple while letting design choose what gets emphasized.

## Stories

- `Blocks/Hero / WithStatPanel` — full editorial hero with three stat blocks
- `Blocks/Hero / SingleColumn` — `Hero.Side` omitted, full-width text
- `Blocks/Hero / DarkSurface` — `dark` prop on `bg-(--color-primary-900)`

The `Pages/Page Demo` story is updated to use `<Hero>` instead of hand-rolling the layout.

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`
- [x] `pnpm test` — 358 passing (3 new auto-generated story tests)
- [x] `pnpm build` succeeds
- [ ] Spot-check Storybook (`Blocks/Hero` — WithStatPanel, SingleColumn, DarkSurface) in light + dark mode
- [ ] Verify the Page demo still looks right with the refactored Hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)