### PR TITLE
feat(ratio-ui): add Strip primitive (beta) + Badge subtle variant

### DIFF
--- a/.changeset/badge-subtle-variant.md
+++ b/.changeset/badge-subtle-variant.md
@@ -1,0 +1,12 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add a `subtle` variant to `Badge` for use as a category tag or kicker that sits inside a card / list row without shouting. Outline pill on a quiet tinted background, mono-uppercase typography, status-tinted colors that mirror the existing filled variants.
+
+```tsx
+<Badge variant="subtle">Course</Badge>
+<Badge variant="subtle" status="warning">Few seats</Badge>
+```
+
+Pairs with the existing filled variant — same `status` enum, same `Status`-keyed colors. Default remains `variant="filled"` so existing usages are unchanged. Use the subtle variant as the canonical "category tag" inside Strip / Card content where the badge supports the surface rather than competing with it.

--- a/.changeset/strip.md
+++ b/.changeset/strip.md
@@ -1,0 +1,32 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add `Strip` (beta) — a three-column horizontal card primitive for chronological listings, calendar entries, search results, and any dense row-shaped content where date / identity, body, and meta / action separate naturally. Marked `@beta` in JSDoc — prop shape, slot contract, and visual treatment may change before release without major bumps.
+
+```tsx
+import { Strip } from '@eventuras/ratio-ui/core/Strip';
+
+<Strip hoverEffect href="/events/123">
+  <Strip.Lead>
+    <span className="font-mono text-xs uppercase">SEP</span>
+    <span className="font-serif text-5xl">14</span>
+  </Strip.Lead>
+  <Strip.Body>
+    <h3 className="font-serif text-xl">Course title</h3>
+    <p className="text-sm text-(--text-muted)">Optional headline.</p>
+  </Strip.Body>
+  <Strip.Trail>
+    <span>Venue</span>
+    <span>View →</span>
+  </Strip.Trail>
+</Strip>
+```
+
+Layout: `160px / 1fr / 280px` columns above the `md` breakpoint, stacks to one column below it. The leading slot picks up a deeper Linen tint (`bg-secondary-300` light, `bg-primary-900` dark) so it reads as a separate column at a glance; dashed-border separators flip from vertical to horizontal when the strip stacks. Pass `href` to render the strip itself as an anchor — the whole row becomes clickable.
+
+Internal slot separators echo the outer `border` prop, so `border={false}` or `border="none"` yields a truly borderless strip with no internal dividers either.
+
+Inherits Card-tier interactive props: `hoverEffect` (1px lift + primary border + soft glow on hover), `color` (semantic surface tint), `shadow`, `border`, `radius`, and the margin family. Defaults to `shadow="none"` since strips read as flat list rows by default.
+
+Lives next to `Card` rather than under it (no `Card.Strip` namespacing) so the two primitives stay independent — `Card` keeps its single-block contract, `Strip` owns the row pattern.

--- a/libs/ratio-ui/src/core/Badge/Badge.stories.tsx
+++ b/libs/ratio-ui/src/core/Badge/Badge.stories.tsx
@@ -10,6 +10,10 @@ const meta: Meta<typeof Badge> = {
       control: 'select',
       options: ['neutral', 'info', 'success', 'warning', 'error'],
     },
+    variant: {
+      control: 'inline-radio',
+      options: ['filled', 'subtle'],
+    },
     block: { control: 'boolean' },
   },
 };
@@ -64,11 +68,41 @@ export const AllStatuses: Story = {
   ),
 };
 
+export const Subtle: Story = {
+  args: {
+    children: 'Course',
+    status: 'neutral',
+    variant: 'subtle',
+  },
+};
+
+export const SubtleAllStatuses: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+      <Badge variant="subtle" status="neutral">Course</Badge>
+      <Badge variant="subtle" status="info">Online</Badge>
+      <Badge variant="subtle" status="success">Available</Badge>
+      <Badge variant="subtle" status="warning">Few seats</Badge>
+      <Badge variant="subtle" status="error">Full</Badge>
+    </div>
+  ),
+};
+
 export const Definition: Story = {
   args: {
     children: 'REG-001',
     definition: true,
     label: 'ID',
     status: 'neutral',
+  },
+};
+
+export const SubtleDefinition: Story = {
+  args: {
+    children: 'REG-001',
+    definition: true,
+    label: 'ID',
+    status: 'neutral',
+    variant: 'subtle',
   },
 };

--- a/libs/ratio-ui/src/core/Badge/Badge.tsx
+++ b/libs/ratio-ui/src/core/Badge/Badge.tsx
@@ -2,49 +2,83 @@ import React from 'react';
 import type { Status } from '../../tokens/colors';
 import { cn } from '../../utils/cn';
 
