### PR TITLE
refactor(web): redesign frontpage featured collection + Container px default

### DIFF
--- a/.changeset/container-default-px.md
+++ b/.changeset/container-default-px.md
@@ -1,0 +1,9 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Give `Container` a responsive default horizontal padding (`px-3 sm:px-4 lg:px-6`) so content stops running edge-to-edge on narrow viewports. Consumers that need a different value or none at all can override via `padding` or `paddingX` (any of those, including `paddingX="none"`, suppresses the default).
+
+Before: at viewport widths below the configured `size`, content rendered flush against the screen edge — visually broken on mobile across most apps that compose with `Container`.
+
+After: 12px / 16px / 24px horizontal breathing room kicks in by default. Matches the convention used by Tailwind's `container` utility, MUI, and Chakra.

--- a/.changeset/core-format-compact-date-range.md
+++ b/.changeset/core-format-compact-date-range.md
@@ -1,0 +1,7 @@
+---
+"@eventuras/core": minor
+---
+
+Add `formatCompactDateRange` to `@eventuras/core/datetime` for dense listings — produces uppercased pill-style labels like `"14. SEP"`, `"14.–16. SEP"`, `"30. AUG–2. SEP"`, or `"30. DEC 2026–2. JAN 2027"` depending on whether the range crosses months or years. Returns an empty string when no start date is supplied.
+
+Pairs with the mono caps tile pattern in event tiles, search result rows, related-event lists, and similar dense displays where the existing `formatDateSpan` (`"14.9.2026 - 16.9.2026"`) is too verbose.

--- a/.changeset/section-link-as.md
+++ b/.changeset/section-link-as.md
@@ -1,0 +1,16 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+`Section.Link` now accepts an `as?: React.ElementType` prop so consumers can render through a framework-specific Link component (Next.js, TanStack, etc) instead of the default plain `<a>`. Use this for internal routes to keep client-side navigation and prefetching:
+
+```tsx
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+<Section.Header>
+  <Section.Title>Featured</Section.Title>
+  <Section.Link as={Link} href="/collections/foo">See all</Section.Link>
+</Section.Header>
+```
+
+Default behaviour is unchanged when `as` is omitted.

--- a/apps/web/src/components/event/EventTile.tsx
+++ b/apps/web/src/components/event/EventTile.tsx
@@ -1,0 +1,53 @@
+import { formatCompactDateRange } from '@eventuras/core/datetime';
+import { Card } from '@eventuras/ratio-ui/core/Card';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+import { appConfig } from '@/config.server';
+import { EventDto } from '@/lib/eventuras-sdk';
+
+interface EventTileProps {
+  event: EventDto;
+}
+
+/**
+ * Compact event tile for collection grids and dense listings — date pill,
+ * serif title, optional headline, and place. Pairs with `EventCard` (the
+ * heavier card used standalone). The whole tile is a link via
+ * `linkOverlay` on the title; hover lifts the surface + primary border
+ * via `Card`'s `hoverEffect`.
+ *
+ * Category indicator (the small dot in the design reference) is
+ * intentionally omitted until we have a category-name → token-color
+ * mapping. Re-introduce when that lands.
+ */
+export const EventTile: React.FC<EventTileProps> = ({ event }) => {
+  const dateLabel = formatCompactDateRange(
+    event.dateStart as string | null | undefined,
+    event.dateEnd as string | null | undefined,
+    appConfig.env.DEFAULT_LOCALE as string
+  );
+  const placeLabel = [event.location, event.city].filter(Boolean).join(', ');
+
+  return (
+    <Card padding="sm" radius="lg" border hoverEffect className="flex flex-col gap-2 h-full">
+      {dateLabel && (
+        <span className="font-mono text-xs uppercase tracking-wider text-(--text-subtle) font-semibold">
+          {dateLabel}
+        </span>
+      )}
+      <Link
+        href={`/events/${event.id}/${event.slug ?? ''}`}
+        linkOverlay
+        className="font-serif text-base leading-tight text-(--text) no-underline hover:text-(--primary)"
+      >
+        {event.title}
+      </Link>
+      {event.headline && (
+        <span className="text-sm text-(--text-muted) line-clamp-2">{event.headline}</span>
+      )}
+      {placeLabel && <span className="text-xs text-(--text-muted) mt-auto">{placeLabel}</span>}
+    </Card>
+  );
+};
+
+export default EventTile;

--- a/apps/web/src/components/event/FeaturedCollectionSection.tsx
+++ b/apps/web/src/components/event/FeaturedCollectionSection.tsx
@@ -1,11 +1,11 @@
 import { MarkdownContent } from '@eventuras/markdown';
 import { Card } from '@eventuras/ratio-ui/core/Card';
-import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
+import { Grid } from '@eventuras/ratio-ui/layout/Grid';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 import { Link } from '@eventuras/ratio-ui-next/Link';
 
