### PR TITLE
Add OAuth logging helpers for structured log context

### DIFF
--- a/.changeset/fides-auth-oauth-logging.md
+++ b/.changeset/fides-auth-oauth-logging.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/fides-auth": minor
+---
+
+Add `@eventuras/fides-auth/oauth-logging` with `getOAuthConfigLogContext` and `getOAuthErrorLogContext` helpers — structured, log-safe context objects for OAuth/OIDC config (excluding `clientSecret`) and `oauth4webapi`-style errors (including `cause`).

--- a/libs/fides-auth/package.json
+++ b/libs/fides-auth/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/oauth.d.ts",
       "import": "./dist/oauth.js"
     },
+    "./oauth-logging": {
+      "types": "./dist/oauth-logging.d.ts",
+      "import": "./dist/oauth-logging.js"
+    },
     "./oauth-browser": {
       "types": "./dist/oauth-browser.d.ts",
       "import": "./dist/oauth-browser.js"

--- a/libs/fides-auth/src/index.ts
+++ b/libs/fides-auth/src/index.ts
@@ -5,6 +5,7 @@
  */
 
 export * from './logger';
+export * from './oauth-logging';
 export * from './session-refresh';
 export * from './session-validation';
 export * from './utils';

--- a/libs/fides-auth/src/oauth-logging.test.ts
+++ b/libs/fides-auth/src/oauth-logging.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getOAuthConfigLogContext,
+  getOAuthErrorLogContext,
+} from './oauth-logging';
+import type { OAuthConfig } from './oauth';
+
+const baseConfig: OAuthConfig = {
+  issuer: 'https://issuer.example.com',
+  clientId: 'client-123',
+  clientSecret: 'super-secret',
+  redirect_uri: 'https://app.example.com/callback',
+  scope: 'openid profile',
+};
+
+describe('getOAuthConfigLogContext', () => {
+  it('returns log-safe fields and excludes clientSecret', () => {
+    const ctx = getOAuthConfigLogContext(baseConfig);
+
+    expect(ctx).toEqual({
+      clientId: 'client-123',
+      issuer: 'https://issuer.example.com',
+      redirectUri: 'https://app.example.com/callback',
+      scope: 'openid profile',
+      usePar: false,
+    });
+    expect(ctx).not.toHaveProperty('clientSecret');
+  });
+
+  it('reflects usePar when set', () => {
+    const ctx = getOAuthConfigLogContext({ ...baseConfig, usePar: true });
+    expect(ctx.usePar).toBe(true);
+  });
+});
+
+describe('getOAuthErrorLogContext', () => {
+  it('returns { value } for non-object errors', () => {
+    expect(getOAuthErrorLogContext('boom')).toEqual({ value: 'boom' });
+    expect(getOAuthErrorLogContext(null)).toEqual({ value: null });
+    expect(getOAuthErrorLogContext(42)).toEqual({ value: 42 });
+  });
+
+  it('extracts standard OAuth error fields', () => {
+    const err = {
+      code: 'OAUTH_RESPONSE_BODY_ERROR',
+      error: 'invalid_grant',
+      error_description: 'refresh token expired',
+      message: 'oauth error',
+      name: 'ResponseBodyError',
+      status: 400,
+    };
+
+    expect(getOAuthErrorLogContext(err)).toEqual({
+      code: 'OAUTH_RESPONSE_BODY_ERROR',
+      error: 'invalid_grant',
+      errorDescription: 'refresh token expired',
+      message: 'oauth error',
+      name: 'ResponseBodyError',
+      status: 400,
+      causeMessage: undefined,
+      causeName: undefined,
+    });
+  });
+
+  it('reads cause message and name when present', () => {
+    const err = {
+      message: 'wrapped',
+      cause: { message: 'underlying', name: 'TypeError' },
+    };
+
+    const ctx = getOAuthErrorLogContext(err);
+    expect(ctx.causeMessage).toBe('underlying');
+    expect(ctx.causeName).toBe('TypeError');
+  });
+
+  it('falls back to cause for code/error/error_description when missing on top-level', () => {
+    const err = {
+      message: 'wrapped',
+      cause: {
+        code: 'OAUTH_RESPONSE_BODY_ERROR',
+        error: 'invalid_grant',
+        error_description: 'refresh token expired',
+        message: 'underlying',
+      },
+    };
+
+    const ctx = getOAuthErrorLogContext(err);
+    expect(ctx.code).toBe('OAUTH_RESPONSE_BODY_ERROR');
+    expect(ctx.error).toBe('invalid_grant');
+    expect(ctx.errorDescription).toBe('refresh token expired');
+    expect(ctx.causeMessage).toBe('underlying');
+  });
+
+  it('prefers top-level OAuth fields over cause when both are present', () => {
+    const err = {
+      code: 'TOP_CODE',
+      error: 'top_error',
+      error_description: 'top description',
+      cause: {
+        code: 'CAUSE_CODE',
+        error: 'cause_error',
+        error_description: 'cause description',
+      },
+    };
+
+    const ctx = getOAuthErrorLogContext(err);
+    expect(ctx.code).toBe('TOP_CODE');
+    expect(ctx.error).toBe('top_error');
+    expect(ctx.errorDescription).toBe('top description');
+  });
+
+  it('ignores wrong-typed properties without throwing', () => {
+    const err = {
+      code: 123,
+      error: null,
+      status: 'not-a-number',
+      cause: 'not-an-object',
+    };
+
+    const ctx = getOAuthErrorLogContext(err);
+    expect(ctx.code).toBeUndefined();
+    expect(ctx.error).toBeUndefined();
+    expect(ctx.status).toBeUndefined();
+    expect(ctx.causeMessage).toBeUndefined();
+  });
+});

