### PR TITLE
feat(ratio-ui): footer dark prop flips background too

### DIFF
--- a/.changeset/footer-dark-bg.md
+++ b/.changeset/footer-dark-bg.md
@@ -1,0 +1,7 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+`Footer`'s `dark` prop now flips the background as well as the text tone — sets `bg-primary-900` (Linseed deep) instead of just adding `surface-dark`. In dark mode the footer also picks up a thin `border-primary-700` top border so it reads as a separate block against the matching-tone page surface.
+
+Light footer (default) is unchanged. Apps already passing `dark` will see a real dark surface instead of just dark-tone text on the previous overlay-press background.

--- a/apps/web/src/app/(admin)/layout.tsx
+++ b/apps/web/src/app/(admin)/layout.tsx
@@ -1,13 +1,10 @@
 import type { ReactNode } from 'react';
-import Link from 'next/link';
 
 import { Unauthorized } from '@eventuras/ratio-ui/blocks/Unauthorized';
-import { Footer } from '@eventuras/ratio-ui/core/Footer';
-import { List } from '@eventuras/ratio-ui/core/List';
 
+import SiteFooter from '@/components/eventuras/SiteFooter';
 import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import { checkAuthorization } from '@/utils/auth/checkAuthorization';
-import getSiteSettings from '@/utils/site/getSiteSettings';
 
 // Force dynamic rendering for all admin routes since they use authentication
 export const dynamic = 'force-dynamic';
@@ -27,23 +24,13 @@ export default async function AdminLayout({ children }: Readonly<{ children: Rea
     return <Unauthorized />;
   }
 
-  const site = await getSiteSettings();
-
   return (
     <>
       <SiteNavbar />
 
       <main id="main-content">{children}</main>
 
-      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
-        <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
-          {site?.footerLinks?.map((link, idx) => (
-            <List.Item key={link.href ?? idx} className="mb-4">
-              <Link href={link.href}>{link.text}</Link>
-            </List.Item>
-          ))}
-        </List>
-      </Footer.Classic>
+      <SiteFooter />
     </>
   );
 }

--- a/apps/web/src/app/(frontpage)/layout.tsx
+++ b/apps/web/src/app/(frontpage)/layout.tsx
@@ -1,10 +1,6 @@
 import type { ReactNode } from 'react';
-import Link from 'next/link';
 
-import { Footer } from '@eventuras/ratio-ui/core/Footer';
-import { List } from '@eventuras/ratio-ui/core/List';
-
-import getSiteSettings from '@/utils/site/getSiteSettings';
+import SiteFooter from '@/components/eventuras/SiteFooter';
 
 /**
  * (frontpage) Route Group Layout
@@ -12,24 +8,14 @@ import getSiteSettings from '@/utils/site/getSiteSettings';
  * No navbar - Hero component has integrated user menu
  * Full-width content for hero section
  */
-export default async function FrontpageLayout({ children }: Readonly<{ children: ReactNode }>) {
-  const site = await getSiteSettings();
-
+export default function FrontpageLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <>
       <main id="main-content" className="w-full">
         {children}
       </main>
 
-      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
-        <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
-          {site?.footerLinks?.map((link, idx) => (
-            <List.Item key={link.href ?? idx} className="mb-4">
-              <Link href={link.href}>{link.text}</Link>
-            </List.Item>
-          ))}
-        </List>
-      </Footer.Classic>
+      <SiteFooter />
     </>
   );
 }

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -1,35 +1,21 @@
 import type { ReactNode } from 'react';
-import Link from 'next/link';
 
-import { Footer } from '@eventuras/ratio-ui/core/Footer';
-import { List } from '@eventuras/ratio-ui/core/List';
-
+import SiteFooter from '@/components/eventuras/SiteFooter';
 import SiteNavbar from '@/components/eventuras/SiteNavbar';
-import getSiteSettings from '@/utils/site/getSiteSettings';
 
 /**
  * (public) Route Group Layout
  * For publicly accessible pages: /collections, /events
  * Includes navbar and footer with container-wrapped content
  */
-export default async function PublicLayout({ children }: Readonly<{ children: ReactNode }>) {
-  const site = await getSiteSettings();
-
+export default function PublicLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <>
       <SiteNavbar />
 
       <main id="main-content">{children}</main>
 
-      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
-        <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
-          {site?.footerLinks?.map((link, idx) => (
-            <List.Item key={link.href ?? idx} className="mb-4">
-              <Link href={link.href}>{link.text}</Link>
-            </List.Item>
-          ))}
-        </List>
-      </Footer.Classic>
+      <SiteFooter />
     </>
   );
 }

--- a/apps/web/src/app/(user)/layout.tsx
+++ b/apps/web/src/app/(user)/layout.tsx
@@ -1,11 +1,7 @@
 import type { ReactNode } from 'react';
-import Link from 'next/link';
 
-import { Footer } from '@eventuras/ratio-ui/core/Footer';
-import { List } from '@eventuras/ratio-ui/core/List';
-
+import SiteFooter from '@/components/eventuras/SiteFooter';
 import SiteNavbar from '@/components/eventuras/SiteNavbar';