-import { CategoryGroupedEvents } from '@/components/event/CategoryGroupedEvents';
+import { EventTile } from '@/components/event/EventTile';
 import { EventCollectionDto, EventDto } from '@/lib/eventuras-sdk';
 
 interface FeaturedCollectionSectionProps {
@@ -17,29 +17,28 @@ export const FeaturedCollectionSection: React.FC<FeaturedCollectionSectionProps>
   collection,
   events,
 }) => {
+  const collectionHref = `/collections/${collection.id}/${collection.slug}`;
+
   return (
     <Section paddingY="lg">
-      {collection.featuredImageUrl && (
-        <Card className="min-h-[33vh] mx-auto" backgroundImageUrl={collection.featuredImageUrl} />
-      )}
       <Container>
-        <Heading as="h2" paddingTop="sm" paddingBottom="xs">
-          <Link href={`/collections/${collection.id}/${collection.slug}`}>{collection.name}</Link>
-        </Heading>
-        {collection.description && <MarkdownContent markdown={collection.description} />}
-        {events.length > 0 && (
-          <div className="mt-6">
-            <CategoryGroupedEvents events={events} />
-          </div>
-        )}
-        <div className="mt-4">
-          <Link
-            href={`/collections/${collection.id}/${collection.slug}`}
-            variant="button-secondary"
-          >
-            Se alle kurs i {collection.name}
-          </Link>
-        </div>
+        <Card color="primary" padding="sm" radius="xl" shadow="none">
+          <Section.Header>
+            <Section.Eyebrow>Aktuelt</Section.Eyebrow>
+            <Section.Title>{collection.name}</Section.Title>
+            <Section.Link as={Link} href={collectionHref}>
+              Se hele samlingen
+            </Section.Link>
+            {collection.description && <MarkdownContent markdown={collection.description} />}
+          </Section.Header>
+          {events.length > 0 && (
+            <Grid cols={{ sm: 2, md: 3, lg: 4 }}>
+              {events.map(event => (
+                <EventTile key={event.id} event={event} />
+              ))}
+            </Grid>
+          )}
+        </Card>
       </Container>
     </Section>
   );

--- a/apps/web/src/components/event/index.ts
+++ b/apps/web/src/components/event/index.ts
@@ -1,4 +1,5 @@
 export { CategoryGroupedEvents } from './CategoryGroupedEvents';
 export { default as EventCard } from './EventCard';
 export { default as EventGrid } from './EventGrid';
+export { default as EventTile } from './EventTile';
 export { FeaturedCollectionSection } from './FeaturedCollectionSection';

--- a/libs/core/src/datetime/formatDate.ts
+++ b/libs/core/src/datetime/formatDate.ts
@@ -52,5 +52,47 @@ const formatDateSpan = (
   return `${formattedStartDate} - ${formattedEndDate}`;
 };
 
-export { formatDate, formatDateSpan };
+/**
+ * Compact date range formatter for dense listings — produces strings like
+ * `"14. SEP"`, `"14.–16. SEP"`, `"30. AUG–2. SEP"`, or
+ * `"30. DEC 2026–2. JAN 2027"` depending on whether the range crosses
+ * months or years. Output is uppercased to read as a label / pill.
+ *
+ * Returns an empty string when no start date is supplied. Pair with the
+ * mono caps tile pattern in `EventTile` and similar dense displays.
+ */
+const formatCompactDateRange = (
+  startDate: string | Date | null | undefined,
+  endDate: string | Date | null | undefined,
+  locale = 'en-US'
+): string => {
+  if (!startDate) return '';
+
+  const start = new Date(startDate);
+  const end = endDate ? new Date(endDate) : null;
+
+  const dayMonthFmt = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' });
+  const dayFmt = new Intl.DateTimeFormat(locale, { day: 'numeric' });
+  const yearFmt = new Intl.DateTimeFormat(locale, { year: 'numeric' });
+
+  const startLabel = dayMonthFmt.format(start).toUpperCase();
+
+  if (!end || +start === +end) {
+    return startLabel;
+  }
+
+  const sameMonth =
+    start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth();
+  const sameYear = start.getFullYear() === end.getFullYear();
+
+  if (sameMonth) {
+    return `${dayFmt.format(start)}.–${dayMonthFmt.format(end)}`.toUpperCase();
+  }
+  if (sameYear) {
+    return `${dayMonthFmt.format(start)}–${dayMonthFmt.format(end)}`.toUpperCase();
+  }
+  return `${dayMonthFmt.format(start)} ${yearFmt.format(start)}–${dayMonthFmt.format(end)} ${yearFmt.format(end)}`.toUpperCase();
+};
+
+export { formatDate, formatDateSpan, formatCompactDateRange };
 export type { FormatDateOptions };

--- a/libs/core/src/datetime/index.ts
+++ b/libs/core/src/datetime/index.ts
@@ -3,5 +3,5 @@
  * @module datetime
  */
 
-export { formatDate, formatDateSpan } from './formatDate.js';
+export { formatDate, formatDateSpan, formatCompactDateRange } from './formatDate.js';
 export type { FormatDateOptions } from './formatDate.js';

--- a/libs/ratio-ui/src/layout/Container/Container.tsx
+++ b/libs/ratio-ui/src/layout/Container/Container.tsx
@@ -79,12 +79,19 @@ export const Container: React.FC<ContainerProps> = ({
   // horizontal margin (which would otherwise be overridden by mx-auto).
   const autoCenter = !margin && !marginX;
 
+  // Default horizontal padding so Container gives content breathing room
+  // against the viewport edge on narrow screens. Skipped when the caller
+  // has provided their own horizontal padding via `padding` or `paddingX`.
+  const defaultPx =
+    padding === undefined && paddingX === undefined ? 'px-3 sm:px-4 lg:px-6' : undefined;
+
   return (
     <Component
       className={cn(
         autoCenter && 'mx-auto',
         'w-full',
         SIZE_CLASSES[size],
+        defaultPx,
         bgClasses,
         borderClasses,
         spacingClasses,

--- a/libs/ratio-ui/src/layout/Section/Section.tsx
+++ b/libs/ratio-ui/src/layout/Section/Section.tsx
@@ -40,6 +40,14 @@ interface SectionTitleProps {
 interface SectionLinkProps extends React.ComponentPropsWithoutRef<'a'> {
   children?: ReactNode;
   className?: string;
+  /**
+   * Override the rendered element. Defaults to a plain `<a>`. Pass a
+   * Next.js / TanStack / framework-specific Link component when the
+   * destination is an internal route so you keep client-side navigation
+   * and prefetching. Receives the same `href`, `className`, and any
+   * other anchor props passed to `Section.Link`.
+   */
+  as?: React.ElementType;
 }
 
 interface SectionComponent extends React.FC<SectionProps> {
@@ -159,8 +167,13 @@ const SectionTitle: React.FC<SectionTitleProps> = ({ children, className, as = '
  * by an up-right arrow that nudges on hover. Pass any anchor props
  * (`href`, `target`, etc.).
  */
-const SectionLink: React.FC<SectionLinkProps> = ({ children, className, ...rest }) => (
-  <a
+const SectionLink: React.FC<SectionLinkProps> = ({
+  as: Component = 'a',
+  children,
+  className,
+  ...rest
+}) => (
+  <Component
     className={cn(
       'group inline-flex items-center gap-1.5 text-sm font-medium text-(--primary) no-underline border-b border-transparent hover:border-(--primary) pb-0.5 transition-colors',
       className,
@@ -173,7 +186,7 @@ const SectionLink: React.FC<SectionLinkProps> = ({ children, className, ...rest 
       focusable={false}
       className="size-4 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
     />
-  </a>
+  </Component>
 );
 
 SectionRoot.Header = SectionHeader;


### PR DESCRIPTION
## Summary

Two related changes to lift the frontpage featured collection block:

### 1. \`Container\` default horizontal padding (\`feat(ratio-ui)\`, minor)

Container previously set \`mx-auto\` + \`max-w-{size}\` + \`w-full\` but no horizontal padding, so at viewport widths below the configured \`size\` content rendered flush against the screen edge — visibly broken on mobile across every app that composes with Container.

Add a responsive default \`px-3 sm:px-4 lg:px-6\` (12 / 16 / 24px). Consumers that need a different value can override via \`padding\` or \`paddingX\` (any of those, including \`paddingX=\"none\"\`, suppresses the default). Matches Tailwind's \`container\` utility, MUI, and Chakra.

### 2. \`FeaturedCollectionSection\` redesign (\`refactor(web)\`)

Replace the cover-image + \`CategoryGroupedEvents\` layout with a tinted \`Card\` wrapping a \`Section.Header\` (eyebrow + collection name + \"Se hele samlingen\" link) and a responsive grid of compact \`EventTile\`s — a new component beside \`EventCard\`.

Each tile shows a date pill (mono caps, compact range like \"14.–16. SEP\"), serif title, optional headline, and place — clickable as a unit via \`linkOverlay\`. Drop the cover image and bottom CTA button entirely; the link in the section header carries that affordance now.

\`EventTile\` lives next to \`EventCard\` so other dense listings (related events, search results) can adopt it without going through a collection.

The compact date logic is extracted to \`@eventuras/core/datetime\` as \`formatCompactDateRange\` so any dense display can adopt it.

### Notes

- Eyebrow reads \"Aktuelt\" — generic, singular, neutral. Avoids assuming every featured collection is a multi-day gathering, and avoids a plural kicker repeating across multiple collections.
- The category dot from the design reference is intentionally omitted until we have a category-name → token-color mapping.

## Test plan

- [x] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui build\` clean, 369 tests pass
- [x] \`pnpm --filter @eventuras/core build\` clean
- [x] \`apps/web\` typechecks
- [ ] Visual: frontpage in dev — collection block renders as tinted card with grid of tiles, tile hover lifts surface + primary border, edge breathing room on mobile
- [ ] Visual: any other apps/web page using \`Container\` — confirm new default px feels right (no over-padding) or that consumers have explicit overrides where needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)