--- a/libs/fides-auth/src/oauth-logging.ts
+++ b/libs/fides-auth/src/oauth-logging.ts
@@ -1,0 +1,62 @@
+import type { OAuthConfig } from './oauth';
+
+/**
+ * Returns a structured, log-safe context describing an `OAuthConfig`.
+ *
+ * Excludes `clientSecret`. Use this to attach provider configuration to log
+ * lines for debugging OAuth/OIDC flows without leaking credentials.
+ */
+export function getOAuthConfigLogContext(config: OAuthConfig) {
+  return {
+    clientId: config.clientId,
+    issuer: config.issuer,
+    redirectUri: config.redirect_uri,
+    scope: config.scope,
+    usePar: config.usePar ?? false,
+  };
+}
+
+/**
+ * Returns a structured log context for an unknown OAuth-related error.
+ *
+ * `oauth4webapi` (used via `openid-client`) wraps OAuth response errors. The
+ * original OAuth response (`{error, error_description, ...}`) usually lives
+ * either on the error itself or on `cause`.
+ *
+ * @see https://github.com/panva/oauth4webapi/blob/main/docs/classes/ResponseBodyError.md
+ */
+export function getOAuthErrorLogContext(error: unknown) {
+  if (typeof error !== 'object' || error === null) {
+    return { value: error };
+  }
+
+  const candidate = error as Record<string, unknown>;
+  const cause =
+    typeof candidate.cause === 'object' && candidate.cause !== null
+      ? (candidate.cause as Record<string, unknown>)
+      : null;
+
+  // OAuth-specific fields (code/error/error_description) may live either on
+  // the error itself or on `cause` depending on how oauth4webapi wraps the
+  // response. Prefer the top-level value but fall back to `cause`.
+  return {
+    code: stringProp(candidate, 'code') ?? (cause ? stringProp(cause, 'code') : undefined),
+    error: stringProp(candidate, 'error') ?? (cause ? stringProp(cause, 'error') : undefined),
+    errorDescription:
+      stringProp(candidate, 'error_description') ??
+      (cause ? stringProp(cause, 'error_description') : undefined),
+    message: stringProp(candidate, 'message'),
+    name: stringProp(candidate, 'name'),
+    status: numberProp(candidate, 'status'),
+    causeMessage: cause ? stringProp(cause, 'message') : undefined,
+    causeName: cause ? stringProp(cause, 'name') : undefined,
+  };
+}
+
+function stringProp(value: Record<string, unknown>, key: string): string | undefined {
+  return typeof value[key] === 'string' ? (value[key] as string) : undefined;
+}
+
+function numberProp(value: Record<string, unknown>, key: string): number | undefined {
+  return typeof value[key] === 'number' ? (value[key] as number) : undefined;
+}

