### PR TITLE
feat(ratio-ui): add Section.Header compound for editorial section openings

### DIFF
--- a/.changeset/section-header.md
+++ b/.changeset/section-header.md
@@ -1,0 +1,34 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add compound subcomponents to `Section` for the editorial section-header pattern (eyebrow + serif title with optional CTA link), plus export `ArrowUpRight` from `@eventuras/ratio-ui/icons`.
+
+```tsx
+<Section paddingY="lg">
+  <Container>
+    <Section.Header>
+      <Section.Eyebrow>Aktuelle samlinger</Section.Eyebrow>
+      <Section.Title>
+        Det skjer i <em className="font-serif text-(--primary)">Nordland</em>
+      </Section.Title>
+      <Section.Link href="#">Se alle</Section.Link>
+    </Section.Header>
+
+    {/* …content… */}
+  </Container>
+</Section>
+```
+
+### Subcomponents
+
+- **`Section.Header`** — flex row with `justify-between` + `items-baseline`. Auto-detects `Section.Link` children and pushes them to the right; everything else (eyebrow, title, free markup) stacks on the left. Drop the link to get a single-column header.
+- **`Section.Eyebrow`** — small mono-font kicker line, Linseed primary by default. (Hero.Eyebrow uses Ochre accent — sections stay subordinate to the page hero.)
+- **`Section.Title`** — serif heading at ~36px, renders as `<h2>` by default (override via `as`). Accepts rich children — wrap accent words in `<em>` with a color class.
+- **`Section.Link`** — text link with auto-appended `ArrowUpRight` icon that nudges on hover.
+
+### Icon export
+
+`ArrowUpRight` is now part of the central icon export, alongside the existing `Chevron*` set.
+
+The `Pages/Page Demo` story uses the new pattern in its "What's inside" section.

--- a/libs/ratio-ui/src/icons/index.ts
+++ b/libs/ratio-ui/src/icons/index.ts
@@ -25,6 +25,7 @@ export {
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
+  ArrowUpRight,
   MoreHorizontal,
 
   // Content

--- a/libs/ratio-ui/src/layout/Section/Section.stories.tsx
+++ b/libs/ratio-ui/src/layout/Section/Section.stories.tsx
@@ -114,6 +114,54 @@ export const DarkSurface: Story = {
   ),
 };
 
