### PR TITLE
refactor(ratio-ui)!: replace Menu menuLabel with Menu.Trigger slot

### DIFF
--- a/.changeset/menu-trigger-slot.md
+++ b/.changeset/menu-trigger-slot.md
@@ -1,0 +1,25 @@
+---
+"@eventuras/ratio-ui": major
+---
+
+**Breaking:** Replace the `Menu` `menuLabel: string` prop with a `Menu.Trigger` compound subcomponent. The previous API forced a single hardcoded pill-shaped trigger; the new slot lets consumers compose any content (avatar + name, icon-only, custom layouts) and override styling via `className`.
+
+```tsx
+// Before
+<Menu menuLabel={user.name}>
+  <Menu.Link href="/profile">Profile</Menu.Link>
+</Menu>
+
+// After
+<Menu>
+  <Menu.Trigger>
+    {user.name}
+    <Menu.Chevron />
+  </Menu.Trigger>
+  <Menu.Link href="/profile">Profile</Menu.Link>
+</Menu>
+```
+
+`Menu.Trigger` keeps the previous default styling (rounded-full primary pill) so flat string migrations stay visually identical — the chevron now ships as `Menu.Chevron` so consumers building avatar/icon triggers can omit it.
+
+This is the only structural change to `Menu` in this release. Future additions (`Menu.Header`, `Menu.Section`, item icon/badge slots, danger variant) will be additive and ship in a later release without further breaking changes.

