### PR TITLE
fix(ratio-ui): address Card review comments

### DIFF
--- a/.changeset/card-api-redesign.md
+++ b/.changeset/card-api-redesign.md
@@ -12,7 +12,7 @@
 | `<Card variant="outline">`        | `<Card transparent border>`                                      |
 | `<Card variant="transparent">`    | `<Card transparent>`                                             |
 | `<Card variant="tile">`           | `<Card padding="lg" radius="lg" shadow="none">`                  |
-| `<Card variant="wide" backgroundImageUrl={…} />` | `<Card backgroundImageUrl={…} className="min-h-[33vh] mx-auto" />` (or use `Hero`, which now also accepts `backgroundImageUrl`) |
+| `<Card variant="wide" backgroundImageUrl={…} />` | `<Card backgroundImageUrl={…} className="min-h-[33vh] mx-auto" radius="lg" border="none" shadow="none" />` (or use `Hero`, which now also accepts `backgroundImageUrl`) |
 
 ### What changed
 

--- a/.changeset/card-hover-effect.md
+++ b/.changeset/card-hover-effect.md
@@ -2,7 +2,7 @@
 "@eventuras/ratio-ui": minor
 ---
 
-Refresh the `Card` `hoverEffect` treatment to match the canonical interactive card pattern, and add two `--shadow-card-hover*` tokens so the glow stays theme-aware.
+Refresh the `Card` `hoverEffect` treatment to match the canonical interactive card pattern, using the existing `--shadow-card-hover*` tokens so the glow stays theme-aware.
 
 ```tsx
 <Card hoverEffect>
@@ -17,11 +17,11 @@ When `hoverEffect` is on, the card now:
 - Gains a soft Linseed-tinted glow (`--shadow-card-hover` when the card has a base shadow, `--shadow-card-hover-tile` when `shadow="none"`).
 - Transitions snappily — `duration-200`, `ease-out`.
 
-The glow is implemented via two new shadow tokens in `theme.css`:
+The glow is implemented via the shadow tokens defined in `theme.css`:
 
 ```css
---shadow-card-hover-tile: 0 4px 12px color-mix(in oklch, var(--primary) 25%, transparent);
---shadow-card-hover:      0 6px 18px color-mix(in oklch, var(--primary) 25%, transparent);
+--shadow-card-hover-tile: 0 2px 6px color-mix(in oklch, var(--primary) 12%, transparent);
+--shadow-card-hover:      0 3px 10px color-mix(in oklch, var(--primary) 15%, transparent);
 ```
 
 Theme-aware automatically via `--primary` (Linseed-600 light, Linseed-400 dark).

--- a/.changeset/card-transparent-precedence.md
+++ b/.changeset/card-transparent-precedence.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/ratio-ui": patch
+---
+
+Fix `Card` so `transparent` takes precedence over `color` (matches the documented prop contract), and update the Outline story doc comment to use the new composable API (`transparent border` instead of `variant="transparent"`).

--- a/libs/ratio-ui/src/core/Card/Card.stories.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
 
 /**
  * Transparent fill with an outline — replaces the old `outline` variant.
- * Compose via `variant="transparent" border`.
+ * Compose via `transparent border`.
  */
 export const Outline: Story = {
   args: {

--- a/libs/ratio-ui/src/core/Card/Card.tsx
+++ b/libs/ratio-ui/src/core/Card/Card.tsx
@@ -82,7 +82,8 @@ export const Card: React.FC<CardProps> = ({
     ? `hover:bg-card-hover hover:border-(--primary) ${hoverShadow}`
     : '';
 
-  const bgClasses = color ? surfaceBgClasses[color] : fillClass;
+  // `transparent` takes precedence over `color` so the prop contract holds.
+  const bgClasses = transparent ? fillClass : color ? surfaceBgClasses[color] : fillClass;
 
   const {
     padding: _padding,


### PR DESCRIPTION
- Card: 'transparent' now takes precedence over 'color' so the prop contract holds
- Card.stories: update Outline doc comment to new composable API
- changesets: align card-hover-effect token values with theme.css and reword to reflect existing tokens
- changesets: include radius/border/shadow in card-api-redesign 'wide' migration example