### PR TITLE
Redesign Card API for composable token props and theme support

### DIFF
--- a/.changeset/card-api-redesign.md
+++ b/.changeset/card-api-redesign.md
@@ -1,0 +1,23 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+**Breaking:** Redesign `Card` props around composable token props. The `variant` prop is gone, along with the `outline`, `wide`, and `tile` flavors. Surface, border, padding, radius, and shadow are now set independently using the same token props the rest of the library uses.
+
+### Migration
+
+| Before                            | After                                                            |
+| --------------------------------- | ---------------------------------------------------------------- |
+| `<Card variant="default">`        | `<Card>`                                                         |
+| `<Card variant="outline">`        | `<Card transparent border>`                                      |
+| `<Card variant="transparent">`    | `<Card transparent>`                                             |
+| `<Card variant="tile">`           | `<Card padding="lg" radius="lg" shadow="none">`                  |
+| `<Card variant="wide" backgroundImageUrl={…} />` | `<Card backgroundImageUrl={…} className="min-h-[33vh] mx-auto" />` (or use `Hero`, which now also accepts `backgroundImageUrl`) |
+
+### What changed
+
+- `variant` removed. Use `transparent?: boolean` for the unfilled surface, and the existing `color`, `border`, `radius`, `padding`, and `shadow` props for everything else.
+- `BorderProps.border` accepts a new `'none'` string variant in addition to `false` / `true` / `'default'` / `'strong'` / `'subtle'`.
+- New `shadow?: 'none' | 'xs' | 'sm' | 'md'` prop. Default is `'xs'` for filled cards, `'none'` for transparent cards.
+- Default `padding` is `'md'`, default `radius` is `'xl'`. Border defaults to on for filled cards, off for transparent ones.
+- The `Hero` block now accepts `backgroundImageUrl` and `style`, covering most cases that previously reached for `<Card variant="wide">`.

--- a/.changeset/card-hover-effect.md
+++ b/.changeset/card-hover-effect.md
@@ -2,10 +2,10 @@
 "@eventuras/ratio-ui": minor
 ---
 
-Refresh the `Card` `hoverEffect` treatment to match the canonical interactive card pattern, and add two `--shadow-card-hover*` tokens so the glow stays theme-aware. Tuned to hint, not shout.
+Refresh the `Card` `hoverEffect` treatment to match the canonical interactive card pattern, and add two `--shadow-card-hover*` tokens so the glow stays theme-aware.
 
 ```tsx
-<Card variant="tile" hoverEffect>
+<Card hoverEffect>
   …
 </Card>
 ```
@@ -14,15 +14,16 @@ When `hoverEffect` is on, the card now:
 
 - Lifts its surface to `--card-hover`.
 - Picks up `--primary` on the border.
-- Translates 1px upward (`-translate-y-px`).
-- Gains a low-alpha Linseed-tinted glow (`--shadow-card-hover` for `default`/`outline`/`wide`/`transparent`, `--shadow-card-hover-tile` for the smaller `tile`).
-- Transitions snappily — `duration-200` instead of `300`.
+- Gains a soft Linseed-tinted glow (`--shadow-card-hover` when the card has a base shadow, `--shadow-card-hover-tile` when `shadow="none"`).
+- Transitions snappily — `duration-200`, `ease-out`.
 
-Two new shadow tokens in `theme.css`, theme-aware automatically via `--primary`:
+The glow is implemented via two new shadow tokens in `theme.css`:
 
 ```css
---shadow-card-hover-tile: 0 2px 6px  color-mix(in oklch, var(--primary) 12%, transparent);
---shadow-card-hover:      0 3px 10px color-mix(in oklch, var(--primary) 15%, transparent);
+--shadow-card-hover-tile: 0 4px 12px color-mix(in oklch, var(--primary) 25%, transparent);
+--shadow-card-hover:      0 6px 18px color-mix(in oklch, var(--primary) 25%, transparent);
 ```
 
