### PR TITLE
feat(web): chronological events list using Strip + Badge

### DIFF
--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -135,6 +135,13 @@
       "eyebrow": "Learn when it suits you",
       "title": "Online courses",
       "tag": "Online course"
+    },
+    "list": {
+      "eyebrow": "Upcoming courses",
+      "title": "All courses in <em>chronological</em> order",
+      "cta": "View course",
+      "shortTitle": "All courses",
+      "linkLabel": "See all courses"
     }
   },
   "labels": {

--- a/apps/web/locales/nb-NO/common.json
+++ b/apps/web/locales/nb-NO/common.json
@@ -96,7 +96,8 @@
       "description": "Vi prøvde å utføre handlingen, men noe gikk galt. Vennligst prøv igjen senere.",
       "title": "Noe gikk veldig galt"
     },
-    "tryRefresh": "Prøv gjerne å oppfrisk siden!"
+    "tryRefresh": "Prøv gjerne å oppfrisk siden!",
+    "failedToLoadEvents": "Kunne ikke laste arrangementer"
   },
   "event-not-found": "Arrangement ikke funnet",
   "events": {
@@ -134,6 +135,13 @@
       "eyebrow": "Lær når det passer",
       "title": "Nettkurs",
       "tag": "Nettkurs"
+    },
+    "list": {
+      "eyebrow": "Kommende kurs",
+      "title": "Alle kurs i <em>kronologisk</em> rekkefølge",
+      "cta": "Se kurs",
+      "shortTitle": "Alle kurs",
+      "linkLabel": "Se alle kurs"
     }
   },
   "labels": {

--- a/apps/web/src/app/(frontpage)/page.tsx
+++ b/apps/web/src/app/(frontpage)/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { Logger } from '@eventuras/logger';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
@@ -7,8 +7,13 @@ import { Text } from '@eventuras/ratio-ui/core/Text';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 import { buildCoverImageStyle } from '@eventuras/ratio-ui/utils';
+import { Link } from '@eventuras/ratio-ui-next/Link';
 
-import { EventGrid, FeaturedCollectionSection, OnDemandCoursesSection } from '@/components/event';
+import {
+  EventListRow,
+  FeaturedCollectionSection,
+  OnDemandCoursesSection,
+} from '@/components/event';
 import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import {
   type EventCollectionDto,
@@ -36,6 +41,7 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function Homepage() {
   const site = await getSiteSettings();
   const t = await getTranslations();
+  const locale = await getLocale();
 
   const ORGANIZATION_ID = getOrganizationId();
 
@@ -149,14 +155,26 @@ export default async function Homepage() {
       {/* On-demand courses — Course events flagged onDemand */}
       {hasOnDemand && <OnDemandCoursesSection events={onDemandCourses} />}
 
-      {/* Regular events */}
+      {/* Regular events — chronological list */}
       {hasEvents && (
         <Section paddingY="lg">
           <Container>
-            <Heading as="h2" paddingBottom="sm">
-              {t('common.events.sectiontitle')}
-            </Heading>
-            <EventGrid eventinfos={regularEvents} />
+            <Section.Header>
+              <Section.Title>{t('common.events.list.shortTitle')}</Section.Title>
+              <Section.Link as={Link} href="/events">
+                {t('common.events.list.linkLabel')}
+              </Section.Link>
+            </Section.Header>
+            <div className="flex flex-col gap-3.5">
+              {regularEvents.map(event => (
+                <EventListRow
+                  key={event.id}
+                  event={event}
+                  ctaLabel={t('common.events.list.cta')}
+                  locale={locale}
+                />
+              ))}
+            </div>
           </Container>
         </Section>
       )}

--- a/apps/web/src/app/(public)/events/page.tsx
+++ b/apps/web/src/app/(public)/events/page.tsx
@@ -1,84 +1,96 @@
-import Link from 'next/link';
-import { getTranslations } from 'next-intl/server';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { Logger } from '@eventuras/logger';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
-import { List } from '@eventuras/ratio-ui/core/List';
 import { Text } from '@eventuras/ratio-ui/core/Text';
+import { Container } from '@eventuras/ratio-ui/layout/Container';
+import { Section } from '@eventuras/ratio-ui/layout/Section';
 
+import { EventListRow } from '@/components/event';
 import { getPublicClient } from '@/lib/eventuras-public-client';
-import { getV3Events } from '@/lib/eventuras-public-sdk';
+import { type EventDto, getV3Events } from '@/lib/eventuras-public-sdk';
 import { getOrganizationId } from '@/utils/organization';
 
 const logger = Logger.create({
   namespace: 'web:events-page',
   context: { page: 'EventsPage' },
 });
+
 // Always render server-side so ORGANIZATION_ID is read at request time, not build time
 export const dynamic = 'force-dynamic';
+
 export default async function EventsPage() {
   const ORGANIZATION_ID = getOrganizationId();
   const t = await getTranslations();
+  const locale = await getLocale();
   logger.info({ organizationId: ORGANIZATION_ID }, 'Fetching events for organization');
-  let eventinfos;
+
+  let events: EventDto[] = [];
   let fetchError = false;
+
   try {
-    // Use public client for anonymous API access
     const publicClient = getPublicClient();
-    eventinfos = await getV3Events({
+    const response = await getV3Events({
       client: publicClient,
       query: {
         OrganizationId: ORGANIZATION_ID,
+        Ordering: ['DateStart', 'Title'],
       },
     });
-    if (eventinfos.error) {
+
+    if (response.error) {
       logger.error(
-        {
-          error: eventinfos.error,
-          organizationId: ORGANIZATION_ID,
-        },
+        { error: response.error, organizationId: ORGANIZATION_ID },
         'Failed to fetch events'
       );
       fetchError = true;
     } else {
+      events = response.data?.data ?? [];
       logger.info(
-        {
-          count: eventinfos.data?.count || 0,
-          organizationId: ORGANIZATION_ID,
-        },
+        { count: events.length, organizationId: ORGANIZATION_ID },
         'Successfully fetched events'
       );
     }
   } catch (error) {
     logger.warn(
-      {
-        error,
-        organizationId: ORGANIZATION_ID,
-        backendUrl: process.env.BACKEND_URL,
-      },
+      { error, organizationId: ORGANIZATION_ID, backendUrl: process.env.BACKEND_URL },
       'Exception while fetching events - this is expected during build time if backend is not running'
     );
     fetchError = true;
   }
+
   return (
-    <>
-      <Heading as="h1" paddingBottom="sm">
-        {t('common.events.sectiontitle')}
-      </Heading>
-      {/* Show error message if fetch failed */}
-      {fetchError && <Text>Unable to load events. Please try again later.</Text>}
-      {/* Events section */}
-      {!fetchError && eventinfos?.data?.count && eventinfos.data.data && (
-        <List>
-          {eventinfos.data.data.map(eventInfo => (
-            <List.Item key={eventInfo.id}>
-              <Link href={`/events/${eventInfo.id}`}>
-                <Text>{eventInfo.title}</Text>
-              </Link>
-            </List.Item>
-          ))}
-        </List>
-      )}
-    </>
+    <Section paddingY="lg">
+      <Container>
+        <Heading.Group className="mb-9">
+          <Heading.Eyebrow>{t('common.events.list.eyebrow')}</Heading.Eyebrow>
+          <Heading
+            as="h1"
+            className="font-serif font-medium text-3xl md:text-4xl leading-[1.1] tracking-tight m-0"
+          >
+            {t.rich('common.events.list.title', {
+              em: chunks => <em className="font-serif italic text-(--primary)">{chunks}</em>,
+            })}
+          </Heading>
+        </Heading.Group>
+
+        {fetchError && <Text>{t('common.errors.failedToLoadEvents')}</Text>}
+
+        {!fetchError && events.length === 0 && <Text>{t('common.events.noEventsAvailable')}</Text>}
+
+        {!fetchError && events.length > 0 && (
+          <div className="flex flex-col gap-3.5">
+            {events.map(event => (
+              <EventListRow
+                key={event.id}
+                event={event}
+                ctaLabel={t('common.events.list.cta')}
+                locale={locale}
+              />
+            ))}
+          </div>
+        )}
+      </Container>
+    </Section>
   );
 }

--- a/apps/web/src/components/event/EventListRow.tsx
+++ b/apps/web/src/components/event/EventListRow.tsx
@@ -1,0 +1,78 @@
+import { formatCompactDateRange } from '@eventuras/core/datetime';
+import { Badge } from '@eventuras/ratio-ui/core/Badge';
+import { Strip } from '@eventuras/ratio-ui/core/Strip';
+import { MapPin } from '@eventuras/ratio-ui/icons';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+import type { EventDto } from '@/lib/eventuras-types';
+
+interface EventListRowProps {
+  event: EventDto;
+  ctaLabel: string;
+  locale: string;
+}
+
+/**
+ * Three-column event row for chronological listings — date column
+ * (mono uppercase range + year), body column (category badge + serif
+ * title + optional headline), and meta column (location + CTA). The
+ * whole row links to the event detail page via `Strip`'s built-in
+ * anchor behaviour; hover lifts the surface and tints the border.
+ *
+ * Pairs with `EventTile` (compact tiles for collection grids) and
+ * `EventCard` (the standalone larger card). Use this row in flat
+ * listings where chronology and dense scan-ability matter.
+ *
+ * Differs from the design reference for now: collection pill, status
+ * pill ("FULLT"), kurspoeng row — those need SDK fields we don't have
+ * yet. Easy to layer in once available.
+ */
+export const EventListRow: React.FC<EventListRowProps> = ({ event, ctaLabel, locale }) => {
+  const startDate = event.dateStart ? new Date(event.dateStart as string) : null;
+  const yearLabel = startDate
+    ? new Intl.DateTimeFormat(locale, { year: 'numeric' }).format(startDate)
+    : '';
+  const rangeLabel = formatCompactDateRange(
+    event.dateStart as string | null | undefined,
+    event.dateEnd as string | null | undefined,
+    locale
+  );
+  const placeLabel = [event.location, event.city].filter(Boolean).join(', ');
+
+  return (
+    <Strip hoverEffect as={Link} href={`/events/${event.id}/${event.slug ?? ''}`}>
+      <Strip.Lead>
+        {rangeLabel && <span>{rangeLabel}</span>}
+        {yearLabel && <span>{yearLabel}</span>}
+      </Strip.Lead>
+      <Strip.Body>
+        {event.category && (
+          <Badge variant="subtle" className="self-start">
+            {event.category}
+          </Badge>
+        )}
+        <h3 className="font-serif text-xl leading-tight tracking-tight text-(--primary) m-0">
+          {event.title}
+        </h3>
+        {event.headline && (
+          <p className="text-sm text-(--text-muted) m-0 max-w-prose line-clamp-2">
+            {event.headline}
+          </p>
+        )}
+      </Strip.Body>
+      <Strip.Trail>
+        {placeLabel && (
+          <span className="inline-flex items-center gap-2 text-sm">
+            <MapPin className="size-4 shrink-0 text-(--text-subtle)" aria-hidden="true" />
+            <span className="font-semibold text-(--text)">{placeLabel}</span>
+          </span>
+        )}
+        <span className="md:mt-auto inline-flex items-center gap-1.5 text-sm font-semibold text-(--primary) transition-transform group-hover/strip:translate-x-0.5">
+          {ctaLabel} <span aria-hidden="true">→</span>
+        </span>
+      </Strip.Trail>
+    </Strip>
+  );
+};
+
+export default EventListRow;

--- a/apps/web/src/components/event/index.ts
+++ b/apps/web/src/components/event/index.ts
@@ -1,6 +1,7 @@
 export { CategoryGroupedEvents } from './CategoryGroupedEvents';
 export { default as EventCard } from './EventCard';
 export { default as EventGrid } from './EventGrid';
+export { default as EventListRow } from './EventListRow';
 export { default as EventTile } from './EventTile';
 export { FeaturedCollectionSection } from './FeaturedCollectionSection';
 export { OnDemandCoursesSection } from './OnDemandCoursesSection';


### PR DESCRIPTION
## Summary

Replace the minimal \`<List><List.Item>\` shell on \`/events\` with a proper kursliste, and reuse the same pattern as the regular-events section on the frontpage.

### \`/events\` page

\`Heading.Group\` (eyebrow + serif h1 with italic accent on \"kronologisk\") above a vertical stack of \`EventListRow\`s sorted on \`DateStart, Title\`.

### Frontpage

Drops the old \`EventGrid\` block. The chronological list now sits between \`OnDemandCoursesSection\` and the footer with a \`Section.Header\` (title \"Alle kurs\" + \"Se alle kurs →\" link to \`/events\`).

### \`EventListRow\` (new)

Sibling of \`EventCard\` and \`EventTile\`. Composes ratio-ui's new \`Strip\` primitive:

- **Strip.Lead** — mono-uppercase compact date range (\"14.–16. SEP\") + year
- **Strip.Body** — category \`Badge variant=\"subtle\"\` + serif title + optional headline
- **Strip.Trail** — location row (map pin + place) + \"Se kurs →\" CTA

The whole row is a link via \`Strip\`'s \`href\` prop — no extra anchor/linkOverlay plumbing.

### i18n

New keys under \`common.events.list.*\` — \`eyebrow\`, \`title\`, \`shortTitle\`, \`linkLabel\`, \`cta\` — for both nb-NO and en-US. Title accepts inline \`<em>\` markup via \`t.rich\` on the page header.

### Deferred

Collection pill, status pill (\"FULLT\"), kurspoeng row from the design reference need SDK fields we don't have yet. Easy to layer in later.

## Test plan

- [x] \`apps/web\` typechecks
- [ ] Visual: \`/events\` in dev — eyebrow + serif h1 with italic accent, vertical stack of strips, hover lift + primary border
- [ ] Visual: frontpage — \"Alle kurs\" section with same strip stack, \"Se alle kurs →\" link goes to \`/events\` via Next client-nav
- [ ] Visual: locale switch — confirm en-US strings render
- [ ] Mobile: strips stack to one column, dashed dividers flip from vertical to horizontal

🤖 Generated with [Claude Code](https://claude.com/claude-code)