### PR TITLE
chore(deps): bump renovate minimumReleaseAge to 5 days, fast-track vuln fixes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,11 +20,16 @@
   "rebaseWhen": "conflicted",
   "platformCommit": "enabled",
   "pruneStaleBranches": true,
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "5 days",
   "prConcurrentLimit": 4,
   "branchConcurrentLimit": 1,
   "lockFileMaintenance": {
     "enabled": false
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+    "labels": ["security"]
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Summary

Two small tweaks to `renovate.json`:

- `minimumReleaseAge: 3 days` → `5 days`. Routine releases settle a bit longer before we adopt them.
- Add an explicit `vulnerabilityAlerts` block that bypasses the age gate (`minimumReleaseAge: null`) for known security advisories, and tags those PRs with `security` so they're easy to find/triage.

```json
"minimumReleaseAge": "5 days",
…
"vulnerabilityAlerts": {
  "enabled": true,
  "minimumReleaseAge": null,
  "labels": ["security"]
}
```

## Notes

There's currently **one open Dependabot alert** (high — Next.js DoS via Server Components, fixed in `16.2.3+`). All `package.json` files already pin `next@16.2.4`, but `pnpm-lock.yaml` still has a stale `next@16.2.1` resolved under `libs/fides-auth-next` (range is `^16.0.0` so the lockfile was just never refreshed). After this config lands, Renovate's next run will fast-track that fix. Alternatively a one-shot `pnpm install` PR can clear it sooner — happy to follow up.

## Test plan

- [ ] Renovate dashboard issue picks up the new config on next run
- [ ] Confirm next vuln-related PR is auto-labelled `security` and not delayed by `minimumReleaseAge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)