--- a/apps/web/src/components/eventuras/UserMenu.tsx
+++ b/apps/web/src/components/eventuras/UserMenu.tsx
@@ -85,7 +85,16 @@ function UserDropdownMenu({
   userName: string;
   isAdmin: boolean;
   hasWarning: boolean;
-  translations: Pick<UserMenuTranslations, 'userLabel' | 'accountLabel' | 'adminLabel' | 'logoutLabel' | 'loggingOutLabel' | 'lightThemeLabel' | 'darkThemeLabel'>;
+  translations: Pick<
+    UserMenuTranslations,
+    | 'userLabel'
+    | 'accountLabel'
+    | 'adminLabel'
+    | 'logoutLabel'
+    | 'loggingOutLabel'
+    | 'lightThemeLabel'
+    | 'darkThemeLabel'
+  >;
   onLogout: () => void;
 }>) {
   const { theme, setTheme } = useTheme();
@@ -102,7 +111,11 @@ function UserDropdownMenu({
   const menuLabel = hasWarning ? `⚠️ ${userName}` : userName;
 
   return (
-    <Menu menuLabel={menuLabel}>
+    <Menu>
+      <Menu.Trigger>
+        {menuLabel}
+        <Menu.Chevron />
+      </Menu.Trigger>
       <Menu.Link testId="profile-link" href="/user">
         {translations.userLabel}
       </Menu.Link>

--- a/libs/ratio-ui/src/core/Menu/Menu.stories.tsx
+++ b/libs/ratio-ui/src/core/Menu/Menu.stories.tsx
@@ -6,17 +6,18 @@ import { fn } from 'storybook/test';
 const meta: Meta<typeof Menu> = {
   component: Menu,
   tags: ['autodocs'],
-  args: {
-    menuLabel: 'Menu',
-  },
 };
 
 export default meta;
 
 type MenuStory = StoryFn<MenuProps>;
 
-export const Playground: MenuStory = args => (
-  <Menu {...args}>
+export const Playground: MenuStory = () => (
+  <Menu>
+    <Menu.Trigger>
+      Menu
+      <Menu.Chevron />
+    </Menu.Trigger>
     <Menu.Link href="#item1">Menu Item 1</Menu.Link>
     <Menu.Link href="#item2">Menu Item 2</Menu.Link>
     <Menu.Link href="#item3">Menu Item 3</Menu.Link>
@@ -24,7 +25,11 @@ export const Playground: MenuStory = args => (
 );
 
 export const WithLinks: MenuStory = () => (
-  <Menu menuLabel="Navigation">
+  <Menu>
+    <Menu.Trigger>
+      Navigation
+      <Menu.Chevron />
+    </Menu.Trigger>
     <Menu.Link href="/home">Home</Menu.Link>
     <Menu.Link href="/about">About</Menu.Link>
     <Menu.Link href="/services">Services</Menu.Link>
@@ -33,7 +38,11 @@ export const WithLinks: MenuStory = () => (
 );
 
 export const WithButtons: MenuStory = () => (
-  <Menu menuLabel="Actions">
+  <Menu>
+    <Menu.Trigger>
+      Actions
+      <Menu.Chevron />
+    </Menu.Trigger>
     <Menu.Button id="action1" onClick={fn()}>
       Action 1
     </Menu.Button>
@@ -47,7 +56,11 @@ export const WithButtons: MenuStory = () => (
 );
 
 export const Mixed: MenuStory = () => (
-  <Menu menuLabel="Options">
+  <Menu>
+    <Menu.Trigger>
+      Options
+      <Menu.Chevron />
+    </Menu.Trigger>
     <Menu.Link href="/profile">View Profile</Menu.Link>
     <Menu.Link href="/settings">Settings</Menu.Link>
     <Menu.Button id="logout" onClick={() => console.log('Logout clicked')}>
@@ -57,7 +70,11 @@ export const Mixed: MenuStory = () => (
 );
 
 export const UserMenu: MenuStory = () => (
-  <Menu menuLabel="User Menu">
+  <Menu>
+    <Menu.Trigger>
+      User Menu
+      <Menu.Chevron />
+    </Menu.Trigger>
     <Menu.Link href="/dashboard">Dashboard</Menu.Link>
     <Menu.Link href="/profile">My Profile</Menu.Link>
     <Menu.Link href="/notifications">Notifications</Menu.Link>
@@ -69,7 +86,11 @@ export const UserMenu: MenuStory = () => (
 );
 
 export const AdminMenu: MenuStory = () => (
-  <Menu menuLabel="Admin">
+  <Menu>
+    <Menu.Trigger>
+      Admin
+      <Menu.Chevron />
+    </Menu.Trigger>
     <Menu.Link href="/admin">Admin Dashboard</Menu.Link>
     <Menu.Link href="/admin/users">Manage Users</Menu.Link>
     <Menu.Link href="/admin/events">Manage Events</Menu.Link>
@@ -81,7 +102,11 @@ export const AdminMenu: MenuStory = () => (
 export const WithThemeToggle: MenuStory = () => {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   return (
-    <Menu menuLabel="user@example.com">
+    <Menu>
+      <Menu.Trigger>
+        user@example.com
+        <Menu.Chevron />
+      </Menu.Trigger>
       <Menu.Link href="/profile">My Profile</Menu.Link>
       <Menu.Link href="/account">Account</Menu.Link>
       <Menu.ThemeToggle theme={theme} onThemeChange={setTheme} />
@@ -91,3 +116,27 @@ export const WithThemeToggle: MenuStory = () => {
     </Menu>
   );
 };
+
+/**
+ * A custom trigger — pass any content + className to override the default
+ * pill. Useful for avatar-style triggers or icon-only buttons.
+ */
+export const CustomTrigger: MenuStory = () => (
+  <Menu>
+    <Menu.Trigger className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border-2 bg-card text-(--text) hover:border-(--primary) transition-colors">
+      <span
+        aria-hidden="true"
+        className="w-7 h-7 rounded-full bg-(--primary)/20 text-(--primary) font-serif italic text-sm flex items-center justify-center"
+      >
+        ol
+      </span>
+      <span className="text-sm">losvik@gmail.com</span>
+      <Menu.Chevron className="ml-0 h-3.5 w-3.5 text-(--text-muted)" />
+    </Menu.Trigger>
+    <Menu.Link href="/user">My profile</Menu.Link>
+    <Menu.Link href="/user/account">Account</Menu.Link>
+    <Menu.Button id="custom-logout" onClick={() => console.log('Logout')}>
+      Log out
+    </Menu.Button>
+  </Menu>
+);

--- a/libs/ratio-ui/src/core/Menu/Menu.tsx
+++ b/libs/ratio-ui/src/core/Menu/Menu.tsx
@@ -1,13 +1,23 @@
-import { ReactNode, createContext, useContext, useEffect, useId, useRef } from 'react';
+import {
+  Children,
+  isValidElement,
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useId,
+  useRef,
+} from 'react';
 import {
   Button as AriaButton,
   Menu as AriaMenu,
   MenuItem,
   MenuItemProps,
-  MenuTrigger,
+  MenuTrigger as AriaMenuTrigger,
   Popover,
 } from 'react-aria-components';
 import { ChevronDown, Sun, Moon } from '../../icons';
+import { cn } from '../../utils/cn';
 
 const styles = {
   popover:
@@ -15,6 +25,8 @@ const styles = {
   menuItemsList: 'bg-card focus:outline-hidden',
   menuItem:
     'cursor-pointer group flex w-full items-center px-2 py-3 border-b border-border-1 last:border-b-0 hover:bg-card-hover text-(--text)',
+  triggerDefault:
+    'inline-flex items-center gap-2 border border-transparent font-bold bg-(--primary) hover:opacity-90 text-(--text-on-primary) rounded-full px-4 py-1 m-1 transition-all duration-500 transform ease-in-out active:scale-110 hover:shadow-sm',
 };
 
 type MenuActionsApi = {
@@ -25,6 +37,28 @@ const MenuActionsContext = createContext<MenuActionsApi>({
   register: () => {},
   unregister: () => {},
 });
+
+export type MenuTriggerProps = {
+  children: ReactNode;
+  /**
+   * Override the default pill-shaped primary button styling. Pass any
+   * Tailwind / utility classes to fully restyle the trigger (e.g. an
+   * avatar pill or icon-only button). When omitted, the default
+   * `--primary` rounded-full button is used.
+   */
+  className?: string;
+  testId?: string;
+};
+
+const MenuTrigger = ({ children, className, testId }: MenuTriggerProps) => (
+  <AriaButton
+    data-testid={testId ?? 'logged-in-menu-button'}
+    className={className ?? styles.triggerDefault}
+  >
+    {children}
+  </AriaButton>
+);
+MenuTrigger.displayName = 'Menu.Trigger';
 
 export type MenuLinkProps = {
   href: string;
@@ -39,7 +73,6 @@ const MenuLink = (props: MenuLinkProps & MenuItemProps) => (
 );
 
 export type MenuProps = {
-  menuLabel: string;
   children: ReactNode;
 };
 
@@ -57,7 +90,7 @@ export type MenuThemeToggleProps = {
   darkLabel?: string;
 };
 
-const Menu = (props: MenuProps) => {
+const Menu = ({ children }: MenuProps) => {
   const actionsRef = useRef(new Map<string, () => void>());
 
   const api = useRef<MenuActionsApi>({
@@ -65,15 +98,31 @@ const Menu = (props: MenuProps) => {
     unregister: (id) => actionsRef.current.delete(id),
   }).current;
 
+  // Split children: the first <Menu.Trigger> becomes the React Aria
+  // button, everything else lives inside the popover menu list. This
+  // keeps the compound API ergonomic while preserving Aria's required
+  // shape (button + popover as direct siblings of MenuTrigger).
+  let trigger: ReactNode = null;
+  const items: ReactNode[] = [];
+  for (const child of Children.toArray(children)) {
+    if (isValidElement(child) && child.type === MenuTrigger) {
+      if (trigger === null) {
+        trigger = child;
+      }
+      // Silently ignore additional <Menu.Trigger>s — first wins.
+    } else {
+      items.push(child);
+    }
+  }
+  if (trigger === null) {
+    throw new Error(
+      'Menu requires a <Menu.Trigger> child. Wrap the trigger label/content in <Menu.Trigger>...</Menu.Trigger>.',
+    );
+  }
+
   return (
-    <MenuTrigger>
-      <AriaButton
-        data-testid="logged-in-menu-button"
-        className="inline-flex items-center gap-2 border border-transparent font-bold bg-(--primary) hover:opacity-90 text-(--text-on-primary) rounded-full px-4 py-1 m-1 transition-all duration-500 transform ease-in-out active:scale-110 hover:shadow-sm"
-      >
-        {props.menuLabel}
-        <ChevronDown aria-hidden="true" className="ml-1 h-5 w-5" />
-      </AriaButton>
+    <AriaMenuTrigger>
+      {trigger}
       <Popover className={styles.popover}>
         <MenuActionsContext.Provider value={api}>
           <AriaMenu
@@ -83,11 +132,11 @@ const Menu = (props: MenuProps) => {
               if (fn) fn();
             }}
           >
-            {props.children}
+            {items}
           </AriaMenu>
         </MenuActionsContext.Provider>
       </Popover>
-    </MenuTrigger>
+    </AriaMenuTrigger>
   );
 };
 
@@ -136,7 +185,19 @@ const MenuThemeToggle = ({
   );
 };
 
+/**
+ * Convenience: the chevron used by the default trigger pattern. Exported
+ * so consumers can drop it into a custom `Menu.Trigger` without having to
+ * reach into `../icons` themselves.
+ */
+const MenuChevron = ({ className }: { className?: string }) => (
+  <ChevronDown aria-hidden="true" className={cn('ml-1 h-5 w-5', className)} />
+);
+MenuChevron.displayName = 'Menu.Chevron';
+
 export default Object.assign(Menu, {
+  Trigger: MenuTrigger,
+  Chevron: MenuChevron,
   Link: MenuLink,
   Button: MenuButton,
   ThemeToggle: MenuThemeToggle,


### PR DESCRIPTION
## Summary

Prep `Menu` for the 2.2 user-menu redesign. The previous \`menuLabel: string\` prop forced a single hardcoded pill-shaped trigger and blocked every modern user-menu pattern (avatar + name, icon-only, custom layouts). Replace it with a \`Menu.Trigger\` compound subcomponent so consumers can compose any content and override styling via \`className\`.

\`\`\`tsx
// Before
<Menu menuLabel={user.name}>
  <Menu.Link href=\"/profile\">Profile</Menu.Link>
</Menu>

// After
<Menu>
  <Menu.Trigger>
    {user.name}
    <Menu.Chevron />
  </Menu.Trigger>
  <Menu.Link href=\"/profile\">Profile</Menu.Link>
</Menu>
\`\`\`

\`Menu.Trigger\` keeps the previous default styling (rounded-full primary pill) so flat string migrations stay visually identical. The chevron now ships as \`Menu.Chevron\` for explicit composition; avatar/icon triggers can omit it.

### Why now

This is the only structural change to \`Menu\` that's hard to add later. The 2.2 user-menu chrome (\`Menu.Header\`, \`Menu.Section\`, item icon / badge / shortcut slots, danger variant, separators, inline switch row) is purely additive and will ship in a later release without further breaking changes.

## Migration

- \`apps/web\` UserMenu — migrated.
- \`Menu.stories.tsx\` — migrated, plus a new \`CustomTrigger\` story showing the avatar pill that 2.2 builds toward.
- \`apps/idem-admin\` UserMenu — does not use ratio-ui's \`Menu\`, no migration needed.

## Test plan

- [x] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui build\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui test\` — 369 passed
- [x] \`apps/web\` typechecks against new Menu API
- [ ] Visual: open Storybook, verify all Menu stories (including CustomTrigger) render and open the popover correctly
- [ ] Visual: web user menu in light + dark mode — confirm the trigger pill, dropdown, theme toggle, and logout all behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)