+export type BadgeVariant = 'filled' | 'subtle';
+
 export type BadgeProps = {
   children: React.ReactNode;
   className?: string;
   status?: Status;
+  /**
+   * Visual treatment.
+   * - `'filled'` (default) — solid status-tinted background with white
+   *   text. Use for prominent indicators where the badge needs to read
+   *   from across the page.
+   * - `'subtle'` — outline pill with mono-uppercase text on a quiet
+   *   tinted background. Use as a category tag or kicker where the
+   *   badge sits inside a larger card or list row and shouldn't shout.
+   */
+  variant?: BadgeVariant;
   block?: boolean;
   definition?: boolean;
   label?: string;
 };
 
-const statusClasses: Record<Status, string> = {
-  neutral: 'bg-neutral-700 dark:bg-neutral-800',
-  info: 'bg-info',
-  success: 'bg-success',
-  warning: 'bg-warning',
-  error: 'bg-error',
+const filledStatusClasses: Record<Status, string> = {
+  neutral: 'bg-neutral-700 dark:bg-neutral-800 text-white',
+  info: 'bg-info text-white',
+  success: 'bg-success text-white',
+  warning: 'bg-warning text-white',
+  error: 'bg-error text-white',
+};
+
+const subtleStatusClasses: Record<Status, string> = {
+  neutral: 'bg-card border border-border-1 text-(--text-muted)',
+  info: 'bg-(--info-bg) border border-(--info-border) text-(--info-text)',
+  success: 'bg-(--success-bg) border border-(--success-border) text-(--success-text)',
+  warning: 'bg-(--warning-bg) border border-(--warning-border) text-(--warning-text)',
+  error: 'bg-(--error-bg) border border-(--error-border) text-(--error-text)',
 };
 
 export const Badge: React.FC<BadgeProps> = ({
   children,
   className,
   status = 'neutral',
+  variant = 'filled',
   block = false,
   definition = false,
   label,
 }) => {
+  const isSubtle = variant === 'subtle';
+  const variantClasses = isSubtle ? subtleStatusClasses[status] : filledStatusClasses[status];
+
   const base = cn(
     block && 'block',
-    statusClasses[status],
-    'text-xs leading-none text-white rounded',
+    variantClasses,
+    'leading-none',
+    isSubtle
+      ? 'font-mono text-[10px] uppercase tracking-wider font-bold rounded-full'
+      : 'text-xs rounded',
   );
 
   if (definition && label) {
     return (
       <span className={cn(base, 'flex overflow-hidden', className)}>
-        <dt className="bg-black/20 px-2 py-2 font-medium uppercase tracking-wide">
+        <dt
+          className={cn(
+            'px-2 py-2 font-medium uppercase tracking-wide',
+            isSubtle ? 'bg-(--text-muted)/10' : 'bg-black/20',
+          )}
+        >
           {label}
         </dt>
-        <dd className="px-2 py-2 m-0">
-          {children}
-        </dd>
+        <dd className="px-2 py-2 m-0">{children}</dd>
       </span>
     );
   }
 
-  return <span className={cn(base, 'p-2', className)}>{children}</span>;
+  return (
+    <span className={cn(base, isSubtle ? 'px-2 py-1' : 'p-2', className)}>
+      {children}
+    </span>
+  );
 };

--- a/libs/ratio-ui/src/core/Strip/Strip.stories.tsx
+++ b/libs/ratio-ui/src/core/Strip/Strip.stories.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { Badge } from '../Badge/Badge';
+import { Strip } from './Strip';
+
+const meta: Meta<typeof Strip> = {
+  title: 'Core/Strip',
+  component: Strip,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Three-column horizontal card. Use `Strip.Lead` / `.Body` / `.Trail` slots for the canonical layout — date stamp on the left, content in the middle, meta + CTA on the right. Stacks to one column below the `md` breakpoint.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Strip>;
+
+const MapPin = () => (
+  <svg
+    aria-hidden="true"
+    className="size-4 shrink-0 text-(--text-subtle)"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    viewBox="0 0 24 24"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 21s7-6.5 7-12a7 7 0 1 0-14 0c0 5.5 7 12 7 12Z" />
+    <circle cx="12" cy="9" r="2.5" strokeLinecap="round" strokeLinejoin="round" />
+  </svg>
+);
+
+export const Default: Story = {
+  args: {
+    hoverEffect: true,
+    href: '#',
+  },
+  render: args => (
+    <div className="max-w-4xl">
+      <Strip {...args}>
+        <Strip.Lead>
+          <span>14.–16. SEP 2026</span>
+        </Strip.Lead>
+        <Strip.Body>
+          <Badge variant="subtle" className="self-start">Course</Badge>
+          <h3 className="font-serif text-xl leading-tight tracking-tight text-(--primary) m-0">
+            Three-column horizontal card example
+          </h3>
+          <p className="text-sm text-(--text-muted) m-0 max-w-prose">
+            Body slot takes flexible width. Use it for titles, headlines, and short
+            descriptions. The leading and trailing slots stay fixed-width on wide
+            screens.
+          </p>
+        </Strip.Body>
+        <Strip.Trail>
+          <span className="inline-flex items-center gap-2 text-sm">
+            <MapPin />
+            <span className="font-semibold text-(--text)">Conference center</span>
+          </span>
+          <span className="md:mt-auto inline-flex items-center gap-1.5 text-sm font-semibold text-(--primary)">
+            View course <span aria-hidden="true">→</span>
+          </span>
+        </Strip.Trail>
+      </Strip>
+    </div>
+  ),
+};
+
+export const StackedList: Story = {
+  render: () => (
+    <div className="max-w-4xl flex flex-col gap-3.5">
+      {[
+        { topLabel: '4.–5. MAY', y: '26', title: 'Health law course' },
+        { topLabel: '6.–7. MAY', y: '2026', title: 'Surgery in general practice' },
+        { topLabel: '14. SEP', y: '2026', title: 'Foundation course B (single day)' },
+        { topLabel: '14.–16. SEP', y: '2026', title: 'Foundation course B (multi-day)' },
+      ].map((c, i) => (
+        <Strip key={i} hoverEffect href="#">
+          <Strip.Lead>
+            <span>{c.topLabel}</span>
+            <span>'{c.y}</span>
+          </Strip.Lead>
+          <Strip.Body>
+            <h3 className="font-serif text-xl leading-tight tracking-tight text-(--primary) m-0">
+              {c.title}
+            </h3>
+          </Strip.Body>
+          <Strip.Trail>
+            <span className="inline-flex items-center gap-2 text-sm">
+              <MapPin />
+              <span className="font-semibold text-(--text)">Venue, City</span>
+            </span>
+            <span className="md:mt-auto inline-flex items-center gap-1.5 text-sm font-semibold text-(--primary)">
+              View <span aria-hidden="true">→</span>
+            </span>
+          </Strip.Trail>
+        </Strip>
+      ))}
+    </div>
+  ),
+};

--- a/libs/ratio-ui/src/core/Strip/Strip.tsx
+++ b/libs/ratio-ui/src/core/Strip/Strip.tsx
@@ -1,0 +1,213 @@
+import React, { createContext, ReactNode, useContext } from 'react';
+import type { SpacingProps } from '../../tokens/spacing';
+import type { BorderProps } from '../../tokens/borders';
+import type { Color } from '../../tokens/colors';
+import { surfaceBgClasses } from '../../tokens/colors';
+import { buildBorderClasses } from '../../tokens/borders';
+import { buildSpacingClasses } from '../../tokens/spacing';
+import { cn } from '../../utils/cn';
+
+// Internal context so slots (Lead/Body/Trail) can mirror the parent's
+// `border` prop on their own dashed separator borders. When the outer
+// strip is borderless, the dashed slot dividers disappear too — keeps
+// the border API consistent across the whole component.
+const StripContext = createContext<{ showSeparators: boolean }>({ showSeparators: true });
+
+export type StripShadow = 'none' | 'xs' | 'sm' | 'md';
+
+export interface StripProps extends BorderProps, Pick<SpacingProps, 'margin' | 'marginX' | 'marginY' | 'marginTop' | 'marginBottom'> {
+  children?: ReactNode;
+  as?: React.ElementType;
+  href?: string;
+  className?: string;
+  /**
+   * Semantic surface tint. Maps to `bg-{color}-50` in light and
+   * `bg-{color}-950` in dark via `surfaceBgClasses`. Overrides the
+   * default `--card` fill.
+   */
+  color?: Color;
+  /**
+   * Drop shadow. Defaults to `'none'` — strips read as flat list rows
+   * by default. Bump to `'xs'` if you want them slightly lifted.
+   */
+  shadow?: StripShadow;
+  /**
+   * Add the canonical interactive hover — surface lifts 1px, border
+   * picks up `--primary`, and a soft Linseed-tinted glow appears. Use
+   * only when the strip is itself a link / clickable surface.
+   */
+  hoverEffect?: boolean;
+  testId?: string;
+}
+
+const SHADOW_CLASSES: Record<StripShadow, string> = {
+  none: '',
+  xs: 'shadow-xs',
+  sm: 'shadow-sm',
+  md: 'shadow-md',
+};
+
+export interface StripSlotProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Leading slot of a `Strip` — a fixed-width column anchored on the
+ * left. Use for date stamps, avatars, icons, or other identity blocks.
+ * Picks up a subtle tinted background and a dashed right-border that
+ * separates it from the body.
+ */
+const StripLead = ({ children, className }: StripSlotProps) => {
+  const { showSeparators } = useContext(StripContext);
+  return (
+    <div
+      className={cn(
+        'px-5 py-5 flex flex-col gap-1',
+        showSeparators && 'border-b md:border-b-0 md:border-r border-dashed border-border-2',
+        'bg-secondary-300 dark:bg-primary-900',
+        // Default child typography — bare <span>s render as mono-uppercase
+        // primary-toned date labels. Consumer overrides by passing different
+        // element types (e.g. <div>) or adding their own classNames on the spans.
+        '[&>span]:font-mono [&>span]:text-base [&>span]:uppercase [&>span]:tracking-wide [&>span]:font-bold [&>span]:text-(--primary) [&>span]:leading-tight',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+StripLead.displayName = 'Strip.Lead';
+
+/**
+ * Body slot of a `Strip` — the flexible center column that takes
+ * the remaining horizontal space. Use for the primary content (title,
+ * description, pills).
+ */
+const StripBody = ({ children, className }: StripSlotProps) => (
+  <div className={cn('px-6 py-5 flex flex-col gap-2 min-w-0', className)}>{children}</div>
+);
+StripBody.displayName = 'Strip.Body';
+
+/**
+ * Trailing slot of a `Strip` — the right-aligned column. Use for
+ * meta info (location, points, duration) and a CTA. Stacks vertically
+ * on wide screens, falls back to an inline row when the strip stacks.
+ */
+const StripTrail = ({ children, className }: StripSlotProps) => {
+  const { showSeparators } = useContext(StripContext);
+  return (
+    <div
+      className={cn(
+        'px-6 py-5 flex flex-row md:flex-col items-start md:items-stretch md:justify-center gap-3 md:gap-2.5 min-w-0',
+        showSeparators && 'border-t md:border-t-0 md:border-l border-dashed border-border-2',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+StripTrail.displayName = 'Strip.Trail';
+
+/**
+ * Three-column horizontal card — leading slot (fixed-width left
+ * column), body (flexible center), trailing slot (fixed-width right
+ * column). Stacks vertically below the `md` breakpoint. Pair with
+ * `Strip.Lead`, `Strip.Body`, `Strip.Trail` for the
+ * canonical layout; pass `href` to render the strip itself as an
+ * anchor (the whole row becomes clickable).
+ *
+ * Use for chronological listings, calendar entries, search results,
+ * and any dense row-shaped content where date/identity, body, and
+ * meta/action separate naturally.
+ *
+ * @beta This component is experimental. The prop shape, slot contract,
+ * and visual treatment may change before release.
+ *
+ * @example
+ * ```tsx
+ * <Strip hoverEffect href="/events/123">
+ *   <Strip.Lead>
+ *     <span className="font-mono text-xs uppercase">SEP</span>
+ *     <span className="font-serif text-5xl">14</span>
+ *   </Strip.Lead>
+ *   <Strip.Body>
+ *     <h3 className="font-serif text-xl">Title</h3>
+ *     <p className="text-sm text-(--text-muted)">Headline.</p>
+ *   </Strip.Body>
+ *   <Strip.Trail>
+ *     <span>Place</span>
+ *     <span>See course →</span>
+ *   </Strip.Trail>
+ * </Strip>
+ * ```
+ */
+const StripRoot: React.FC<StripProps> = ({
+  as,
+  href,
+  hoverEffect = false,
+  shadow = 'none',
+  color,
+  children,
+  className,
+  testId,
+  margin, marginX, marginY, marginTop, marginBottom,
+  ...border
+}) => {
+  const Component: React.ElementType = as ?? (href ? 'a' : 'div');
+  const radius = border.radius ?? 'xl';
+  const borderProp = border.border ?? true;
+
+  const bgClasses = color ? surfaceBgClasses[color] : 'bg-card';
+
+  const transitionClasses = hoverEffect ? 'transition-all duration-200 ease-out' : '';
+  const hoverShadow = shadow === 'none' ? 'hover:shadow-card-hover-tile' : 'hover:shadow-card-hover';
+  const hoverClasses = hoverEffect
+    ? cn('hover:border-(--primary) hover:-translate-y-px', hoverShadow)
+    : '';
+
+  const borderClasses = buildBorderClasses({
+    border: borderProp,
+    borderColor: border.borderColor,
+    radius,
+  });
+
+  const spacingClasses = buildSpacingClasses({
+    margin, marginX, marginY, marginTop, marginBottom,
+  });
+
+  // Internal slot separators echo the outer border on/off state. When
+  // the consumer opts into a borderless strip, the dashed dividers
+  // disappear too.
+  const showSeparators = borderProp !== false && borderProp !== 'none';
+
+  return (
+    <StripContext.Provider value={{ showSeparators }}>
+      <Component
+        href={href}
+        className={cn(
+          'grid grid-cols-1 md:grid-cols-[160px_1fr_280px] gap-0 overflow-hidden',
+          'text-(--text) no-underline',
+          bgClasses,
+          borderClasses,
+          SHADOW_CLASSES[shadow],
+          transitionClasses,
+          hoverClasses,
+          spacingClasses,
+          className,
+        )}
+        data-testid={testId}
+      >
+        {children}
+      </Component>
+    </StripContext.Provider>
+  );
+};
+StripRoot.displayName = 'Strip';
+
+export const Strip = Object.assign(StripRoot, {
+  Lead: StripLead,
+  Body: StripBody,
+  Trail: StripTrail,
+});

--- a/libs/ratio-ui/src/core/Strip/index.ts
+++ b/libs/ratio-ui/src/core/Strip/index.ts
@@ -1,0 +1,2 @@
+export { Strip } from './Strip';
+export type { StripProps, StripShadow, StripSlotProps } from './Strip';


### PR DESCRIPTION
## Summary

Two related additions to ratio-ui that unlock the chronological-list pattern in apps/web (kursliste).

### 1. \`Badge\` subtle variant (\`feat(ratio-ui)\`, minor)

Add \`variant: 'filled' | 'subtle'\` to \`Badge\`. The subtle variant renders an outline pill on a quiet tinted background with mono-uppercase typography — for category tags or kickers that sit inside a card / list row without competing with the surface around them.

\`\`\`tsx
<Badge variant=\"subtle\">Course</Badge>
<Badge variant=\"subtle\" status=\"warning\">Few seats</Badge>
\`\`\`

Default remains \`variant=\"filled\"\` so existing usages render identically.

### 2. \`Strip\` three-column horizontal card (\`feat(ratio-ui)\`, minor, **@beta**)

A new primitive for chronological listings, calendar entries, search results, and any dense row-shaped content where date / identity, body, and meta / action separate naturally.

\`\`\`tsx
import { Strip } from '@eventuras/ratio-ui/core/Strip';
import { Badge } from '@eventuras/ratio-ui/core/Badge';

<Strip hoverEffect href=\"/events/123\">
  <Strip.Lead>
    <span>14.–16. SEP</span>
    <span>2026</span>
  </Strip.Lead>
  <Strip.Body>
    <Badge variant=\"subtle\">Course</Badge>
    <h3 className=\"font-serif text-xl\">Course title</h3>
  </Strip.Body>
  <Strip.Trail>
    <span>Venue</span>
    <span>View →</span>
  </Strip.Trail>
</Strip>
\`\`\`

- **Three slots** — \`Strip.Lead\` (fixed 160px), \`Strip.Body\` (flex), \`Strip.Trail\` (fixed 280px). Stacks to one column below \`md\`; dashed-border separators flip from vertical to horizontal when stacked.
- **Click target** — pass \`href\` to render the strip itself as an anchor.
- **Inherits Card-tier props** — \`hoverEffect\`, \`color\`, \`shadow\`, \`border\`, \`radius\`, margins. Defaults to \`shadow=\"none\"\`.
- **Lead default typography** — bare \`<span>\`s render as mono-uppercase primary-toned date labels so consumers don't repeat the styling at every callsite.
- **\`@beta\`** — prop shape, slot contract, and visual treatment may change before release without major bumps. Marked in JSDoc + changeset.

Lives next to \`Card\` rather than under it (no \`Card.Strip\` namespace) so the two primitives stay independent.

### Why both in one PR

\`Strip\` stories use the new \`Badge\` subtle variant for the canonical \"category tag\" pattern. Two commits, separated by concern.

## Test plan

- [x] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui build\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui test\` — 373 passed (+4 from new stories)
- [ ] Visual: open Storybook \`Core/Strip\` — confirm 3-column layout above md, stacked below, hover lift, primary border. Toggle dark mode.
- [ ] Visual: \`Core/Badge\` — confirm subtle variants render across all 5 statuses, filled variants unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)