### PR TITLE
refactor(ratio-ui): route commerce through semantic tokens for dark mode

### DIFF
--- a/.changeset/commerce-dark-tokens.md
+++ b/.changeset/commerce-dark-tokens.md
@@ -1,0 +1,17 @@
+---
+"@eventuras/ratio-ui": patch
+---
+
+Replace legacy `dark:bg-gray-*` / `dark:text-gray-*` Tailwind classes in the commerce components (`CartLineItem`, `OrderSummary`) with semantic CSS-variable tokens, so dark mode reads warm (Linseed/Linen) instead of cold neutral gray.
+
+```tsx
+// Before
+'text-gray-900 dark:text-white' / 'text-gray-500 dark:text-gray-400' / 'border-gray-200 dark:border-gray-700'
+
+// After
+'text-(--text)' / 'text-(--text-subtle)' / 'border-border-1'
+```
+
+The "Fjern" remove button moves from `text-red-600 dark:text-red-400` to `text-error-text hover:opacity-80`.
+
+Second sweep in the dark-mode token migration; forms went out in a previous PR. Core components and blocks still pending.

--- a/libs/ratio-ui/src/commerce/CartLineItem/CartLineItem.tsx
+++ b/libs/ratio-ui/src/commerce/CartLineItem/CartLineItem.tsx
@@ -70,10 +70,10 @@ export const CartLineItem: React.FC<CartLineItemProps> = ({
   return (
     <div className="flex items-start gap-4">
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-gray-900 dark:text-white truncate">
+        <p className="text-sm font-medium text-(--text) truncate">
           {item.title}
         </p>
-        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+        <p className="mt-1 text-xs text-(--text-subtle)">
           {item.quantity} x {formatPrice(item.pricePerUnitIncVat, item.currency, locale)}
           {' '}(inkl mva {formatPrice(item.vatAmount, item.currency, locale)})
         </p>
@@ -102,17 +102,18 @@ export const CartLineItem: React.FC<CartLineItemProps> = ({
       <div className="flex flex-col items-end justify-between">
         {showQuantityControls && onRemove && (
           <button
+            type="button"
             onClick={() => onRemove(item.productId)}
-            className="text-sm text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            className="text-sm text-error-text hover:opacity-80"
           >
             Fjern
           </button>
         )}
         <div className="text-right">
-          <p className="text-sm font-semibold text-gray-900 dark:text-white whitespace-nowrap">
+          <p className="text-sm font-semibold text-(--text) whitespace-nowrap">
             {formatPrice(item.lineTotalIncVat, item.currency, locale)}
           </p>
-          <p className="text-xs text-gray-500 dark:text-gray-400">
+          <p className="text-xs text-(--text-subtle)">
             inkl. mva
           </p>
         </div>

--- a/libs/ratio-ui/src/commerce/OrderSummary/OrderSummary.tsx
+++ b/libs/ratio-ui/src/commerce/OrderSummary/OrderSummary.tsx
@@ -64,7 +64,7 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
 
       {/* Items */}
       {children && (
-        <div className="space-y-4 mb-6 pb-6 border-b border-gray-200 dark:border-gray-700">
+        <div className="space-y-4 mb-6 pb-6 border-b border-border-1">
           {children}
         </div>
       )}
@@ -73,20 +73,20 @@ export const OrderSummary: React.FC<OrderSummaryProps> = ({
       <div className="space-y-2">
         {showVatBreakdown && (
           <>
-            <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex justify-between text-sm text-(--text-muted)">
               <span>Subtotal (eks. mva)</span>
               <span>{formatPrice(summary.subtotalExVat, summary.currency, locale)}</span>
             </div>
-            <div className="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+            <div className="flex justify-between text-sm text-(--text-muted)">
               <span>MVA</span>
               <span>{formatPrice(summary.totalVat, summary.currency, locale)}</span>
             </div>
           </>
         )}
 
-        <div className="flex justify-between items-center pt-2 border-t border-gray-200 dark:border-gray-700">
-          <span className="text-lg font-semibold text-gray-900 dark:text-white">Total</span>
-          <span className="text-2xl font-bold text-gray-900 dark:text-white">
+        <div className="flex justify-between items-center pt-2 border-t border-border-1">
+          <span className="text-lg font-semibold text-(--text)">Total</span>
+          <span className="text-2xl font-bold text-(--text)">
             {formatPrice(summary.totalIncVat, summary.currency, locale)}
           </span>
         </div>


### PR DESCRIPTION
## Summary

Second sweep in the dark-mode token migration. Replaces legacy `dark:bg-gray-*` / `dark:text-gray-*` Tailwind classes in the commerce components (`CartLineItem`, `OrderSummary`) with semantic CSS-variable tokens so dark mode reads warm (Linseed/Linen) instead of cold neutral gray. The forms sweep is in #1381; core components + blocks are still pending.

```tsx
// Before
'text-gray-900 dark:text-white'           // body text
'text-gray-500 dark:text-gray-400'        // subtle text
'border-gray-200 dark:border-gray-700'    // hairline border
'text-red-600 dark:text-red-400'          // remove button

// After
'text-(--text)'
'text-(--text-subtle)'
'border-border-1'
'text-error-text hover:opacity-80'
```

### Touched

- \`commerce/CartLineItem/CartLineItem.tsx\`
- \`commerce/OrderSummary/OrderSummary.tsx\`

## Test plan

- [ ] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [ ] \`pnpm --filter @eventuras/ratio-ui build\` clean
- [ ] \`pnpm --filter @eventuras/ratio-ui test\` — 359 passed
- [ ] Storybook: any story rendering \`CartLineItem\` / \`OrderSummary\` — toggle dark theme and verify warm Linseed/Linen instead of cold gray
- [ ] Visual: cart page in apps/web (\`apps/web/src/app/(public)/cart\`) — line items + summary should sit on warm surface in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)