### PR TITLE
chore(deps): add pnpm renovate:dry / renovate:run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "oxo": "cd apps/oxo-cli && node bin/run.js",
     "prepare": "simple-git-hooks",
     "release": "changeset version && git add . && git commit -m 'chore: version packages' && changeset tag && git push --follow-tags",
+    "renovate:dry": "pnpm dlx renovate --platform=github --dry-run losol/eventuras",
+    "renovate:run": "pnpm dlx renovate --platform=github losol/eventuras",
     "test": "turbo run test"
   },
   "simple-git-hooks": {


### PR DESCRIPTION
## Summary

Two convenience scripts for driving Renovate locally when the hosted app is misbehaving (memory issues, stuck queue, etc.):

```bash
RENOVATE_TOKEN=ghp_… pnpm renovate:dry   # preview only, no PRs created
RENOVATE_TOKEN=ghp_… pnpm renovate:run   # actual run
```

Both target `losol/eventuras` explicitly and respect the rules in `renovate.json` — `prConcurrentLimit: 4`, `branchConcurrentLimit: 1`, age gate, vulnerability fast-track, etc.

## Token

`RENOVATE_TOKEN` should be a personal access token with `repo` + `workflow` scope (classic) or the equivalent fine-grained PAT.

## Caveat

PRs created via local runs are authored by the token owner, not the Renovate bot. For sporadic unblock-when-the-app-hangs use that's fine; if local runs become routine consider creating a dedicated `eventuras-bot` GitHub user so attribution stays consistent.

## Test plan

- [ ] `RENOVATE_TOKEN=… pnpm renovate:dry` lists candidate updates without creating PRs
- [ ] Optional: `pnpm renovate:run` opens at most 4 PRs (per concurrent limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)