+/**
+ * Editorial section header — eyebrow + serif title with optional italic
+ * accent. Use when you want a quietly-marked content section to stand
+ * apart from neighboring sections without competing with the page hero.
+ */
+export const WithHeader: Story = {
+  render: () => (
+    <Section paddingY="lg">
+      <Container>
+        <Section.Header>
+          <Section.Eyebrow>Lær på din egen tid</Section.Eyebrow>
+          <Section.Title>
+            Self-paced <em className="font-serif text-(--primary)">study</em> tracks
+          </Section.Title>
+        </Section.Header>
+        <p className="text-(--text-muted) max-w-prose">
+          Each track is a curated reading list with notes and exercises — go through them in
+          order, or jump in wherever your curiosity takes you.
+        </p>
+      </Container>
+    </Section>
+  ),
+};
+
+/**
+ * Section header with a CTA link. `Section.Link` is auto-detected and
+ * pushed to the right side of the header row; everything else stacks on
+ * the left. The arrow nudges on hover.
+ */
+export const WithHeaderAndLink: Story = {
+  render: () => (
+    <Section paddingY="lg">
+      <Container>
+        <Section.Header>
+          <Section.Eyebrow>Kommende</Section.Eyebrow>
+          <Section.Title>
+            All <em className="font-serif text-(--primary)">articles</em>, in chronological order
+          </Section.Title>
+          <Section.Link href="#">Filter and search</Section.Link>
+        </Section.Header>
+        <p className="text-(--text-muted)">
+          The full archive — newest first. Use the filter for tags, authors, or date range.
+        </p>
+      </Container>
+    </Section>
+  ),
+};
+
 export const GridLayout: Story = {
   render: () => (
     <Section paddingY="xl" className="grid grid-cols-1 md:grid-cols-2" gap="lg">

--- a/libs/ratio-ui/src/layout/Section/Section.tsx
+++ b/libs/ratio-ui/src/layout/Section/Section.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import type { SpacingProps } from '../../tokens/spacing';
 import type { Color } from '../../tokens/colors';
 import { surfaceBgClasses } from '../../tokens/colors';
 import { buildSpacingClasses, extractSpacingProps } from '../../tokens/spacing';
+import { ArrowUpRight } from '../../icons';
 import { cn } from '../../utils/cn';
 
 export interface SectionProps
@@ -19,7 +20,35 @@ export interface SectionProps
   testId?: string;
 }
 
-export const Section: React.FC<SectionProps> = (props) => {
+interface SectionHeaderProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+interface SectionEyebrowProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+interface SectionTitleProps {
+  children?: ReactNode;
+  className?: string;
+  as?: 'h1' | 'h2' | 'h3';
+}
+
+interface SectionLinkProps extends React.ComponentPropsWithoutRef<'a'> {
+  children?: ReactNode;
+  className?: string;
+}
+
+interface SectionComponent extends React.FC<SectionProps> {
+  Header: React.FC<SectionHeaderProps>;
+  Eyebrow: React.FC<SectionEyebrowProps>;
+  Title: React.FC<SectionTitleProps>;
+  Link: React.FC<SectionLinkProps>;
+}
+
+const SectionRoot: SectionComponent = (props => {
   const [spacing, {
     color,
     dark,
@@ -43,6 +72,104 @@ export const Section: React.FC<SectionProps> = (props) => {
       {children}
     </section>
   );
+}) as SectionComponent;
+
+/**
+ * Header row for a section — eyebrow + title on the left, optional
+ * `Section.Link`(s) on the right. The component picks up `Section.Link`
+ * children automatically and groups them on the right via
+ * `justify-between`; everything else (eyebrow, title, free markup) is
+ * stacked on the left in a flex column. Drop the link to get a
+ * left-aligned single-column header.
+ *
+ * `Section.Link` must be a direct child — links nested inside fragments
+ * or other wrappers are treated as part of the left column.
+ *
+ * @example
+ * ```tsx
+ * <Section.Header>
+ *   <Section.Eyebrow>Aktuelle samlinger</Section.Eyebrow>
+ *   <Section.Title>Det skjer i <em>Nordland</em></Section.Title>
+ *   <Section.Link href="#">Se alle</Section.Link>
+ * </Section.Header>
+ * ```
+ */
+const SectionHeader: React.FC<SectionHeaderProps> = ({ children, className }) => {
+  const childArray = React.Children.toArray(children);
+  const isLink = (child: React.ReactNode): boolean =>
+    React.isValidElement(child) && child.type === SectionLink;
+  const links = childArray.filter(isLink);
+  const rest = childArray.filter(child => !isLink(child));
+
+  return (
+    <div
+      className={cn('flex justify-between items-baseline gap-6 flex-wrap mb-9', className)}
+    >
+      <div className="flex flex-col">{rest}</div>
+      {links.length > 0 && <div className="flex items-baseline gap-4">{links}</div>}
+    </div>
+  );
 };
 
-Section.displayName = 'Section';
+/**
+ * Small mono-font kicker line above the section title. Uses Linseed
+ * primary by default — quieter than a hero eyebrow (which is Ochre)
+ * so sections stay subordinate to the page's primary heading.
+ */
+const SectionEyebrow: React.FC<SectionEyebrowProps> = ({ children, className }) => (
+  <p
+    className={cn(
+      'font-mono text-[10.5px] uppercase tracking-[0.18em] text-(--primary) font-bold mb-2',
+      className,
+    )}
+  >
+    {children}
+  </p>
+);
+
+/**
+ * Section heading — serif, ~36px, with subtle italic accents for emphasis
+ * via `<em>` children. Renders as `<h2>` by default since the page's
+ * primary heading is usually in a Hero. Override via `as`.
+ */
+const SectionTitle: React.FC<SectionTitleProps> = ({ children, className, as: Component = 'h2' }) => (
+  <Component
+    className={cn(
+      'font-serif font-medium text-3xl md:text-4xl leading-[1.1] tracking-tight m-0 text-(--text)',
+      className,
+    )}
+  >
+    {children}
+  </Component>
+);
+
+/**
+ * Right-side CTA link for `Section.Header`. Renders the label followed
+ * by an up-right arrow that nudges on hover. Pass any anchor props
+ * (`href`, `target`, etc.).
+ */
+const SectionLink: React.FC<SectionLinkProps> = ({ children, className, ...rest }) => (
+  <a
+    className={cn(
+      'group inline-flex items-center gap-1.5 text-sm font-medium text-(--primary) no-underline border-b border-transparent hover:border-(--primary) pb-0.5 transition-colors',
+      className,
+    )}
+    {...rest}
+  >
+    {children}
+    <ArrowUpRight
+      aria-hidden="true"
+      focusable={false}
+      className="size-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+    />
+  </a>
+);
+
+SectionRoot.Header = SectionHeader;
+SectionRoot.Eyebrow = SectionEyebrow;
+SectionRoot.Title = SectionTitle;
+SectionRoot.Link = SectionLink;
+
+SectionRoot.displayName = 'Section';
+
+export const Section = SectionRoot;

--- a/libs/ratio-ui/src/pages/Page/Page.stories.tsx
+++ b/libs/ratio-ui/src/pages/Page/Page.stories.tsx
@@ -84,7 +84,13 @@ const PageDemo: React.FC<{ title: string }> = ({ title }) => (
       {/* Three-up feature cards — neutral surface */}
       <Section paddingY="lg" color="neutral" id="features">
         <Container>
-          <Heading as="h2" className="!mb-2">What's inside</Heading>
+          <Section.Header>
+            <Section.Eyebrow>The library</Section.Eyebrow>
+            <Section.Title>
+              What's <em className="font-serif text-(--primary)">inside</em>
+            </Section.Title>
+            <Section.Link href="#">Browse all components</Section.Link>
+          </Section.Header>
           <p className="text-(--text-muted) max-w-[60ch] mb-10">
             Tokens, primitives, and patterns ready to compose. Every piece is documented in
             Storybook with the source you actually ship.


### PR DESCRIPTION
## Summary

Adds compound subcomponents to `Section` for the editorial section-header pattern that recurs throughout the new design — mono eyebrow + serif title with optional right-aligned CTA link.

## API

```tsx
<Section paddingY="lg">
  <Container>
    <Section.Header>
      <Section.Eyebrow>Aktuelle samlinger</Section.Eyebrow>
      <Section.Title>
        Det skjer i <em className="font-serif text-(--primary)">Nordland</em>
      </Section.Title>
      <Section.Link href="#">Se alle</Section.Link>
    </Section.Header>

    {/* …content… */}
  </Container>
</Section>
```

When `Section.Link` is omitted the header collapses to a single-column eyebrow + title.

## Subcomponents

- **`Section.Header`** — flex row with `justify-between` + `items-baseline`. Auto-detects `Section.Link` children via `React.Children.toArray` + `.type === SectionLink` and pushes them to the right; everything else stacks on the left. Same pattern as `Hero` does for `Hero.Side`.
- **`Section.Eyebrow`** — small mono-font kicker line, Linseed primary by default. Quieter than `Hero.Eyebrow` (which is Ochre accent) so sections stay subordinate to the page's primary heading.
- **`Section.Title`** — serif heading at ~36px, renders as `<h2>` by default (override via `as`). Accepts rich children — wrap accent words in `<em>` with a color class.
- **`Section.Link`** — text link with auto-appended `ArrowUpRight` icon that nudges on hover.

## Icon export

`ArrowUpRight` is now part of the central icon export from `@eventuras/ratio-ui/icons`, alongside the existing `Chevron*` set.

## Plan

This is part of the design-handoff implementation:
- ✅ #1375 Linseed/Linen/Ochre palette
- ✅ #1376 Self-hosted Source Serif 4 + Source Sans 3
- ⏳ #1377 Hero block
- ⏳ #1378 (this) Section.Header compound
- 🔜 PR5 — `<Tile>` primitive (covers small event tiles + hero stat blocks with one component)

Together these primitives let consumers compose the kursinord-style page (and similar editorial pages) with `Section + Container + Section.Header + Card + Grid + Tile` — all generic, no domain-specific blocks.

## Test plan

- [x] `pnpm tsc --noEmit` clean in `libs/ratio-ui`
- [x] `pnpm test` — 357 passing (+2 new auto-generated story tests)
- [x] `pnpm build` succeeds
- [ ] Spot-check Storybook (`Layout/Section` — WithHeader, WithHeaderAndLink) in light + dark mode
- [ ] Spot-check `Pages/Page Demo` — the "What's inside" section now uses `Section.Header` with eyebrow + italic-accented title + "Browse all components" CTA link
- [ ] Verify hover state on `Section.Link` — arrow should nudge up-right and underline should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)