### PR TITLE
Add type-to-confirm gate to AlertDialog

### DIFF
--- a/.changeset/alert-dialog-type-to-confirm.md
+++ b/.changeset/alert-dialog-type-to-confirm.md
@@ -1,0 +1,25 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add a type-to-confirm gate to `AlertDialog`. Set `confirmText` and the primary button stays disabled until the user types that exact phrase (whitespace trimmed, case-sensitive). Pair `confirmLabel` with it for a localised instruction.
+
+```tsx
+<AlertDialog
+  variant="destructive"
+  isOpen={open}
+  onClose={() => setOpen(false)}
+  onPrimaryAction={handleDelete}
+  title="Delete event?"
+  primaryActionLabel="Delete event"
+  cancelLabel="Cancel"
+  confirmText="delete"
+  confirmLabel='Type "delete" to confirm'
+>
+  This will permanently remove the event and all registrations.
+</AlertDialog>
+```
+
+Reserve for irreversible actions where a single misclick is too easy. When `confirmText` is set the input is auto-focused on open (instead of the cancel button), and pressing Enter while the phrase matches triggers the primary action.
+
+Also: the `Input` primitive now forwards `ref` so callers can imperatively focus it.

--- a/libs/ratio-ui/src/forms/Input/Input.tsx
+++ b/libs/ratio-ui/src/forms/Input/Input.tsx
@@ -1,5 +1,5 @@
 import { Input as AriaInput } from 'react-aria-components';
-import type { ComponentProps } from 'react';
+import type { ComponentPropsWithRef } from 'react';
 
 /**
  * Default input styles for React Aria components
@@ -39,6 +39,6 @@ export const inputStyles = {
  * </SearchField>
  * ```
  */
-export function Input({ className, ...props }: ComponentProps<typeof AriaInput>) {
-  return <AriaInput className={className ?? inputStyles.default} {...props} />;
+export function Input({ className, ref, ...props }: ComponentPropsWithRef<typeof AriaInput>) {
+  return <AriaInput ref={ref} className={className ?? inputStyles.default} {...props} />;
 }

--- a/libs/ratio-ui/src/layout/Dialog/AlertDialog.stories.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/AlertDialog.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
+import { expect, fn, userEvent, within } from 'storybook/test';
 import { AlertDialog, AlertDialogProps, AlertDialogVariant } from './AlertDialog';
 import { Button } from '../../core/Button';
 
@@ -150,5 +151,69 @@ export const AutoFocusCancel: Story = {
     cancelLabel: 'Cancel',
     secondaryActionLabel: undefined,
     autoFocusButton: 'cancel',
+  },
+};
+
+/**
+ * Type-to-confirm gate. The primary button stays disabled until the user
+ * types the exact `confirmText` phrase (whitespace trimmed, case-sensitive).
+ * Reserve for irreversible destructive actions where a single misclick is
+ * too easy.
+ */
+export const TypeToConfirm: Story = {
+  render: args => <StatefulAlertDialog {...args} />,
+  args: {
+    variant: 'destructive',
+    title: 'Delete event?',
+    children: 'This will permanently remove the event and all registrations. This cannot be undone.',
+    primaryActionLabel: 'Delete event',
+    cancelLabel: 'Cancel',
+    secondaryActionLabel: undefined,
+    confirmText: 'delete',
+    confirmLabel: 'Type "delete" to confirm',
+  },
+};
+
+const onPrimarySpy = fn();
+
+export const TypeToConfirmPlay: Story = {
+  name: 'TypeToConfirm — play test',
+  render: () => (
+    <AlertDialog
+      isOpen
+      onClose={fn()}
+      onPrimaryAction={onPrimarySpy}
+      variant="destructive"
+      title="Delete event?"
+      primaryActionLabel="Delete event"
+      cancelLabel="Cancel"
+      confirmText="delete"
+      confirmLabel='Type "delete" to confirm'
+    >
+      Permanently remove the event.
+    </AlertDialog>
+  ),
+  play: async ({ canvasElement }) => {
+    onPrimarySpy.mockClear();
+    // The dialog renders via React Aria's portal — reach into the body, not
+    // the canvas, since the Modal escapes the story root.
+    const screen = within(canvasElement.ownerDocument.body);
+
+    const primary = await screen.findByRole('button', { name: 'Delete event' });
+    await expect(primary).toBeDisabled();
+
+    const input = await screen.findByLabelText('Type "delete" to confirm');
+
+    // Wrong phrase keeps it disabled — case-sensitive match.
+    await userEvent.type(input, 'DELETE');
+    await expect(primary).toBeDisabled();
+
+    // Right phrase enables it (after clearing the wrong one).
+    await userEvent.clear(input);
+    await userEvent.type(input, 'delete');
+    await expect(primary).toBeEnabled();
+
+    await userEvent.click(primary);
+    await expect(onPrimarySpy).toHaveBeenCalledTimes(1);
   },
 };