-import getSiteSettings from '@/utils/site/getSiteSettings';
 
 // Force dynamic rendering for all user routes since they use authentication
 export const dynamic = 'force-dynamic';
@@ -16,24 +12,14 @@ export const dynamic = 'force-dynamic';
  * Includes navbar and footer with container-wrapped content
  * Requires authentication
  */
-export default async function UserLayout({ children }: Readonly<{ children: ReactNode }>) {
-  const site = await getSiteSettings();
-
+export default function UserLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <>
       <SiteNavbar />
 
       <main id="main-content">{children}</main>
 
-      <Footer.Classic siteTitle={site?.name} publisher={site?.publisher}>
-        <List className="list-none text-gray-800 dark:text-gray-300 font-medium">
-          {site?.footerLinks?.map((link, idx) => (
-            <List.Item key={link.href ?? idx} className="mb-4">
-              <Link href={link.href}>{link.text}</Link>
-            </List.Item>
-          ))}
-        </List>
-      </Footer.Classic>
+      <SiteFooter />
     </>
   );
 }

--- a/apps/web/src/components/eventuras/SiteFooter.tsx
+++ b/apps/web/src/components/eventuras/SiteFooter.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+import { Footer } from '@eventuras/ratio-ui/core/Footer';
+import { List } from '@eventuras/ratio-ui/core/List';
+
+import getSiteSettings from '@/utils/site/getSiteSettings';
+
+/**
+ * Shared site footer used by every route group layout. Renders the
+ * canonical dark `Footer.Classic` with the site's name + publisher
+ * block on the left and the configured footer links on the right.
+ *
+ * Centralised so the footer pattern (and any future tweak — column
+ * count, link styling, social rows) lives in one place instead of
+ * being duplicated across `(frontpage)`, `(public)`, `(user)`, and
+ * `(admin)` layouts.
+ */
+export default async function SiteFooter() {
+  const site = await getSiteSettings();
+
+  return (
+    <Footer.Classic dark siteTitle={site?.name} publisher={site?.publisher}>
+      <List>
+        {site?.footerLinks?.map((link, idx) => (
+          <List.Item key={link.href ?? idx} className="mb-4">
+            <Link href={link.href} className="hover:text-(--accent)">
+              {link.text}
+            </Link>
+          </List.Item>
+        ))}
+      </List>
+    </Footer.Classic>
+  );
+}

--- a/libs/ratio-ui/src/core/Footer/Footer.tsx
+++ b/libs/ratio-ui/src/core/Footer/Footer.tsx
@@ -16,9 +16,12 @@ export interface FooterProps {
   children?: React.ReactNode;
   className?: string;
   /**
-   * Marks the footer as a dark surface so child text uses the light
-   * `var(--text)` color. Use when the footer is rendered against a
-   * dark page or branded section.
+   * Render the footer as a dark surface — flips the background to
+   * `--color-primary-900` (Linseed deep) and applies `surface-dark`
+   * so child text picks up the light `var(--text)` color. In dark
+   * mode the footer also gets a thin `--color-primary-700` top border
+   * so it reads as a separate block against the dark page surface.
+   * Use to anchor the bottom of the page with a deep block.
    */
   dark?: boolean;
 }
@@ -43,8 +46,10 @@ interface FooterComponent extends React.FC<FooterProps> {
 const FooterRoot: FooterComponent = (({ children, className, dark }: FooterProps) => (
   <footer
     className={cn(
-      'p-3 pt-10 bg-overlay-press',
-      dark && 'surface-dark',
+      'p-3 pt-10',
+      dark
+        ? 'bg-primary-900 surface-dark dark:border-t dark:border-primary-700'
+        : 'bg-overlay-press',
       className,
     )}
   >


### PR DESCRIPTION
## Summary

\`Footer\`'s \`dark\` prop previously only added \`surface-dark\` to flip child text tone — the background stayed \`bg-overlay-press\` (a light overlay). That meant \`<Footer dark>\` rendered as light text on a near-white surface, which is not what \"dark\" should mean.

### Changes

- **\`Footer\`** — \`dark\` now flips the background to \`bg-primary-900\` (Linseed deep) in addition to the surface-dark text tone. In dark mode the footer also picks up a thin \`border-primary-700\` top border so it reads as a separate block against the page surface (which is also Linseed-toned in dark mode).
- **\`apps/web\` layouts** — adopt \`<Footer.Classic dark>\` across all four route groups (frontpage, public, user, admin) for a consistent dark anchor at the bottom of every page. Drop the redundant \`text-gray-800 dark:text-gray-300\` classes (handled by \`surface-dark\` now), add \`hover:text-(--accent)\` for a small Ochre kick on footer links.

This is a small step toward the canonical footer pattern — not the full 4-column grid + brand + bottom-strip yet. That's planned for a later PR.

## Test plan

- [x] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui build\` clean
- [x] \`apps/web\` typechecks
- [ ] Visual: light mode — footer is deep Linseed-900 against light page, strong contrast
- [ ] Visual: dark mode — footer is Linseed-900 against page Linseed-950, thin Linseed-700 top border separates them
- [ ] Visual: footer links — light text, Ochre on hover
- [ ] Visual: cycle through frontpage, /events, /user, /admin — confirm consistent dark footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)