--- a/libs/fides-auth/src/oauth.ts
+++ b/libs/fides-auth/src/oauth.ts
@@ -3,6 +3,7 @@ import { decodeJwt } from 'jose';
 import * as openid from 'openid-client';
 
 import { createLogger } from './logger';
+import { getOAuthErrorLogContext } from './oauth-logging';
 import type { Session } from './types';
 
 const logger = createLogger({ namespace: 'fides-auth:oauth' });
@@ -67,17 +68,16 @@ export async function refreshAccessToken(
 
     return tokens;
   } catch (error) {
-    // Check if this is an expected invalid_grant error (expired/invalid refresh token)
-    const err = error as { code?: string; error?: string; error_description?: string; };
-    const isInvalidGrant = err?.code === 'OAUTH_RESPONSE_BODY_ERROR' && err?.error === 'invalid_grant';
+    const errorContext = getOAuthErrorLogContext(error);
+    const isInvalidGrant =
+      errorContext.code === 'OAUTH_RESPONSE_BODY_ERROR' && errorContext.error === 'invalid_grant';
 
     if (isInvalidGrant) {
       // Most often the refresh token has expired - log at info level
-      logger.info({
-        error: err.error,
-        error_description: err.error_description,
-        issuer: oAuthConfig.issuer
-      }, 'Token refresh failed - refresh token expired or invalid');
+      logger.info(
+        { ...errorContext, issuer: oAuthConfig.issuer },
+        'Token refresh failed - refresh token expired or invalid',
+      );
     } else {
       // Unexpected error - log at error level
       logger.error({ error, issuer: oAuthConfig.issuer }, 'Token refresh failed');

--- a/libs/fides-auth/src/session-refresh.ts
+++ b/libs/fides-auth/src/session-refresh.ts
@@ -1,5 +1,6 @@
 import { createLogger } from './logger';
 import { OAuthConfig, refreshAccessToken } from "./oauth";
+import { getOAuthErrorLogContext } from './oauth-logging';
 import { CreateSessionOptions, Session } from "./types";
 
 const logger = createLogger({ namespace: 'fides-auth:session-refresh' });
@@ -49,15 +50,16 @@ export const refreshSession = async (
     return updatedSession;
   } catch (error) {
     // Check if this is an expected invalid_grant error
-    const err = error as { code?: string; error?: string; };
-    const isInvalidGrant = err?.code === 'OAUTH_RESPONSE_BODY_ERROR' && err?.error === 'invalid_grant';
+    const errorContext = getOAuthErrorLogContext(error);
+    const isInvalidGrant =
+      errorContext.code === 'OAUTH_RESPONSE_BODY_ERROR' && errorContext.error === 'invalid_grant';
 
     if (isInvalidGrant) {
       // Expected error during logout/session expiry - log at info level
       logger.info('Session refresh failed - refresh token expired or invalid');
     } else {
       // Unexpected error - log at error level
-      logger.error({ error }, 'Session refresh failed');
+      logger.error({ error: errorContext }, 'Session refresh failed');
     }
 
     throw error;

--- a/libs/fides-auth/vite.config.ts
+++ b/libs/fides-auth/vite.config.ts
@@ -8,6 +8,7 @@ export default defineVanillaLibConfig({
     'session-validation': 'src/session-validation.ts',
     oauth: 'src/oauth.ts',
     'oauth-browser': 'src/oauth-browser.ts',
+    'oauth-logging': 'src/oauth-logging.ts',
     'silent-login': 'src/silent-login.ts',
     utils: 'src/utils.ts',
     types: 'src/types.ts',


### PR DESCRIPTION
Introduce new logging helpers for OAuth configuration and error handling. The changes include a log-safe view of OAuthConfig that excludes sensitive information and structured logging for OAuth-related errors, enhancing the debugging process without exposing credentials. Refactor existing token refresh logic to utilize these new helpers for improved error logging.