--- a/libs/ratio-ui/src/layout/Dialog/AlertDialog.tsx
+++ b/libs/ratio-ui/src/layout/Dialog/AlertDialog.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useEffect, useId, useRef, useState } from 'react';
 import { Button } from '../../core/Button';
+import { Input } from '../../forms/Input/Input';
 import { Dialog, DialogProps, DialogSize } from './Dialog';
 
 export type AlertDialogVariant =
@@ -29,6 +30,23 @@ export interface AlertDialogProps {
 
   autoFocusButton?: AlertDialogAutoFocus;
 
+  /**
+   * Type-to-confirm gate. Renders an input below the message; the
+   * primary action stays disabled until the user types this exact
+   * phrase. Comparison trims whitespace from both sides and is
+   * case-sensitive. An empty or whitespace-only value is treated as
+   * "no gate", since a blank phrase couldn't meaningfully gate anything.
+   * Reserve for high-risk destructive actions where a click is too easy.
+   */
+  confirmText?: string;
+  /**
+   * Visible label rendered above the confirm input, referenced by
+   * `aria-labelledby` so non-text ReactNode content stays the source of
+   * the accessible name. When omitted, an English `aria-label` fallback
+   * is used — pass this prop to localise the instruction.
+   */
+  confirmLabel?: ReactNode;
+
   onPrimaryAction: () => void;
   onSecondaryAction?: () => void;
   onCancel?: () => void;
@@ -56,6 +74,8 @@ export const AlertDialog = ({
   isPrimaryActionDisabled,
   isSecondaryActionDisabled,
   autoFocusButton,
+  confirmText,
+  confirmLabel,
   onPrimaryAction,
   onSecondaryAction,
   onCancel,
@@ -63,17 +83,38 @@ export const AlertDialog = ({
   const primaryRef = useRef<HTMLButtonElement>(null);
   const secondaryRef = useRef<HTMLButtonElement>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
+  const confirmInputRef = useRef<HTMLInputElement>(null);
+  const confirmInputId = useId();
+  const confirmLabelId = useId();
+
+  // Trim both sides so leading/trailing whitespace in either the consumer's
+  // `confirmText` or the user's input doesn't cause a phantom mismatch. An
+  // empty/whitespace-only `confirmText` is treated as "no gate" — a blank
+  // phrase couldn't meaningfully gate anything.
+  const trimmedConfirmText = confirmText?.trim();
+  const gateActive = trimmedConfirmText !== undefined && trimmedConfirmText !== '';
+  const [confirmInput, setConfirmInput] = useState('');
+  const confirmMismatch = gateActive && confirmInput.trim() !== trimmedConfirmText;
+  const primaryDisabled = isPrimaryActionDisabled || confirmMismatch;
+  const hasConfirmLabel = Boolean(confirmLabel);
+
+  // Reset the typed phrase whenever the dialog (re-)opens so reusing the
+  // same dialog instance doesn't leak state between confirmations.
+  useEffect(() => {
+    if (isOpen) setConfirmInput('');
+  }, [isOpen]);
 
   // Default focus: cancel for destructive/error (safer), primary otherwise.
   // `autoFocusButton` overrides the heuristic; either way we fall back to
   // the first rendered + enabled action so we never try to focus a button
-  // that doesn't exist or can't receive focus.
+  // that doesn't exist or can't receive focus. When `confirmText` is set
+  // we focus the input instead — the user has to type before they can act.
   const desiredFocus: AlertDialogAutoFocus =
     autoFocusButton ??
     (variant === 'destructive' || variant === 'error' ? 'cancel' : 'primary');
 
   const isFocusable: Record<AlertDialogAutoFocus, boolean> = {
-    primary: !isPrimaryActionDisabled,
+    primary: !primaryDisabled,
     secondary: Boolean(secondaryActionLabel) && !isSecondaryActionDisabled,
     cancel: Boolean(cancelLabel),
   };
@@ -87,10 +128,15 @@ export const AlertDialog = ({
   const focusTarget = fallbackOrder.find(t => isFocusable[t]);
 
   useEffect(() => {
-    if (!isOpen || !focusTarget) return;
+    if (!isOpen) return;
+    if (gateActive) {
+      confirmInputRef.current?.focus();
+      return;
+    }
+    if (!focusTarget) return;
     const refs = { primary: primaryRef, secondary: secondaryRef, cancel: cancelRef };
     refs[focusTarget].current?.focus();
-  }, [isOpen, focusTarget]);
+  }, [isOpen, focusTarget, gateActive]);
 
   const handleCancel = () => {
     onCancel?.();
@@ -98,6 +144,7 @@ export const AlertDialog = ({
   };
 
   const handlePrimary = () => {
+    if (primaryDisabled) return;
     onPrimaryAction();
     onClose();
   };
@@ -115,10 +162,46 @@ export const AlertDialog = ({
     role: 'alertdialog',
   };
 
+  const fallbackConfirmLabel = gateActive ? `Type "${trimmedConfirmText}" to confirm` : undefined;
+
   return (
     <Dialog {...dialogProps}>
       <Dialog.Heading>{title}</Dialog.Heading>
-      <Dialog.Content>{children}</Dialog.Content>
+      <Dialog.Content>
+        {children}
+        {gateActive && (
+          <div className="mt-4 flex flex-col gap-2">
+            {hasConfirmLabel && (
+              <label
+                id={confirmLabelId}
+                htmlFor={confirmInputId}
+                className="text-sm text-(--text)"
+              >
+                {confirmLabel}
+              </label>
+            )}
+            <Input
+              ref={confirmInputRef}
+              id={confirmInputId}
+              value={confirmInput}
+              onChange={e => setConfirmInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter' && !confirmMismatch && !isPrimaryActionDisabled) {
+                  e.preventDefault();
+                  handlePrimary();
+                }
+              }}
+              placeholder={trimmedConfirmText}
+              autoComplete="off"
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              aria-labelledby={hasConfirmLabel ? confirmLabelId : undefined}
+              aria-label={hasConfirmLabel ? undefined : fallbackConfirmLabel}
+            />
+          </div>
+        )}
+      </Dialog.Content>
       <Dialog.Footer>
         {cancelLabel && (
           <Button ref={cancelRef} variant="secondary" onClick={handleCancel}>
@@ -138,7 +221,7 @@ export const AlertDialog = ({
         <Button
           ref={primaryRef}
           variant={variantPrimaryStyle[variant]}
-          disabled={isPrimaryActionDisabled}
+          disabled={primaryDisabled}
           onClick={handlePrimary}
         >
           {primaryActionLabel}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1168,8 +1168,8 @@ importers:
   libs/lustro-search:
     dependencies:
       '@eventuras/ratio-ui':
-        specifier: workspace:^
-        version: link:../ratio-ui
+        specifier: '>=1'
+        version: 1.3.0(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.61.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)
       '@orama/orama':
         specifier: ^3.1.18
         version: 3.1.18
@@ -3086,6 +3086,30 @@ packages:
   '@eslint/plugin-kit@0.7.1':
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eventuras/logger@0.8.0':
+    resolution: {integrity: sha512-0Aq8aduQ52BJ5GyXVjhQHEMVKCdtvOyyepNAw2xNXFGx4358j4k9onZZRutn8j7WSTJos9yaJKB1LKBiHGnPog==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/api-logs': '>=0.200.0 <1.0.0'
+      '@opentelemetry/instrumentation-pino': '>=0.50.0 <1.0.0'
+      '@opentelemetry/sdk-logs': '>=0.200.0 <1.0.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/api-logs':
+        optional: true
+      '@opentelemetry/instrumentation-pino':
+        optional: true
+      '@opentelemetry/sdk-logs':
+        optional: true
+
+  '@eventuras/ratio-ui@1.3.0':
+    resolution: {integrity: sha512-JuS58esAJOppN3ZJfVwT1glIaK2PXQ0UKx1kQgFEvfpG0wdBmdzbXvfa0Qn5cMWsJ+y76x2LeiWw/ct4oy3gtw==}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
 
   '@exodus/bytes@1.15.0':
     resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
@@ -5149,6 +5173,12 @@ packages:
 
   '@react-aria/overlays@3.31.2':
     resolution: {integrity: sha512-78HYI08r6LvcfD34gyv19ArRIjy1qxOKuXl/jYnjLDyQzD4pVb634IQWcm0zt10RdKgyuH6HTqvuDOgZTLet7Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/overlays@3.32.0':
+    resolution: {integrity: sha512-H9meBB14/M0bDwk8gZl8Fu8bwZN2El9LDlk5cNkgAozbEiRuQvTFOeE3RoP6XI6bwEnSBvb0ovPmx3/kNyOehQ==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -15425,6 +15455,37 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
+  '@eventuras/logger@0.8.0(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.61.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      pino: 10.3.1
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.215.0
+      '@opentelemetry/instrumentation-pino': 0.61.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
+
+  '@eventuras/ratio-ui@1.3.0(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.61.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.2.4)':
+    dependencies:
+      '@eventuras/logger': 0.8.0(@opentelemetry/api-logs@0.215.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.61.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.215.0(@opentelemetry/api@1.9.1))
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@react-aria/overlays': 3.32.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-stately/data': 3.16.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      clsx: 2.1.1
+      lucide-react: 1.11.0(react@19.2.5)
+      react: 19.2.5
+      react-aria-components: 1.17.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
+      react-stately: 3.46.0(react@19.2.5)
+      tailwind-merge: 3.5.0
+      tailwindcss-react-aria-components: 2.1.0(tailwindcss@4.2.4)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/api-logs'
+      - '@opentelemetry/instrumentation-pino'
+      - '@opentelemetry/sdk-logs'
+      - tailwindcss
+
   '@exodus/bytes@1.15.0': {}
 
   '@faceless-ui/modal@3.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
@@ -17990,9 +18051,9 @@ snapshots:
 
   '@react-aria/i18n@3.12.16(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
-      '@internationalized/date': 3.12.0
+      '@internationalized/date': 3.12.1
       '@internationalized/message': 3.1.8
-      '@internationalized/number': 3.6.5
+      '@internationalized/number': 3.6.6
       '@internationalized/string': 3.2.7
       '@react-aria/ssr': 3.9.10(react@19.2.4)
       '@react-aria/utils': 3.33.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -18218,6 +18279,13 @@ snapshots:
       '@swc/helpers': 0.5.21
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  '@react-aria/overlays@3.32.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@swc/helpers': 0.5.21
+      react: 19.2.5
+      react-aria: 3.48.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react-dom: 19.2.5(react@19.2.5)
 
   '@react-aria/progress@3.4.27(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -18993,13 +19061,13 @@ snapshots:
 
   '@react-types/calendar@3.8.0(react@19.2.4)':
     dependencies:
-      '@internationalized/date': 3.12.0
+      '@internationalized/date': 3.12.1
       '@react-types/shared': 3.33.1(react@19.2.4)
       react: 19.2.4
 
   '@react-types/calendar@3.8.1(react@19.2.4)':
     dependencies:
-      '@internationalized/date': 3.12.0
+      '@internationalized/date': 3.12.1
       '@react-types/shared': 3.33.1(react@19.2.4)
       react: 19.2.4
 
@@ -19026,7 +19094,7 @@ snapshots:
 
   '@react-types/datepicker@3.13.2(react@19.2.4)':
     dependencies:
-      '@internationalized/date': 3.12.0
+      '@internationalized/date': 3.12.1
       '@react-types/calendar': 3.8.1(react@19.2.4)
       '@react-types/overlays': 3.9.2(react@19.2.4)
       '@react-types/shared': 3.33.1(react@19.2.4)
@@ -19034,7 +19102,7 @@ snapshots:
 
   '@react-types/datepicker@3.13.3(react@19.2.4)':
     dependencies:
-      '@internationalized/date': 3.12.0
+      '@internationalized/date': 3.12.1
       '@react-types/calendar': 3.8.1(react@19.2.4)
       '@react-types/overlays': 3.9.2(react@19.2.4)
       '@react-types/shared': 3.33.1(react@19.2.4)
@@ -22800,7 +22868,7 @@ snapshots:
       eslint: 10.2.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@10.2.0(jiti@2.6.1))
@@ -22835,7 +22903,7 @@ snapshots:
       eslint-config-xo: 0.49.0(eslint@10.2.0(jiti@2.6.1))
       eslint-config-xo-space: 0.35.0(eslint@10.2.0(jiti@2.6.1))
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-jsdoc: 50.8.0(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-mocha: 10.5.0(eslint@10.2.0(jiti@2.6.1))
       eslint-plugin-n: 17.24.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3)
@@ -22891,7 +22959,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -22906,7 +22974,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -22944,7 +23012,7 @@ snapshots:
       eslint-utils: 2.1.0
       regexpp: 3.2.0
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -22973,7 +23041,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.2.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)))(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -24481,7 +24549,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.6.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
Introduce a type-to-confirm feature in the AlertDialog component, requiring users to input a specific phrase to enable the primary action. This enhancement aims to prevent accidental confirmations for irreversible actions. The input field is auto-focused when the dialog opens, and the primary button remains disabled until the correct phrase is typed. Additionally, the Input primitive now forwards refs for imperative focus control.