### PR TITLE
fix(ratio-ui): make ValueTile server-component-safe

### DIFF
--- a/.changeset/value-tile-server-component.md
+++ b/.changeset/value-tile-server-component.md
@@ -1,0 +1,7 @@
+---
+"@eventuras/ratio-ui": patch
+---
+
+Fix `ValueTile` to work in React Server Components. The compound API used `createContext` / `useContext` to propagate the `orientation` from the root to `ValueTile.Caption`, which forced any page rendering a `ValueTile` to wrap with `'use client'` (or saw a Next.js build error: "createContext only works in Client Components").
+
+Replace the context with a `data-orientation` attribute on the root + named Tailwind `group-orientation-horizontal/value-tile:` variant on the caption — same observable behaviour, no React context, server-component-safe everywhere.

--- a/libs/ratio-ui/src/core/ValueTile/ValueTile.tsx
+++ b/libs/ratio-ui/src/core/ValueTile/ValueTile.tsx
@@ -42,7 +42,9 @@ interface ValueTileComponent extends React.FC<ValueTileProps> {
   Caption: React.FC<CaptionProps>;
 }
 
-const OrientationContext = React.createContext<ValueTileOrientation>('vertical');
+// Orientation propagates from root to Caption via a `data-orientation`
+// attribute on the root element + Tailwind's named group-data variant.
+// CSS-only so ValueTile stays server-component-safe (no React context).
 
 /**
  * Editorial stat tile — a serif display value with a small muted caption.
@@ -93,11 +95,13 @@ const ValueTileRoot: ValueTileComponent = (({
   );
 
   return (
-    <OrientationContext.Provider value={orientation}>
-      <div className={cn(layoutClass, className)} data-testid={testId}>
-        {inner}
-      </div>
-    </OrientationContext.Provider>
+    <div
+      className={cn('group/value-tile', layoutClass, className)}
+      data-orientation={orientation}
+      data-testid={testId}
+    >
+      {inner}
+    </div>
   );
 }) as ValueTileComponent;
 
@@ -124,20 +128,19 @@ const ValueTileValue: React.FC<ValueProps> = ({ children, className }) => (
  * (horizontal). The vertical layout adds a small top margin; horizontal
  * relies on the parent's gap.
  */
-const ValueTileCaption: React.FC<CaptionProps> = ({ children, className }) => {
-  const orientation = React.useContext(OrientationContext);
-  return (
-    <p
-      className={cn(
-        'text-sm text-(--text-muted)',
-        orientation === 'vertical' && 'mt-1.5',
-        className,
-      )}
-    >
-      {children}
-    </p>
-  );
-};
+const ValueTileCaption: React.FC<CaptionProps> = ({ children, className }) => (
+  <p
+    className={cn(
+      'text-sm text-(--text-muted)',
+      // Vertical (default) gets a small top margin; horizontal cancels it
+      // so the caption sits flush on the same baseline.
+      'mt-1.5 group-data-[orientation=horizontal]/value-tile:mt-0',
+      className,
+    )}
+  >
+    {children}
+  </p>
+);
 
 ValueTileRoot.Value = ValueTileValue;
 ValueTileRoot.Caption = ValueTileCaption;


### PR DESCRIPTION
## Summary

\`ValueTile\` used React \`createContext\` / \`useContext\` to propagate the \`orientation\` flag from the root to \`ValueTile.Caption\` (so the caption could conditionally add a small top margin in vertical layout). That forced any page rendering a \`ValueTile\` to add \`'use client'\` (or hit Next.js's build error: *\"createContext only works in Client Components\"*).

Reproduce: render \`<ValueTile number={42} label=\"foo\" />\` inside a Next.js server component → build/runtime fails.

## Fix

Replace the React context with a \`data-orientation\` attribute on the root \`<div>\` + a named Tailwind \`group-orientation-horizontal/value-tile:\` variant on the caption. Same observable behaviour — vertical layout keeps the \`mt-1.5\` gap, horizontal cancels it — but propagation happens in CSS, no React context, server-component-safe everywhere.

Same pattern as the previous \`Strip\` server-component fix.

## Test plan

- [x] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui build\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui test\` — 374 passed
- [ ] Visual: Storybook \`Core/ValueTile\` — vertical and horizontal orientation render identically to before
- [ ] Visual: render \`<ValueTile>\` in apps/web from a server component, confirm no \`'use client'\` build error

🤖 Generated with [Claude Code](https://claude.com/claude-code)