### PR TITLE
fix(ratio-ui): explicit transparent borders on filled buttons + theme-aware link decoration

### DIFF
--- a/.changeset/button-link-borders.md
+++ b/.changeset/button-link-borders.md
@@ -1,0 +1,9 @@
+---
+"@eventuras/ratio-ui": patch
+---
+
+Follow-up to #1383 — fix three issues spotted in review:
+
+- **`Button.tsx`** primary and danger variants used `border` without an explicit color, defaulting to `currentColor`. With the new semantic text tokens (`text-(--text-on-primary)`, `text-error-on`), the border picked up a high-contrast outline against the button fill in dark mode. Now `border-transparent`.
+- **`Menu.tsx`** trigger button had the same `border` + `currentColor` issue. Now `border-transparent`.
+- **`Link.tsx`** default link styling used hardcoded `decoration-blue-600/30 hover:decoration-blue-800` for the underline color, ignoring the warm Linseed/Linen theme. Switched to `decoration-current/30 hover:decoration-current` so the underline follows the link color.

--- a/libs/ratio-ui/src/core/Button/Button.tsx
+++ b/libs/ratio-ui/src/core/Button/Button.tsx
@@ -13,7 +13,7 @@ const ANIMATION_CLASSES = [
 ].join(' ');
 
 export const buttonStyles = {
-  primary: `border font-bold bg-(--primary) hover:opacity-90 text-(--text-on-primary) rounded-full ${ANIMATION_CLASSES}`,
+  primary: `border border-transparent font-bold bg-(--primary) hover:opacity-90 text-(--text-on-primary) rounded-full ${ANIMATION_CLASSES}`,
   secondary:
     `border border-border-1 text-(--text) bg-card hover:bg-card-hover hover:border-border-2 ` +
     `rounded-full ${ANIMATION_CLASSES}`,
@@ -24,7 +24,7 @@ export const buttonStyles = {
     `border border-border-2 hover:border-(--primary) hover:bg-card-hover ` +
     `rounded-full ${ANIMATION_CLASSES}`,
   danger:
-    `border font-bold bg-error hover:opacity-90 ` +
+    `border border-transparent font-bold bg-error hover:opacity-90 ` +
     `text-error-on rounded-full ${ANIMATION_CLASSES}`,
 };
 

--- a/libs/ratio-ui/src/core/Link/Link.tsx
+++ b/libs/ratio-ui/src/core/Link/Link.tsx
@@ -41,7 +41,7 @@ export const Link = React.forwardRef<HTMLElement, LinkProps>(
 
     // Default link styling (when no variant or custom className is set)
     const defaultLinkClasses = !variant && !className
-      ? 'text-(--primary) hover:opacity-80 underline decoration-blue-600/30 hover:decoration-blue-800 underline-offset-2 transition-colors'
+      ? 'text-(--primary) hover:opacity-80 underline decoration-current/30 hover:decoration-current underline-offset-2 transition-colors'
       : '';
 
     // Transparent variants (`button-outline`, `button-text`) inherit text

--- a/libs/ratio-ui/src/core/Menu/Menu.tsx
+++ b/libs/ratio-ui/src/core/Menu/Menu.tsx
@@ -69,10 +69,10 @@ const Menu = (props: MenuProps) => {
     <MenuTrigger>
       <AriaButton
         data-testid="logged-in-menu-button"
-        className="inline-flex items-center gap-2 border font-bold bg-(--primary) hover:opacity-90 text-(--text-on-primary) rounded-full px-4 py-1 m-1 transition-all duration-500 transform ease-in-out active:scale-110 hover:shadow-sm"
+        className="inline-flex items-center gap-2 border border-transparent font-bold bg-(--primary) hover:opacity-90 text-(--text-on-primary) rounded-full px-4 py-1 m-1 transition-all duration-500 transform ease-in-out active:scale-110 hover:shadow-sm"
       >
         {props.menuLabel}
-        <ChevronDown className="ml-1 h-5 w-5" />
+        <ChevronDown aria-hidden="true" className="ml-1 h-5 w-5" />
       </AriaButton>
       <Popover className={styles.popover}>
         <MenuActionsContext.Provider value={api}>


### PR DESCRIPTION
## Summary

Follow-up to #1383 addressing three Copilot review comments:

### `Button.tsx` — primary/danger borders

The `primary` and `danger` variants set `border` width but no color, so the border defaulted to `currentColor`. With the new semantic text tokens (`text-(--text-on-primary)` for primary, `text-error-on` for danger — both very dark), this produced a high-contrast dark outline around the filled button, especially noticeable in dark mode.

```diff
- primary: 'border font-bold bg-(--primary) ... text-(--text-on-primary) ...'
+ primary: 'border border-transparent font-bold bg-(--primary) ... text-(--text-on-primary) ...'

- danger: 'border font-bold bg-error ... text-error-on ...'
+ danger: 'border border-transparent font-bold bg-error ... text-error-on ...'
```

### `Menu.tsx` — trigger button border

Same issue: trigger button used `border` without color, falling back to `text-(--text-on-primary)`. Fixed with `border-transparent`.

### `Link.tsx` — underline decoration color

`defaultLinkClasses` still used hardcoded `decoration-blue-600/30 hover:decoration-blue-800`, reintroducing a fixed blue palette into the semantic-token sweep — looked off against the warm Linseed/Linen theme.

```diff
- 'text-(--primary) hover:opacity-80 underline decoration-blue-600/30 hover:decoration-blue-800 underline-offset-2 transition-colors'
+ 'text-(--primary) hover:opacity-80 underline decoration-current/30 hover:decoration-current underline-offset-2 transition-colors'
```

`decoration-current` follows the link's text color, so the underline stays on-brand in both themes.

## Test plan

- [x] `pnpm --filter @eventuras/ratio-ui exec tsc --noEmit` clean
- [x] `pnpm --filter @eventuras/ratio-ui build` clean
- [x] `pnpm --filter @eventuras/ratio-ui test` — 359 passed
- [ ] Storybook: `Core/Button` — `primary` and `danger` variants in dark mode should have no visible outline
- [ ] Storybook: any view that triggers `Menu` — the trigger button should look identical to a regular `Button primary` (no extra outline)
- [ ] Storybook: `Core/Link` default story — underline should be a subtle Linseed tint in light mode and a subtle lifted Linseed in dark mode, not blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)