### PR TITLE
chore(ratio-ui): differentiate Card default and tile variants

### DIFF
--- a/.changeset/card-thinner-default-border.md
+++ b/.changeset/card-thinner-default-border.md
@@ -1,0 +1,11 @@
+---
+"@eventuras/ratio-ui": patch
+---
+
+Differentiate `Card` `default` and `tile` variants more clearly:
+
+- **`default`** — elevated card: 1px `border-border-2` (visible hairline), `rounded-xl`, `shadow-sm` (up from `shadow-xs`). Reads as "lifted" — for primary content surfaces.
+- **`tile`** — flat editorial card: 1px `border-border-1` (subtle hairline), `rounded-lg`, no shadow, roomier padding. Reads as "quiet" — for content tiles in grids.
+- **`outline`** — unchanged (1px `border-border-1`, transparent fill, no shadow).
+
+The visual hierarchy now comes from three axes — border tone (`border-2` louder vs `border-1` quieter), radius (`xl` vs `lg`), and elevation (`shadow-sm` vs none) — rather than border width. All three border-bearing variants share the 1px hairline so the system reads as one family.

--- a/libs/ratio-ui/src/core/Card/Card.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.tsx
@@ -15,11 +15,16 @@ export interface CardProps extends SpacingProps, BorderProps {
   style?: React.CSSProperties;
   color?: Color;
   /**
-   * Visual treatment. `default` — branded card, border + shadow. `outline`
-   * — border only. `transparent` — no chrome. `wide` — full-bleed feature
-   * surface. `tile` — editorial card: quieter border, roomier padding,
-   * uses the modern surface tokens. Pair with `Heading` + `<p>` (or
-   * `ValueTile` for stat content).
+   * Visual treatment.
+   *
+   * - `default` — elevated card: 1px border, soft shadow, `rounded-xl`.
+   *   Use for primary content surfaces that should read as "lifted".
+   * - `tile` — flat editorial card: 1px border, no shadow, `rounded-lg`,
+   *   roomier padding. Use for content tiles in grids that should sit
+   *   quietly on the page.
+   * - `outline` — border only, transparent fill. Functional framing.
+   * - `transparent` — no chrome.
+   * - `wide` — full-bleed feature surface.
    */
   variant?: 'default' | 'wide' | 'outline' | 'transparent' | 'tile';
   hoverEffect?: boolean;
@@ -40,15 +45,19 @@ export const Card: React.FC<CardProps> = ({
   testId,
   ...spacingAndBorder
 }) => {
-  const baseClasses =
-    variant === 'tile'
-      ? 'p-6 relative rounded-lg border border-border-1'
-      : 'p-4 relative rounded-lg';
+  const baseByVariant: Record<NonNullable<CardProps['variant']>, string> = {
+    default: 'p-4 relative rounded-xl',
+    tile: 'p-6 relative rounded-lg border border-border-1',
+    outline: 'p-4 relative rounded-lg',
+    transparent: 'p-4 relative rounded-lg',
+    wide: 'p-4 relative rounded-lg',
+  };
+  const baseClasses = baseByVariant[variant];
   const transitionClasses = hoverEffect ? 'transform transition duration-300 ease-in-out' : '';
   const hoverClasses = hoverEffect ? 'hover:bg-card-hover transition-colors duration-200' : '';
 
   const variantStyles = {
-    default: 'bg-card border-2 border-border-1 shadow-xs',
+    default: 'bg-card border border-border-2 shadow-sm',
     wide: 'bg-card mx-auto min-h-[33vh]',
     outline: 'border border-border-1 bg-transparent',
     transparent: 'bg-transparent',


### PR DESCRIPTION
## Summary

Bring `Card` `default` border down from `border-2` to `border` (1px), matching `outline` and `tile`. To keep the visual hierarchy clear, the two filled variants now lean on **radius and elevation** instead of border width:

- **`default`** — elevated card: 1px border, `rounded-xl` (12px), `shadow-sm`. Lifted surface for primary content (booking widgets, CTAs, focus content).
- **`tile`** — flat editorial card: 1px border, `rounded-lg` (8px), no shadow, roomier padding (`p-6`). Quiet surface for content tiles in grids.
- **`outline`** — unchanged (1px border, transparent fill, no shadow).

All three border-bearing variants share the 1px hairline so the system reads as one family. The differentiation between `default` and `tile` is now carried by **radius + shadow**, matching the design reference where editorial tiles sit quietly while a primary card lifts off the surface.

```diff
  variantStyles = {
-   default: 'bg-card border-2 border-border-1 shadow-xs',
+   default: 'bg-card border border-border-1 shadow-sm',
    ...
    tile: 'bg-card',
  };

- baseClasses = variant === 'tile' ? 'p-6 rounded-lg border border-border-1' : 'p-4 rounded-lg';
+ baseClasses = variant === 'tile'
+   ? 'p-6 rounded-lg border border-border-1'
+   : variant === 'default'
+     ? 'p-4 rounded-xl'
+     : 'p-4 rounded-lg';
```

## Test plan

- [x] `pnpm --filter @eventuras/ratio-ui exec tsc --noEmit` clean
- [x] `pnpm --filter @eventuras/ratio-ui build` clean
- [x] `pnpm --filter @eventuras/ratio-ui test` — 359 passed
- [ ] Storybook: `Core/Card` — `Default` should have visible elevation (shadow + bigger radius); `Tile` should sit flat with the same hairline border
- [ ] Visual: side-by-side a `default` Card and a `tile` Card to confirm the hierarchy reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)