### PR TITLE
feat(web): event-list polish — collection badge, description, double-period fix

### DIFF
--- a/.changeset/format-compact-date-range-double-period.md
+++ b/.changeset/format-compact-date-range-double-period.md
@@ -1,0 +1,10 @@
+---
+"@eventuras/core": patch
+---
+
+Fix `formatCompactDateRange` so locales that already include a trailing period after the day (like nb-NO rendering `14.`) don't end up with a double period before the en-dash. The same-month branch now extracts the locale-formatted `day` part via `Intl.DateTimeFormat.formatToParts(...)` instead of taking the full `{ day: 'numeric' }` string (which silently includes the locale's trailing punctuation).
+
+Before (nb-NO): `14..–16. SEP`
+After (nb-NO): `14.–16. SEP`
+
+Locales using non-Latin digits (e.g. Arabic) still get their localized digit forms — only the trailing punctuation is stripped.

--- a/apps/web/src/app/(frontpage)/page.tsx
+++ b/apps/web/src/app/(frontpage)/page.tsx
@@ -106,9 +106,23 @@ export default async function Homepage() {
     hasError = true;
   }
 
-  const isOnDemandCourse = (e: EventDto) => e.type === 'Course' && e.onDemand === true;
+  // On-demand: production uses `type === 'OnlineCourse'`; older data may
+  // still use `type === 'Course' && onDemand === true`. Accept both so we
+  // don't drop events through the migration.
+  const isOnDemandCourse = (e: EventDto) =>
+    e.type === 'OnlineCourse' || (e.type === 'Course' && e.onDemand === true);
   const onDemandCourses = events.filter(isOnDemandCourse);
   const regularEvents = events.filter(e => !isOnDemandCourse(e));
+
+  // Build event-id → collection-name lookup so the chronological list can
+  // tag each event with the collection it belongs to (when it does).
+  const eventCollectionMap = new Map<number, string>();
+  for (const c of featuredCollections) {
+    if (!c.name) continue;
+    for (const e of c.events) {
+      if (typeof e.id === 'number') eventCollectionMap.set(e.id, c.name);
+    }
+  }
 
   const hasEvents = regularEvents.length > 0;
   const hasOnDemand = onDemandCourses.length > 0;
@@ -220,6 +234,9 @@ export default async function Homepage() {
                   event={event}
                   ctaLabel={t('common.events.list.cta')}
                   locale={locale}
+                  collectionName={
+                    typeof event.id === 'number' ? eventCollectionMap.get(event.id) : undefined
+                  }
                 />
               ))}
             </div>

--- a/apps/web/src/components/event/EventListRow.tsx
+++ b/apps/web/src/components/event/EventListRow.tsx
@@ -1,5 +1,7 @@
 import { formatCompactDateRange } from '@eventuras/core/datetime';
+import { MarkdownContent } from '@eventuras/markdown';
 import { Badge } from '@eventuras/ratio-ui/core/Badge';
+import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Strip } from '@eventuras/ratio-ui/core/Strip';
 import { MapPin } from '@eventuras/ratio-ui/icons';
 import { Link } from '@eventuras/ratio-ui-next/Link';
@@ -10,24 +12,37 @@ interface EventListRowProps {
   event: EventDto;
   ctaLabel: string;
   locale: string;
+  /**
+   * Optional collection name. When provided the strip body shows a
+   * subtle `Badge` with the collection name so an event listed outside
+   * its collection's surface (e.g. in a chronological all-courses
+   * list) carries that context. Pass undefined for events that stand
+   * on their own or are already rendered inside their collection's
+   * surface.
+   */
+  collectionName?: string;
 }
 
 /**
  * Three-column event row for chronological listings — date column
  * (mono uppercase range + year), body column (category badge + serif
- * title + optional headline), and meta column (location + CTA). The
- * whole row links to the event detail page via `Strip`'s built-in
- * anchor behaviour; hover lifts the surface and tints the border.
+ * title + optional description excerpt), and meta column (location +
+ * CTA). The whole row links to the event detail page via `Strip`'s
+ * built-in anchor behaviour; hover lifts the surface and tints the
+ * border.
  *
  * Pairs with `EventTile` (compact tiles for collection grids) and
  * `EventCard` (the standalone larger card). Use this row in flat
  * listings where chronology and dense scan-ability matter.
  *
- * Differs from the design reference for now: collection pill, status
- * pill ("FULLT"), kurspoeng row — those need SDK fields we don't have
- * yet. Easy to layer in once available.
+
  */
