### PR TITLE
feat(ratio-ui): refresh Card hoverEffect to match canonical interactive cards

### DIFF
--- a/.changeset/card-hover-effect.md
+++ b/.changeset/card-hover-effect.md
@@ -1,0 +1,28 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Refresh the `Card` `hoverEffect` treatment to match the canonical interactive card pattern, and add two `--shadow-card-hover*` tokens so the glow stays theme-aware. Tuned to hint, not shout.
+
+```tsx
+<Card variant="tile" hoverEffect>
+  …
+</Card>
+```
+
+When `hoverEffect` is on, the card now:
+
+- Lifts its surface to `--card-hover`.
+- Picks up `--primary` on the border.
+- Translates 1px upward (`-translate-y-px`).
+- Gains a low-alpha Linseed-tinted glow (`--shadow-card-hover` for `default`/`outline`/`wide`/`transparent`, `--shadow-card-hover-tile` for the smaller `tile`).
+- Transitions snappily — `duration-200` instead of `300`.
+
+Two new shadow tokens in `theme.css`, theme-aware automatically via `--primary`:
+
+```css
+--shadow-card-hover-tile: 0 2px 6px  color-mix(in oklch, var(--primary) 12%, transparent);
+--shadow-card-hover:      0 3px 10px color-mix(in oklch, var(--primary) 15%, transparent);
+```
+
+Reserve `hoverEffect` for cards that act as clickable surfaces — static cards should leave it off so the page doesn't twitch on cursor pass-by.

--- a/libs/ratio-ui/src/core/Card/Card.stories.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.stories.tsx
@@ -100,13 +100,37 @@ export const Wide: Story = {
   },
 };
 
+/**
+ * `hoverEffect` adds the canonical interactive treatment — surface
+ * lifts to `--card-hover`, border picks up `--primary`, the card
+ * translates 1px upward and gains a soft Linseed-tinted glow. Reserve
+ * for cards that act as clickable surfaces.
+ */
 export const WithHoverEffect: Story = {
   args: {
     hoverEffect: true,
     children: (
       <Box>
-        <Heading as="h3" marginBottom="xs">Hover Me!</Heading>
-        <p>This card has a hover effect. Try hovering over it.</p>
+        <Heading as="h3" marginBottom="xs">Hover me</Heading>
+        <p>Surface lifts, border glows, card nudges upward.</p>
+      </Box>
+    ),
+  },
+};
+
+/**
+ * `tile` variant + `hoverEffect` — the editorial hover for grid tiles.
+ * Same 1px lift as `default`, but with a softer glow tuned for the
+ * tile's smaller footprint.
+ */
+export const TileWithHover: Story = {
+  args: {
+    variant: 'tile',
+    hoverEffect: true,
+    children: (
+      <Box>
+        <Heading as="h4" marginBottom="xs">Editorial tile</Heading>
+        <p className="text-sm text-(--text-muted)">Quiet by default, comes alive on hover.</p>
       </Box>
     ),
   },

--- a/libs/ratio-ui/src/core/Card/Card.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.tsx
@@ -27,6 +27,14 @@ export interface CardProps extends SpacingProps, BorderProps {
    * - `wide` — full-bleed feature surface.
    */
   variant?: 'default' | 'wide' | 'outline' | 'transparent' | 'tile';
+  /**
+   * Add the canonical interactive hover — surface lifts to `--card-hover`,
+   * border picks up `--primary`, the card translates 1px upward, and a
+   * soft Linseed-tinted glow appears. Tuned to hint, not shout. Use only
+   * on cards that act as clickable surfaces (links, calls-to-action) —
+   * static cards should omit this so the page doesn't twitch on cursor
+   * pass-by.
+   */
   hoverEffect?: boolean;
   backgroundImageUrl?: string;
   testId?: string;
@@ -53,8 +61,15 @@ export const Card: React.FC<CardProps> = ({
     wide: 'p-4 relative rounded-lg',
   };
   const baseClasses = baseByVariant[variant];
-  const transitionClasses = hoverEffect ? 'transform transition duration-300 ease-in-out' : '';
-  const hoverClasses = hoverEffect ? 'hover:bg-card-hover transition-colors duration-200' : '';
+  // Hover effect — opt-in, only meaningful for clickable surfaces.
+  // tile gets the smaller glow; every other variant gets a slightly
+  // bigger one to match its visual presence. All share a subtle 1px
+  // lift — the goal is "hints" not "shouts".
+  const hoverShadow = variant === 'tile' ? 'hover:shadow-card-hover-tile' : 'hover:shadow-card-hover';
+  const transitionClasses = hoverEffect ? 'transition-all duration-200 ease-out' : '';
+  const hoverClasses = hoverEffect
+    ? `hover:bg-card-hover hover:border-(--primary) hover:-translate-y-px ${hoverShadow}`
+    : '';
 
   const variantStyles = {
     default: 'bg-card border border-border-2 shadow-sm',

--- a/libs/ratio-ui/src/tokens/theme.css
+++ b/libs/ratio-ui/src/tokens/theme.css
@@ -188,6 +188,10 @@
 
   /* Shadow */
   --shadow-focus: 0 0 0 4px var(--focus-ring);
+  /* Card hover glow — Linseed-tinted, theme-aware via --primary.
+     Kept low-alpha so the lift hints rather than shouts. */
+  --shadow-card-hover-tile: 0 2px 6px color-mix(in oklch, var(--primary) 12%, transparent);
+  --shadow-card-hover: 0 3px 10px color-mix(in oklch, var(--primary) 15%, transparent);
 }
 
 /* --------------------------------------------


### PR DESCRIPTION
## Summary

Refresh the `Card` `hoverEffect` treatment to match the canonical interactive card pattern, and add two `--shadow-card-hover*` tokens so the glow stays theme-aware. Tuned to hint, not shout — low-alpha Linseed mix and a 1px lift.

```tsx
<Card variant="tile" hoverEffect>…</Card>
```

When `hoverEffect` is on, the card now:
- Lifts its surface to `--card-hover`.
- Picks up `--primary` on the border.
- Translates 1px upward (`-translate-y-px`).
- Gains a Linseed-tinted glow.
- Transitions snappily — `duration-200`.

### New shadow tokens

```css
--shadow-card-hover-tile: 0 2px 6px  color-mix(in oklch, var(--primary) 12%, transparent);
--shadow-card-hover:      0 3px 10px color-mix(in oklch, var(--primary) 15%, transparent);
```

Both follow the active theme automatically since `--primary` resolves to Linseed-600 in light and Linseed-400 in dark. The `tile` variant uses the smaller tile-tier glow; `default`/`outline`/`wide`/`transparent` use the slightly bigger one.

### API stays opt-in

`hoverEffect` remains opt-in (default `false`). Reserve it for cards that act as clickable surfaces (links, CTAs). Static info cards (dashboard summaries, panels) should leave it off so the page doesn't twitch on cursor pass-by.

## Test plan

- [x] `pnpm --filter @eventuras/ratio-ui exec tsc --noEmit` clean
- [x] `pnpm --filter @eventuras/ratio-ui test` — 360 passed
- [ ] Storybook: `Core/Card` `WithHoverEffect` and `TileWithHover` — hover should feel subtle, lift and glow noticeable but not loud
- [ ] Toggle dark theme — glow stays warm Linseed in both themes (Linseed-600 light → Linseed-400 dark)

🤖 Generated with [Claude Code](https://claude.com/claude-code)