-Reserve `hoverEffect` for cards that act as clickable surfaces — static cards should leave it off so the page doesn't twitch on cursor pass-by.
+Theme-aware automatically via `--primary` (Linseed-600 light, Linseed-400 dark).
+
+The card stays put on hover (no translate) so cursor pass-by doesn't make text twitch. Reserve `hoverEffect` for cards that act as clickable surfaces.

--- a/apps/web/src/app/(admin)/admin/events/[id]/EconomySection.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EconomySection.tsx
@@ -119,14 +119,14 @@ const EconomySection: React.FC<EconomySectionProps> = ({ participants }) => {
     <Stack gap="xl" className="py-8">
       {/* Summary */}
       <Grid cols={{ sm: 2, md: 2 }}>
-        <Card variant="outline" className="text-center">
+        <Card transparent border className="text-center">
           <ValueTile
             number={statistics.totalOrders}
             label={t('admin.economy.statistics.totalOrders')}
             className="items-center"
           />
         </Card>
-        <Card variant="outline" className="text-center">
+        <Card transparent border className="text-center">
           <ValueTile
             number={Number.parseFloat(statistics.totalRevenue.toFixed(2))}
             label={`${t('admin.economy.statistics.totalRevenue')} (kr)`}
@@ -137,28 +137,28 @@ const EconomySection: React.FC<EconomySectionProps> = ({ participants }) => {
 
       {/* Order status breakdown */}
       <Grid cols={{ sm: 2, md: 4 }}>
-        <Card variant="outline" className="text-center">
+        <Card transparent border className="text-center">
           <ValueTile
             number={statistics.draftOrders}
             label={t('admin.economy.statistics.draftOrders')}
             className="items-center"
           />
         </Card>
-        <Card variant="outline" className="text-center">
+        <Card transparent border className="text-center">
           <ValueTile
             number={statistics.verifiedOrders}
             label={t('admin.economy.statistics.verifiedOrders')}
             className="items-center"
           />
         </Card>
-        <Card variant="outline" className="text-center">
+        <Card transparent border className="text-center">
           <ValueTile
             number={statistics.invoicedOrders}
             label={t('admin.economy.statistics.invoicedOrders')}
             className="items-center"
           />
         </Card>
-        <Card variant="outline" className="text-center">
+        <Card transparent border className="text-center">
           <ValueTile
             number={statistics.cancelledOrders}
             label={t('admin.economy.statistics.cancelledOrders')}

--- a/apps/web/src/app/(public)/collections/[id]/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/collections/[id]/[slug]/page.tsx
@@ -53,10 +53,7 @@ const CollectionPage: React.FC<EventInfoProps> = async props => {
   return (
     <>
       {collection?.featuredImageUrl && (
-        <Card
-          variant="wide"
-          {...(collection?.featuredImageUrl && { backgroundImage: collection.featuredImageUrl })}
-        ></Card>
+        <Card className="min-h-[33vh] mx-auto" backgroundImageUrl={collection.featuredImageUrl} />
       )}
       <Section className="py-16">
         <Container>

--- a/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
@@ -120,7 +120,10 @@ export default async function EventDetailsPage({ params }: Readonly<EventDetails
         <Section className="pb-8">
           <Container>
             {eventinfo.featuredImageUrl && (
-              <Card variant="wide" backgroundImageUrl={eventinfo.featuredImageUrl} />
+              <Card
+                className="min-h-[33vh] mx-auto"
+                backgroundImageUrl={eventinfo.featuredImageUrl}
+              />
             )}
 
             <Heading as="h1" paddingY="xs">

--- a/apps/web/src/components/event/FeaturedCollectionSection.tsx
+++ b/apps/web/src/components/event/FeaturedCollectionSection.tsx
@@ -20,7 +20,7 @@ export const FeaturedCollectionSection: React.FC<FeaturedCollectionSectionProps>
   return (
     <Section paddingY="lg">
       {collection.featuredImageUrl && (
-        <Card variant="wide" backgroundImageUrl={collection.featuredImageUrl} />
+        <Card className="min-h-[33vh] mx-auto" backgroundImageUrl={collection.featuredImageUrl} />
       )}
       <Container>
         <Heading as="h2" paddingTop="sm" paddingBottom="xs">

--- a/libs/ratio-ui/.storybook/modeDecorator.tsx
+++ b/libs/ratio-ui/.storybook/modeDecorator.tsx
@@ -37,7 +37,9 @@ export const ModeDecorator = (Story: any, context: any) => {
         data-theme={isDarkMode ? 'dark' : 'light'}
         style={{
           minWidth: '100%',
-          backgroundColor: isDarkMode ? '#1a1a1a' : '#ffffff',
+          minHeight: '100vh',
+          backgroundColor: 'var(--surface)',
+          color: 'var(--text)',
           padding: noPadding ? '0' : '2rem',
         }}
       >

--- a/libs/ratio-ui/src/blocks/Hero/Hero.tsx
+++ b/libs/ratio-ui/src/blocks/Hero/Hero.tsx
@@ -1,18 +1,27 @@
-import React, { type ReactNode } from 'react';
+import React, { type CSSProperties, type ReactNode } from 'react';
 
 import { Heading } from '../../core/Heading';
 import { Container } from '../../layout/Container';
+import { buildCoverImageStyle } from '../../utils/buildCoverImageStyle';
 import { cn } from '../../utils/cn';
 
 export interface HeroProps {
   children?: ReactNode;
   className?: string;
+  style?: CSSProperties;
   /**
    * Marks the hero as a dark surface (applies `surface-dark` className) so
    * descendants reading `var(--text)` pick up the light tone. Useful for
    * heroes with photo backgrounds or strongly colored fills.
    */
   dark?: boolean;
+  /**
+   * Background image URL — sets the hero's `background-image` to a
+   * full-cover image with a soft dark overlay so foreground text stays
+   * readable. Pair with `dark` if you want the typography tuned for
+   * a dark surface.
+   */
+  backgroundImageUrl?: string;
 }
 
 interface HeroSlotProps {
@@ -62,7 +71,13 @@ interface HeroComponent extends React.FC<HeroProps> {
  * </Hero>
  * ```
  */
-const HeroRoot: HeroComponent = (({ children, className, dark }: HeroProps) => {
+const HeroRoot: HeroComponent = (({
+  children,
+  className,
+  style,
+  dark,
+  backgroundImageUrl,
+}: HeroProps) => {
   // Detect whether the consumer included a Hero.Side so we can drop the
   // second grid column when there's nothing to put in it. Without this
   // the main content would float in the left half on lg+ with empty
@@ -71,6 +86,8 @@ const HeroRoot: HeroComponent = (({ children, className, dark }: HeroProps) => {
     child => React.isValidElement(child) && child.type === HeroSide,
   );
 
+  const combinedStyle = buildCoverImageStyle(backgroundImageUrl, style);
+
   return (
     <section
       className={cn(
@@ -78,6 +95,7 @@ const HeroRoot: HeroComponent = (({ children, className, dark }: HeroProps) => {
         dark && 'surface-dark',
         className,
       )}
+      style={combinedStyle}
     >
       <Container>
         <div

--- a/libs/ratio-ui/src/core/Card/Card.stories.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.stories.tsx
@@ -12,21 +12,18 @@ const meta: Meta<typeof Card> = {
   component: Card,
   tags: ['autodocs'],
   argTypes: {
-    variant: {
-      control: 'select',
-      options: ['default', 'wide', 'outline', 'transparent', 'tile'],
-    },
-    gap: {
-      control: 'select',
-      options: ['none', 'xs', 'sm', 'md', 'lg', 'xl'],
-    },
+    transparent: { control: 'boolean' },
+    border: { control: 'select', options: [false, true, 'default', 'strong', 'subtle', 'none'] },
+    radius: { control: 'select', options: ['none', 'sm', 'md', 'lg', 'xl', 'full'] },
+    shadow: { control: 'select', options: ['none', 'xs', 'sm', 'md'] },
+    padding: { control: 'select', options: ['none', 'xs', 'sm', 'md', 'lg', 'xl'] },
+    gap: { control: 'select', options: ['none', 'xs', 'sm', 'md', 'lg', 'xl'] },
     hoverEffect: { control: 'boolean' },
     color: {
       control: 'select',
       options: [undefined, 'neutral', 'primary', 'secondary', 'accent', 'success', 'warning', 'error', 'info'],
     },
     backgroundImageUrl: { control: 'text' },
-    padding: { control: 'select', options: ['none', 'xs', 'sm', 'md', 'lg', 'xl'] },
     margin: { control: 'select', options: ['none', 'xs', 'sm', 'md', 'lg', 'xl'] },
   },
 };
@@ -45,26 +42,34 @@ export const Default: Story = {
   },
 };
 
+/**
+ * Transparent fill with an outline — replaces the old `outline` variant.
+ * Compose via `variant="transparent" border`.
+ */
 export const Outline: Story = {
   args: {
-    variant: 'outline',
+    transparent: true,
+    border: true,
     children: (
       <Box>
         <Heading as="h3" marginBottom="xs">Outline Card</Heading>
-        <p>This card uses the outline variant with a border.</p>
+        <p>This card uses `transparent border`.</p>
       </Box>
     ),
   },
 };
 
 /**
- * Editorial tile — quieter border, roomier padding (`p-6`), modern
- * surface tokens. Pair with a `Heading` + paragraph for feature-card
- * grids; pair with `ValueTile` for stat blocks that need a surface.
+ * Editorial tile composition — flat (no shadow), roomier padding,
+ * tighter radius. Compose via `padding="lg" radius="lg" shadow="none"`.
+ * Pair with a `Heading` + paragraph for feature-card grids; pair with
+ * `ValueTile` for stat blocks that need a surface.
  */
 export const Tile: Story = {
   args: {
-    variant: 'tile',
+    padding: 'lg',
+    radius: 'lg',
+    shadow: 'none',
     children: (
       <Box>
         <Heading as="h4" marginBottom="xs">Tokens</Heading>
@@ -78,23 +83,11 @@ export const Tile: Story = {
 
 export const Transparent: Story = {
   args: {
-    variant: 'transparent',
+    transparent: true,
     children: (
       <Box>
         <Heading as="h3" marginBottom="xs">Transparent Card</Heading>
         <p>This card has no background or border, just structure and padding.</p>
-      </Box>
-    ),
-  },
-};
-
-export const Wide: Story = {
-  args: {
-    variant: 'wide',
-    children: (
-      <Box>
-        <Heading as="h3" marginBottom="xs">Wide Card</Heading>
-        <p>This card uses the wide variant with minimum height.</p>
       </Box>
     ),
   },
@@ -119,13 +112,15 @@ export const WithHoverEffect: Story = {
 };
 
 /**
- * `tile` variant + `hoverEffect` — the editorial hover for grid tiles.
- * Same 1px lift as `default`, but with a softer glow tuned for the
- * tile's smaller footprint.
+ * Tile composition + `hoverEffect` — the editorial hover for grid
+ * tiles. The smaller `--shadow-card-hover-tile` glow kicks in when no
+ * base shadow is present.
  */
 export const TileWithHover: Story = {
   args: {
-    variant: 'tile',
+    padding: 'lg',
+    radius: 'lg',
+    shadow: 'none',
     hoverEffect: true,
     children: (
       <Box>
@@ -158,7 +153,8 @@ export const GridWithImage: Story = {
 
 export const GridOutline: Story = {
   args: {
-    variant: 'outline',
+    transparent: true,
+    border: true,
     className: 'grid grid-cols-1 md:grid-cols-2',
     children: (
       <>
@@ -202,7 +198,8 @@ export const GridWithSmallGap: Story = {
   args: {
     className: 'grid grid-cols-1 md:grid-cols-2',
     gap: 'sm',
-    variant: 'outline',
+    transparent: true,
+    border: true,
     children: (
       <>
         <Image

--- a/libs/ratio-ui/src/core/Card/Card.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.tsx
@@ -8,40 +8,51 @@ import { buildBorderClasses } from '../../tokens/borders';
 import { buildCoverImageStyle } from '../../utils/buildCoverImageStyle';
 import { cn } from '../../utils/cn';
 
+export type CardShadow = 'none' | 'xs' | 'sm' | 'md';
+
 export interface CardProps extends SpacingProps, BorderProps {
   children?: ReactNode;
   as?: React.ElementType;
   className?: string;
   style?: React.CSSProperties;
+  /**
+   * Semantic surface tint. Maps to `bg-{color}-50` in light and
+   * `bg-{color}-950` in dark via `surfaceBgClasses`. Overrides the
+   * default `--card` fill.
+   */
   color?: Color;
   /**
-   * Visual treatment.
-   *
-   * - `default` — elevated card: 1px border, soft shadow, `rounded-xl`.
-   *   Use for primary content surfaces that should read as "lifted".
-   * - `tile` — flat editorial card: 1px border, no shadow, `rounded-lg`,
-   *   roomier padding. Use for content tiles in grids that should sit
-   *   quietly on the page.
-   * - `outline` — border only, transparent fill. Functional framing.
-   * - `transparent` — no chrome.
-   * - `wide` — full-bleed feature surface.
+   * Drop the fill, leaving the card transparent. Pair with `border`
+   * (from `BorderProps`) when you want an outlined transparent card.
    */
-  variant?: 'default' | 'wide' | 'outline' | 'transparent' | 'tile';
+  transparent?: boolean;
+  /**
+   * Drop shadow. Defaults to `'xs'` for filled cards, `'none'` for
+   * transparent ones.
+   */
+  shadow?: CardShadow;
   /**
    * Add the canonical interactive hover — surface lifts to `--card-hover`,
-   * border picks up `--primary`, the card translates 1px upward, and a
-   * soft Linseed-tinted glow appears. Tuned to hint, not shout. Use only
-   * on cards that act as clickable surfaces (links, calls-to-action) —
-   * static cards should omit this so the page doesn't twitch on cursor
-   * pass-by.
+   * border picks up `--primary`, and a soft Linseed-tinted glow appears.
+   * Tuned to hint, not shout; the card stays put so cursor pass-by
+   * doesn't make text twitch. Use only on cards that act as clickable
+   * surfaces (links, calls-to-action).
    */
   hoverEffect?: boolean;
   backgroundImageUrl?: string;
   testId?: string;
 }
 
+const SHADOW_CLASSES: Record<CardShadow, string> = {
+  none: '',
+  xs: 'shadow-xs',
+  sm: 'shadow-sm',
+  md: 'shadow-md',
+};
+
 export const Card: React.FC<CardProps> = ({
-  variant = 'default',
+  transparent = false,
+  shadow,
   hoverEffect = false,
   gap = 'sm',
   color,
@@ -53,43 +64,39 @@ export const Card: React.FC<CardProps> = ({
   testId,
   ...spacingAndBorder
 }) => {
-  const baseByVariant: Record<NonNullable<CardProps['variant']>, string> = {
-    default: 'p-4 relative rounded-xl',
-    tile: 'p-6 relative rounded-lg border border-border-1',
-    outline: 'p-4 relative rounded-lg',
-    transparent: 'p-4 relative rounded-lg',
-    wide: 'p-4 relative rounded-lg',
-  };
-  const baseClasses = baseByVariant[variant];
+  // Card-tier defaults — applied when consumer doesn't pass them.
+  const padding = spacingAndBorder.padding ?? 'md';
+  const radius = spacingAndBorder.radius ?? 'xl';
+  const border = spacingAndBorder.border ?? !transparent;
+  const effectiveShadow: CardShadow = shadow ?? (transparent ? 'none' : 'xs');
+
+  const fillClass = transparent ? 'bg-transparent' : 'bg-card';
+
   // Hover effect — opt-in, only meaningful for clickable surfaces.
-  // tile gets the smaller glow; every other variant gets a slightly
-  // bigger one to match its visual presence. All share a subtle 1px
-  // lift — the goal is "hints" not "shouts".
-  const hoverShadow = variant === 'tile' ? 'hover:shadow-card-hover-tile' : 'hover:shadow-card-hover';
+  // The smaller tile-tier glow when no shadow is present (flat editorial
+  // mode); the bigger one for elevated cards.
+  const hoverShadow =
+    effectiveShadow === 'none' ? 'hover:shadow-card-hover-tile' : 'hover:shadow-card-hover';
   const transitionClasses = hoverEffect ? 'transition-all duration-200 ease-out' : '';
   const hoverClasses = hoverEffect
-    ? `hover:bg-card-hover hover:border-(--primary) hover:-translate-y-px ${hoverShadow}`
+    ? `hover:bg-card-hover hover:border-(--primary) ${hoverShadow}`
     : '';
 
-  const variantStyles = {
-    default: 'bg-card border border-border-2 shadow-sm',
-    wide: 'bg-card mx-auto min-h-[33vh]',
-    outline: 'border border-border-1 bg-transparent',
-    transparent: 'bg-transparent',
-    tile: 'bg-card',
-  };
-
-  const bgClasses = color ? surfaceBgClasses[color] : variantStyles[variant];
+  const bgClasses = color ? surfaceBgClasses[color] : fillClass;
 
   const {
-    padding, paddingX, paddingY, paddingTop, paddingBottom,
+    padding: _padding,
+    paddingX, paddingY, paddingTop, paddingBottom,
     margin, marginX, marginY, marginTop, marginBottom,
-    border, borderColor, radius,
+    border: _border,
+    borderColor,
+    radius: _radius,
     ...rest
   } = spacingAndBorder;
 
   const spacingClasses = buildSpacingClasses({
-    padding, paddingX, paddingY, paddingTop, paddingBottom,
+    padding,
+    paddingX, paddingY, paddingTop, paddingBottom,
     margin, marginX, marginY, marginTop, marginBottom,
     gap,
   });
@@ -99,7 +106,16 @@ export const Card: React.FC<CardProps> = ({
 
   return (
     <Component
-      className={cn(baseClasses, transitionClasses, hoverClasses, bgClasses, spacingClasses, borderClasses, className)}
+      className={cn(
+        'relative',
+        bgClasses,
+        borderClasses,
+        SHADOW_CLASSES[effectiveShadow],
+        transitionClasses,
+        hoverClasses,
+        spacingClasses,
+        className,
+      )}
       style={combinedStyle}
       data-testid={testId}
       {...rest}

--- a/libs/ratio-ui/src/core/ValueTile/ValueTile.stories.tsx
+++ b/libs/ratio-ui/src/core/ValueTile/ValueTile.stories.tsx
@@ -88,21 +88,21 @@ export const Grid: Story = {
 
 /**
  * Wrapped in `Card` for a surfaced dashboard tile. The dashboard pattern
- * pairs `Card variant="outline"` with the convenience API.
+ * pairs `Card transparent border` with the convenience API.
  */
 export const InsideCard: Story = {
   render: () => (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-3xl">
-      <Card variant="outline" className="text-center">
+      <Card transparent border className="text-center">
         <ValueTile number={156} label="Total events" className="items-center" />
       </Card>
-      <Card variant="outline" className="text-center">
+      <Card transparent border className="text-center">
         <ValueTile number={2341} label="Registrations" className="items-center" />
       </Card>
-      <Card variant="outline" className="text-center">
+      <Card transparent border className="text-center">
         <ValueTile number={89} label="Active events" className="items-center" />
       </Card>
-      <Card variant="outline" className="text-center">
+      <Card transparent border className="text-center">
         <ValueTile number={undefined} label="Loading…" className="items-center" />
       </Card>
     </div>

--- a/libs/ratio-ui/src/core/ValueTile/ValueTile.tsx
+++ b/libs/ratio-ui/src/core/ValueTile/ValueTile.tsx
@@ -54,8 +54,10 @@ const OrientationContext = React.createContext<ValueTileOrientation>('vertical')
  * - **Compound:** wrap `ValueTile.Value` and `ValueTile.Caption` for rich
  *   markup — italic accents, multi-token phrases, etc.
  *
- * Has no surface of its own. Wrap in `Card` (e.g. `variant="outline"` or
- * `variant="tile"`) when you want a border or background.
+ * Has no surface of its own. Wrap in `Card` (e.g.
+ * `<Card transparent border>` or `<Card padding="lg" radius="lg"
+ * shadow="none">` for the editorial tile look) when you want a
+ * border or background.
  *
  * @example
  * ```tsx

--- a/libs/ratio-ui/src/global.css
+++ b/libs/ratio-ui/src/global.css
@@ -163,6 +163,8 @@
   body {
     @apply h-full m-0 flex flex-col min-h-screen antialiased;
     overflow-x: hidden;
+    background-color: var(--surface);
+    color: var(--text);
   }
 
   /* Main animated gradient background */

--- a/libs/ratio-ui/src/pages/Page/Page.stories.tsx
+++ b/libs/ratio-ui/src/pages/Page/Page.stories.tsx
@@ -82,21 +82,21 @@ const PageDemo: React.FC<{ title: string }> = ({ title }) => (
             Storybook with the source you actually ship.
           </p>
           <div className="grid md:grid-cols-3 gap-6">
-            <Card variant="tile">
+            <Card padding="lg" radius="lg" shadow="none">
               <Heading as="h4" marginBottom="xs">Tokens</Heading>
               <p className="text-sm text-(--text-muted)">
                 Color scales, typography, spacing, borders, status — all theme-aware via CSS
                 variables.
               </p>
             </Card>
-            <Card variant="tile">
+            <Card padding="lg" radius="lg" shadow="none">
               <Heading as="h4" marginBottom="xs">Primitives</Heading>
               <p className="text-sm text-(--text-muted)">
                 Dialog, Drawer, Navbar, Footer — built on React Aria for keyboard and screen
                 reader support.
               </p>
             </Card>
-            <Card variant="tile">
+            <Card padding="lg" radius="lg" shadow="none">
               <Heading as="h4" marginBottom="xs">Patterns</Heading>
               <p className="text-sm text-(--text-muted)">
                 Compound APIs (Heading, Content, Footer slots) for the shapes that show up over

--- a/libs/ratio-ui/src/pages/ThreeColumnLayout/ThreeColumnLayout.stories.tsx
+++ b/libs/ratio-ui/src/pages/ThreeColumnLayout/ThreeColumnLayout.stories.tsx
@@ -127,10 +127,10 @@ export function MyPage() {
 
     <h3 id="card">Card</h3>
     <p>
-      Cards are container components with optional hover effects, multiple variants (default, wide,
-      outline, transparent), and support for click handlers.
+      Cards are container components with optional hover effects, a transparent variant, semantic
+      color tints, and composable padding/border/radius props.
     </p>
-    <CodeBlock>{`<Card variant="outline" hoverEffect>
+    <CodeBlock>{`<Card transparent border hoverEffect>
   <Heading as="h3">Feature</Heading>
   <Text>Description of this feature.</Text>
 </Card>`}</CodeBlock>

--- a/libs/ratio-ui/src/tokens/borders.ts
+++ b/libs/ratio-ui/src/tokens/borders.ts
@@ -4,9 +4,16 @@
 
 import type { Color } from './colors';
 
-export type BorderVariant = 'default' | 'strong' | 'subtle';
+export type BorderVariant = 'none' | 'default' | 'strong' | 'subtle';
 
 export interface BorderProps {
+  /**
+   * Border weight.
+   * - `false` / `'none'` — no border.
+   * - `true` / `'default'` — 1px solid.
+   * - `'strong'` — 2px solid.
+   * - `'subtle'` — 1px dashed.
+   */
   border?: boolean | BorderVariant;
   borderColor?: 'default' | 'subtle' | 'strong' | Color;
   radius?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
@@ -38,7 +45,7 @@ const borderColorMap: Record<NonNullable<BorderProps['borderColor']>, string> = 
 export function buildBorderClasses(props: BorderProps): string {
   const classes: string[] = [];
 
-  if (props.border) {
+  if (props.border !== undefined && props.border !== false && props.border !== 'none') {
     const variant = props.border === true ? 'default' : props.border;
     switch (variant) {
       case 'default':

--- a/libs/ratio-ui/src/tokens/theme.css
+++ b/libs/ratio-ui/src/tokens/theme.css
@@ -215,9 +215,6 @@
   --text-on-secondary: var(--color-neutral-900);
   --text-on-accent: var(--color-secondary-100);
 
-  --border-1: var(--color-secondary-300);
-  --border-2: var(--color-secondary-400);
-
   --alpha-1: 0.04;
   --alpha-2: 0.08;
   --alpha-3: 0.12;
@@ -227,9 +224,18 @@
   --overlay-press: rgba(var(--overlay-ink), var(--alpha-2));
   --overlay-drag: rgba(var(--overlay-ink), var(--alpha-3));
 
-  --card: rgb(255 255 255 / 0.55);
-  --card-hover: rgb(255 255 255 / 0.75);
-  --surface: var(--color-secondary-200);
+  /* Page surface — warm Linen, slightly muted. */
+  --surface: oklch(0.945 0.012 88);
+
+  /* Card lifts from the surface toward white — a touch lighter so
+     it reads as elevated. Hover steps further. */
+  --card: oklch(0.985 0.008 88);
+  --card-hover: oklch(0.998 0.005 90);
+
+  /* Borders — subtle hairline (1) and a more visible step (2),
+     darker than the card so the edge defines without competing. */
+  --border-1: oklch(0.92 0.018 85);
+  --border-2: oklch(0.85 0.025 85);
 
   --focus-ring: oklch(0.520 0.082 226 / 0.45);
 
@@ -280,9 +286,6 @@
   --text-on-secondary: var(--color-secondary-200);
   --text-on-accent: var(--color-accent-950);
 
-  --border-1: var(--color-primary-800);
-  --border-2: var(--color-primary-700);
-
   --alpha-1: 0.06;
   --alpha-2: 0.10;
   --alpha-3: 0.16;
@@ -292,9 +295,18 @@
   --overlay-press: rgba(var(--overlay-ink), var(--alpha-2));
   --overlay-drag: rgba(var(--overlay-ink), var(--alpha-3));
 
-  --card: oklch(0.220 0.040 232);
-  --card-hover: oklch(0.260 0.046 232);
+  /* Page surface — Linseed-950, the deep cool floor of the palette. */
   --surface: var(--color-primary-950);
+
+  /* Card lifts to Linseed-900, a clear step above surface. Hover sits
+     between Linseed-900 and 800. */
+  --card: var(--color-primary-900);
+  --card-hover: oklch(0.290 0.050 230);
+
+  /* Borders — hairline subtle, then a more visible step. Both
+     Linseed-tinted so they stay coherent with the surface family. */
+  --border-1: oklch(0.285 0.035 232);
+  --border-2: oklch(0.350 0.050 230);
 
   --focus-ring: oklch(0.730 0.078 224 / 0.45);
 


### PR DESCRIPTION
Revamp the Card component to eliminate the variant prop and introduce composable token props for surface, border, padding, radius, and shadow. Update styles for dark/light theme support and enhance the Hero component to accept background images. Adjust related components to align with the new Card API.