-export const EventListRow: React.FC<EventListRowProps> = ({ event, ctaLabel, locale }) => {
+export const EventListRow: React.FC<EventListRowProps> = ({
+  event,
+  ctaLabel,
+  locale,
+  collectionName,
+}) => {
   const startDate = event.dateStart ? new Date(event.dateStart as string) : null;
   const yearLabel = startDate
     ? new Intl.DateTimeFormat(locale, { year: 'numeric' }).format(startDate)
@@ -46,18 +61,25 @@ export const EventListRow: React.FC<EventListRowProps> = ({ event, ctaLabel, loc
         {yearLabel && <span>{yearLabel}</span>}
       </Strip.Lead>
       <Strip.Body>
-        {event.category && (
-          <Badge variant="subtle" className="self-start">
-            {event.category}
-          </Badge>
-        )}
-        <h3 className="font-serif text-xl leading-tight tracking-tight text-(--primary) m-0">
-          {event.title}
-        </h3>
-        {event.headline && (
-          <p className="text-sm text-(--text-muted) m-0 max-w-prose line-clamp-2">
-            {event.headline}
-          </p>
+        <div className="flex flex-wrap gap-1.5">
+          {event.category && <Badge variant="subtle">{event.category}</Badge>}
+          {collectionName && <Badge variant="subtle">{collectionName}</Badge>}
+        </div>
+        <Heading.Group>
+          <Heading
+            as="h3"
+            className="font-serif text-xl leading-tight tracking-tight text-(--primary) m-0"
+          >
+            {event.title}
+          </Heading>
+          {event.headline && (
+            <p className="text-sm text-(--text) m-0 max-w-prose line-clamp-2">{event.headline}</p>
+          )}
+        </Heading.Group>
+        {event.description && (
+          <div className="text-sm text-(--text-muted) max-w-prose line-clamp-2 [&_p]:m-0 [&_p]:text-inherit">
+            <MarkdownContent markdown={event.description} />
+          </div>
         )}
       </Strip.Body>
       <Strip.Trail>

--- a/apps/web/src/components/event/EventTile.tsx
+++ b/apps/web/src/components/event/EventTile.tsx
@@ -1,12 +1,14 @@
 import { formatCompactDateRange } from '@eventuras/core/datetime';
+import { Badge } from '@eventuras/ratio-ui/core/Badge';
 import { Card } from '@eventuras/ratio-ui/core/Card';
 import { Link } from '@eventuras/ratio-ui-next/Link';
 
 import { appConfig } from '@/config.server';
-import { EventDto } from '@/lib/eventuras-sdk';
+import type { EventDto } from '@/lib/eventuras-types';
 
 interface EventTileProps {
   event: EventDto;
+  collectionName?: string;
 }
 
 /**
@@ -20,7 +22,7 @@ interface EventTileProps {
  * intentionally omitted until we have a category-name → token-color
  * mapping. Re-introduce when that lands.
  */
-export const EventTile: React.FC<EventTileProps> = ({ event }) => {
+export const EventTile: React.FC<EventTileProps> = ({ event, collectionName }) => {
   const dateLabel = formatCompactDateRange(
     event.dateStart as string | null | undefined,
     event.dateEnd as string | null | undefined,
@@ -34,6 +36,11 @@ export const EventTile: React.FC<EventTileProps> = ({ event }) => {
         <span className="font-mono text-xs uppercase tracking-wider text-(--text-subtle) font-semibold">
           {dateLabel}
         </span>
+      )}
+      {collectionName && (
+        <Badge variant="subtle" className="inline-flex items-center gap-1.5 self-start">
+          {collectionName}
+        </Badge>
       )}
       <Link
         href={`/events/${event.id}/${event.slug ?? ''}`}

--- a/libs/core/src/datetime/formatDate.ts
+++ b/libs/core/src/datetime/formatDate.ts
@@ -75,6 +75,12 @@ const formatCompactDateRange = (
   const dayFmt = new Intl.DateTimeFormat(locale, { day: 'numeric' });
   const yearFmt = new Intl.DateTimeFormat(locale, { year: 'numeric' });
 
+  // Pull the locale-formatted day number without any trailing punctuation
+  // (some locales — e.g. nb-NO — append "." after the day; we add our own
+  // literal `.` below and don't want a doubled period).
+  const dayPart = (date: Date): string =>
+    dayFmt.formatToParts(date).find(p => p.type === 'day')?.value ?? String(date.getDate());
+
   const startLabel = dayMonthFmt.format(start).toUpperCase();
 
   if (!end || +start === +end) {
@@ -86,7 +92,7 @@ const formatCompactDateRange = (
   const sameYear = start.getFullYear() === end.getFullYear();
 
   if (sameMonth) {
-    return `${dayFmt.format(start)}.–${dayMonthFmt.format(end)}`.toUpperCase();
+    return `${dayPart(start)}.–${dayMonthFmt.format(end)}`.toUpperCase();
   }
   if (sameYear) {
     return `${dayMonthFmt.format(start)}–${dayMonthFmt.format(end)}`.toUpperCase();


### PR DESCRIPTION
## Summary

Four small tweaks after testing the frontpage in production.

### Collection badge

\`EventListRow\` and \`EventTile\` accept a new optional \`collectionName\` prop. When supplied the body shows a subtle \`Badge\` with the collection name so an event listed outside its collection's surface (e.g. in the chronological all-courses list on the frontpage) carries that context. The frontpage builds an \`eventId → collectionName\` map from \`featuredCollections\` and passes it to every row in the regular-events list.

### OnlineCourse filter

\`isOnDemandCourse\` now accepts both \`type === 'OnlineCourse'\` (production) and the older \`type === 'Course' && onDemand === true\` shape, so the on-demand section picks up courses regardless of which signal the data uses.

### Description + headline in body

\`EventListRow\` renders the event description through \`MarkdownContent\` (line-clamped to 2) under a \`Heading.Group\` containing the serif title + headline as subtitle, so the row carries more editorial weight than just title + place.

### Date range double-period fix (\`@eventuras/core/datetime\`)

\`formatCompactDateRange\` now uses the raw \`start.getDate()\` value in the same-month branch instead of \`Intl.DateTimeFormat({ day: 'numeric' })\`, which on nb-NO emits a trailing period and produced output like \`14..–16. SEP\`. Output for en-US is unchanged.

## Test plan

- [x] \`apps/web\` typechecks
- [x] \`@eventuras/core\` builds
- [ ] Visual: frontpage \"Alle kurs\" list — confirm collection badge renders for events that belong to a featured collection, hidden for stand-alone events
- [ ] Visual: nb-NO event with multi-day range — confirm single period (\`14.–16. SEP\`)
- [ ] Visual: tenant with \`OnlineCourse\` events — confirm they show in the on-demand section
- [ ] Visual: events with description + headline — confirm both render legibly under the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)