### PR TITLE
feat(ratio-ui): add Menu.Header (beta) + polish menu trigger and popover

### DIFF
--- a/.changeset/avatar-component.md
+++ b/.changeset/avatar-component.md
@@ -1,0 +1,17 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add `Avatar` — circular user-avatar component with serif italic initials over a primary-tinted radial gradient. Pass `src` to render a profile image; the browser handles the load. The component does not silently fall back to the initials on broken images — pass URLs you've already verified, or skip `src` and rely on the initials.
+
+```tsx
+<Avatar name="Leo Losen" />                  // initials "ll" auto-derived
+<Avatar name="Ola" initials="o" size="sm" /> // manual override + small
+<Avatar name="Ada Lovelace" src="/me.jpg" size="lg" /> // image + lg
+```
+
+Three sizes — `sm` (30px) for navbar trigger pills, `md` (40px) default, `lg` (44px) for the identity header inside user-menu dropdowns. Initials auto-derive from `name` (first letter of first + last word, lowercased; first two letters for a single-word name) with a manual `initials` override for edge cases.
+
+The radial gradient uses different primary-mix percentages per theme (25/12 in light, 10/4 in dark) so the avatar reads as lighter against a light page and noticeably darker against the dark surface. Initial text uses `text-primary-800 dark:text-primary-200` for strong contrast in either mode.
+
+When `src` is set the wrapper carries `role="img"` plus an accessible name from `name` (or the new `ariaLabel` override) so screen readers announce something meaningful even if the image element itself ends up empty.

--- a/.changeset/menu-header.md
+++ b/.changeset/menu-header.md
@@ -1,0 +1,25 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add `Menu.Header` (beta) — identity block for the top of a user-menu dropdown. Composes a leading node (typically `<Avatar>`) with three meta slots — `Menu.Header.Name`, `Menu.Header.Email`, `Menu.Header.Role` — over a primary-tinted background separated from the menu items by a hairline border.
+
+```tsx
+import { Avatar } from '@eventuras/ratio-ui/core/Avatar';
+
+<Menu>
+  <Menu.Trigger>...</Menu.Trigger>
+  <Menu.Header>
+    <Avatar name="Leo Losen" size="lg" />
+    <Menu.Header.Name>Leo Losen</Menu.Header.Name>
+    <Menu.Header.Email>leo@losen.com</Menu.Header.Email>
+    <Menu.Header.Role>Admin</Menu.Header.Role>
+  </Menu.Header>
+  <Menu.Link href="/user">My profile</Menu.Link>
+  <Menu.Button id="logout" onClick={...}>Log out</Menu.Button>
+</Menu>
+```
+
+The component walks its children and groups the meta slots into a flex column to the right of any non-meta children, so consumers write the natural reading order without wrapping the meta column themselves.
+
+Marked `@beta` in JSDoc — the prop shape, slot contract, and visual treatment may evolve before release. Additive only: existing `Menu` callers are unaffected.

--- a/libs/ratio-ui/src/core/Avatar/Avatar.stories.tsx
+++ b/libs/ratio-ui/src/core/Avatar/Avatar.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Avatar } from './Avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Core/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'inline-radio',
+      options: ['sm', 'md', 'lg'],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Initials: Story = {
+  args: {
+    name: 'Leo Losen',
+    size: 'md',
+  },
+};
+
+export const SingleWordName: Story = {
+  args: {
+    name: 'Ola',
+    size: 'md',
+  },
+};
+
+export const ManualInitials: Story = {
+  args: {
+    name: 'Leo van der Losen',
+    initials: 'lv',
+    size: 'md',
+  },
+};
+
+export const WithImage: Story = {
+  args: {
+    name: 'Ada Lovelace',
+    src: 'https://i.pravatar.cc/100?img=1',
+    size: 'md',
+  },
+};
+
+/**
+ * Documents what a 404 image looks like with the current implementation:
+ * the browser paints its default broken-image indicator inside the
+ * `<img>` box. The component does not silently fall back to the
+ * initials on load failure — pass URLs you've already verified, or
+ * skip `src` entirely.
+ */
+export const BrokenImageDoesNotSilentlyFallBack: Story = {
+  args: {
+    name: 'Leo Losen',
+    src: 'https://example.invalid/this-will-404.jpg',
+    size: 'md',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex items-end gap-4">
+      <div className="flex flex-col items-center gap-1">
+        <Avatar name="Leo Losen" size="sm" />
+        <span className="text-xs text-(--text-muted)">sm — 30px</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar name="Leo Losen" size="md" />
+        <span className="text-xs text-(--text-muted)">md — 40px</span>
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Avatar name="Leo Losen" size="lg" />
+        <span className="text-xs text-(--text-muted)">lg — 44px</span>
+      </div>
+    </div>
+  ),
+};
+
+export const InsideMenuTrigger: Story = {
+  render: () => (
+    <button
+      type="button"
+      className="inline-flex items-center gap-2.5 pl-1 pr-4 py-1 rounded-full border border-border-2 bg-card text-(--text) hover:border-(--primary) transition-colors"
+    >
+      <Avatar name="Leo Losen" size="sm" />
+      <span className="text-sm">leo@losen.com</span>
+    </button>
+  ),
+};

--- a/libs/ratio-ui/src/core/Avatar/Avatar.tsx
+++ b/libs/ratio-ui/src/core/Avatar/Avatar.tsx
@@ -1,0 +1,123 @@
+import type { FC } from 'react';
+import { cn } from '../../utils/cn';
+
+export type AvatarSize = 'sm' | 'md' | 'lg';
+
+export interface AvatarProps {
+  /**
+   * User image URL. Rendered as an `<img>` over the initials. When the
+   * URL loads, the photo covers the initials. When it fails to load
+   * the browser paints its default broken-image indicator inside the
+   * `<img>` box, which obscures the initials underneath — pass URLs
+   * you've already verified, or skip `src` and rely on the initials.
+   */
+  src?: string;
+  /**
+   * User's name. Used for the `<img>` alt attribute, the wrapper's
+   * accessible name when `src` is set, and (when `initials` is
+   * omitted) auto-derived initials — first letter of the first and
+   * last word, lowercased; for a single-word name the first two
+   * letters of that word.
+   */
+  name?: string;
+  /**
+   * Initials to display under the image. Defaults to the first letter
+   * of the first and last word in `name` (or the first two letters
+   * for a single-word name). Override when the auto-derivation isn't
+   * quite right (e.g. "Leo van der Losen" → `ll` by default; pass
+   * `'lv'` to keep "van" in there).
+   */
+  initials?: string;
+  /**
+   * Visual size — `sm` (30px), `md` (40px), `lg` (44px). Matches the
+   * design reference's trigger / default / identity-header sizes.
+   */
+  size?: AvatarSize;
+  /**
+   * Override the wrapper's accessible label. Defaults to `name` when
+   * `src` is set, otherwise the avatar relies on the visible initials
+   * and is left unlabelled. Use this to provide a meaningful label
+   * when neither `name` nor visible content carries one.
+   */
+  ariaLabel?: string;
+  className?: string;
+  testId?: string;
+}
+
+const SIZE_CLASSES: Record<AvatarSize, string> = {
+  sm: 'size-[30px] text-[13px]',
+  md: 'size-10 text-sm',
+  lg: 'size-11 text-lg',
+};
+
+function deriveInitials(name?: string): string {
+  if (!name) return '';
+  const parts = name.trim().split(/\s+/);
+  if (parts.length === 0) return '';
+  if (parts.length === 1) {
+    return parts[0]!.slice(0, 2).toLowerCase();
+  }
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toLowerCase();
+}
+
+/**
+ * User avatar — circular badge with serif italic initials over a
+ * primary-tinted radial gradient. Pass `src` to render a profile
+ * image; the browser handles loading and missing-resource painting,
+ * so callers should provide URLs they trust.
+ *
+ * Pair with the `Menu.Trigger` (avatar pill in a navbar) and the
+ * identity header inside a user-menu dropdown — three sizes cover the
+ * common cases.
+ *
+ * @example
+ * ```tsx
+ * <Avatar name="Leo Losen" />                  // initials "ll"
+ * <Avatar name="Ola" initials="o" size="sm" /> // override + small
+ * <Avatar name="Ola" src="/avatar.jpg" size="lg" /> // image + lg
+ * ```
+ */
+export const Avatar: FC<AvatarProps> = ({
+  src,
+  name,
+  initials,
+  size = 'md',
+  ariaLabel,
+  className,
+  testId,
+}) => {
+  const initialsText = initials ?? deriveInitials(name);
+  const wrapperLabel = ariaLabel ?? (src ? name : undefined);
+  // Only set role="img" when we also have an accessible label. A
+  // role="img" without a name fails axe rules, and the avatar with
+  // visible initials and no src is already labelled by its text.
+  const a11yProps = wrapperLabel
+    ? { role: 'img' as const, 'aria-label': wrapperLabel }
+    : {};
+
+  return (
+    <span
+      className={cn(
+        'relative inline-flex items-center justify-center rounded-full overflow-hidden shrink-0',
+        'text-primary-800 dark:text-primary-200 font-serif italic font-medium tracking-tight',
+        'bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklch,var(--primary)_25%,var(--surface)),color-mix(in_oklch,var(--primary)_12%,var(--surface)))]',
+        'dark:bg-[radial-gradient(circle_at_30%_30%,color-mix(in_oklch,var(--primary)_10%,var(--surface)),color-mix(in_oklch,var(--primary)_4%,var(--surface)))]',
+        SIZE_CLASSES[size],
+        className,
+      )}
+      {...a11yProps}
+      data-testid={testId}
+    >
+      {initialsText && <span aria-hidden={Boolean(src)}>{initialsText}</span>}
+      {src && (
+        <img
+          src={src}
+          alt={name ?? ''}
+          className="absolute inset-0 size-full object-cover"
+        />
+      )}
+    </span>
+  );
+};
+
+Avatar.displayName = 'Avatar';

--- a/libs/ratio-ui/src/core/Avatar/index.ts
+++ b/libs/ratio-ui/src/core/Avatar/index.ts
@@ -1,0 +1,2 @@
+export { Avatar } from './Avatar';
+export type { AvatarProps, AvatarSize } from './Avatar';

--- a/libs/ratio-ui/src/core/Menu/Menu.stories.tsx
+++ b/libs/ratio-ui/src/core/Menu/Menu.stories.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Meta, StoryFn } from '@storybook/react-vite';
 import Menu, { MenuProps } from './Menu';
+import { Avatar } from '../Avatar';
 import { fn } from 'storybook/test';
 
 const meta: Meta<typeof Menu> = {
@@ -118,19 +119,14 @@ export const WithThemeToggle: MenuStory = () => {
 };
 
 /**
- * A custom trigger — pass any content + className to override the default
- * pill. Useful for avatar-style triggers or icon-only buttons.
+ * A custom trigger pill with the new `Avatar` component — the canonical
+ * user-menu trigger look.
  */
 export const CustomTrigger: MenuStory = () => (
   <Menu>
-    <Menu.Trigger className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border border-border-2 bg-card text-(--text) hover:border-(--primary) transition-colors">
-      <span
-        aria-hidden="true"
-        className="w-7 h-7 rounded-full bg-(--primary)/20 text-(--primary) font-serif italic text-sm flex items-center justify-center"
-      >
-        ol
-      </span>
-      <span className="text-sm">losvik@gmail.com</span>
+    <Menu.Trigger className="inline-flex items-center gap-2.5 pl-1 pr-4 py-1 rounded-full border border-border-2 bg-card text-(--text) hover:border-(--primary) transition-colors">
+      <Avatar name="Leo Losen" size="sm" />
+      <span className="text-sm">leo@losen.com</span>
       <Menu.Chevron className="ml-0 h-3.5 w-3.5 text-(--text-muted)" />
     </Menu.Trigger>
     <Menu.Link href="/user">My profile</Menu.Link>
@@ -139,4 +135,35 @@ export const CustomTrigger: MenuStory = () => (
       Log out
     </Menu.Button>
   </Menu>
+);
+
+/**
+ * The full user-menu shape with `Menu.Header` at the top — avatar +
+ * name + email + role chip on a primary-tinted surface, followed by
+ * the regular menu items.
+ *
+ * `Menu.Header` and its `.Name` / `.Email` / `.Role` slots are marked
+ * `@beta` — the API may evolve before release without major bumps.
+ */
+export const UserMenuWithHeader: MenuStory = () => (
+  <div className="flex justify-end">
+    <Menu>
+      <Menu.Trigger className="inline-flex items-center gap-2.5 pl-1 pr-4 py-1 rounded-full border border-border-2 bg-card text-(--text) hover:border-(--accent) focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-(--accent)/45 aria-expanded:shadow-[0_2px_10px_color-mix(in_oklch,var(--accent)_28%,transparent)] transition-all">
+        <Avatar name="Leo Losen" size="sm" />
+        <span className="text-sm">leo@losen.com</span>
+        <Menu.Chevron className="ml-0 h-3.5 w-3.5 text-(--text-muted)" />
+      </Menu.Trigger>
+      <Menu.Header>
+        <Avatar name="Leo Losen" size="lg" />
+        <Menu.Header.Name>Leo Losen</Menu.Header.Name>
+        <Menu.Header.Email>leo@losen.com</Menu.Header.Email>
+        <Menu.Header.Role>Admin</Menu.Header.Role>
+      </Menu.Header>
+      <Menu.Link href="/user">My profile</Menu.Link>
+      <Menu.Link href="/user/account">Account</Menu.Link>
+      <Menu.Button id="user-logout" onClick={() => console.log('Logout')}>
+        Log out
+      </Menu.Button>
+    </Menu>
+  </div>
 );

--- a/libs/ratio-ui/src/core/Menu/Menu.tsx
+++ b/libs/ratio-ui/src/core/Menu/Menu.tsx
@@ -20,8 +20,23 @@ import { ChevronDown, Sun, Moon } from '../../icons';
 import { cn } from '../../utils/cn';
 
 const styles = {
-  popover:
-    'w-56 origin-top-right shadow-lg border border-border-1 rounded-xl overflow-hidden',
+  popover: cn(
+    'min-w-[280px] max-w-sm origin-top-right border border-border-1 rounded-xl overflow-hidden',
+    // Light-mode glow: multi-layer primary-tinted box-shadow gives the
+    // popover a soft editorial lift on the light surface.
+    'shadow-[0_1px_0_color-mix(in_oklch,var(--primary)_6%,transparent),0_12px_28px_color-mix(in_oklch,var(--primary)_18%,transparent),0_4px_8px_color-mix(in_oklch,var(--primary)_12%,transparent)]',
+    // Dark-mode shadow: primary-tinted shadows wash out on the dark
+    // surface, so the design uses a thin white top-highlight + black
+    // depth shadows for separation.
+    'dark:shadow-[0_1px_0_rgb(255_255_255/0.08),0_16px_36px_rgb(0_0_0/0.6),0_4px_12px_rgb(0_0_0/0.4)]',
+    // Pop-in / pop-out animation. React Aria Popover sets
+    // `data-entering` / `data-exiting`; we transition opacity +
+    // transform from a slightly-scaled, slightly-up state into the
+    // resting position for a short editorial pop.
+    'transition-[opacity,transform] duration-150 ease-out',
+    'data-[entering]:opacity-0 data-[entering]:-translate-y-1 data-[entering]:scale-[0.98]',
+    'data-[exiting]:opacity-0 data-[exiting]:-translate-y-1 data-[exiting]:scale-[0.98]',
+  ),
   menuItemsList: 'bg-card focus:outline-hidden',
   menuItem:
     'cursor-pointer group flex w-full items-center px-2 py-3 border-b border-border-1 last:border-b-0 hover:bg-card-hover text-(--text)',
@@ -92,27 +107,34 @@ export type MenuThemeToggleProps = {
 
 const Menu = ({ children }: MenuProps) => {
   const actionsRef = useRef(new Map<string, () => void>());
+  const headerLabelId = useId();
 
   const api = useRef<MenuActionsApi>({
     register: (id, fn) => actionsRef.current.set(id, fn),
     unregister: (id) => actionsRef.current.delete(id),
   }).current;
 
-  // Split children: the first <Menu.Trigger> becomes the React Aria
-  // button, everything else lives inside the popover menu list. This
-  // keeps the compound API ergonomic while preserving Aria's required
-  // shape (button + popover as direct siblings of MenuTrigger).
+  // Split children:
+  //   - first <Menu.Trigger>      → React Aria's button (next to Popover)
+  //   - first <Menu.Header>       → rendered inside Popover but OUTSIDE
+  //                                 AriaMenu (it's not a navigable item;
+  //                                 AriaMenu strips non-MenuItem children)
+  //   - everything else           → menu items inside AriaMenu
   let trigger: ReactNode = null;
+  let header: ReactNode = null;
   const items: ReactNode[] = [];
   for (const child of Children.toArray(children)) {
-    if (isValidElement(child) && child.type === MenuTrigger) {
-      if (trigger === null) {
-        trigger = child;
+    if (isValidElement(child)) {
+      if (child.type === MenuTrigger) {
+        if (trigger === null) trigger = child;
+        continue;
       }
-      // Silently ignore additional <Menu.Trigger>s — first wins.
-    } else {
-      items.push(child);
+      if (child.type === MenuHeader) {
+        if (header === null) header = child;
+        continue;
+      }
     }
+    items.push(child);
   }
   if (trigger === null) {
     throw new Error(
@@ -123,10 +145,16 @@ const Menu = ({ children }: MenuProps) => {
   return (
     <AriaMenuTrigger>
       {trigger}
-      <Popover className={styles.popover}>
+      <Popover placement="bottom end" className={styles.popover}>
+        {header && <div id={headerLabelId}>{header}</div>}
         <MenuActionsContext.Provider value={api}>
           <AriaMenu
             className={styles.menuItemsList}
+            // When a Menu.Header is present, point the menu's accessible
+            // name at it so screen readers announce the user identity
+            // when arrow-keying into the first item, instead of jumping
+            // straight past the visually-rendered header.
+            aria-labelledby={header ? headerLabelId : undefined}
             onAction={key => {
               const fn = actionsRef.current.get(key.toString());
               if (fn) fn();
@@ -191,9 +219,141 @@ const MenuThemeToggle = ({
  * reach into `../icons` themselves.
  */
 const MenuChevron = ({ className }: { className?: string }) => (
-  <ChevronDown aria-hidden="true" className={cn('ml-1 h-5 w-5', className)} />
+  <ChevronDown
+    aria-hidden="true"
+    className={cn(
+      'ml-1 h-5 w-5 transition-transform duration-200',
+      // When the chevron sits inside a trigger with aria-expanded=true
+      // (i.e. the menu is open), flip it 180° so the arrow points up.
+      'in-aria-expanded:rotate-180',
+      className,
+    )}
+  />
 );
 MenuChevron.displayName = 'Menu.Chevron';
+
+// ── Menu.Header (beta) ────────────────────────────────────────────
+//
+// Identity block at the top of a user-menu dropdown. Composes the
+// `Avatar` (or any leading node) with three meta slots — Name, Email,
+// Role — into a flex row over a primary-tinted background.
+
+interface MenuHeaderSlotProps {
+  children?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Display name for the user-menu identity header. Serif, mid-weight,
+ * `--text` color, ellipsised when it overflows the meta column.
+ *
+ * @beta API may evolve before release.
+ */
+const MenuHeaderName = ({ children, className }: MenuHeaderSlotProps) => (
+  <h4
+    className={cn(
+      'font-serif font-medium text-base leading-tight tracking-tight',
+      'text-(--text) m-0 truncate',
+      className,
+    )}
+  >
+    {children}
+  </h4>
+);
+MenuHeaderName.displayName = 'Menu.Header.Name';
+
+/**
+ * Secondary line in the identity header — typically the user's email.
+ * Sans, small, muted, ellipsised.
+ *
+ * @beta API may evolve before release.
+ */
+const MenuHeaderEmail = ({ children, className }: MenuHeaderSlotProps) => (
+  <p
+    className={cn(
+      'text-sm text-(--text-muted) m-0 truncate mt-0.5',
+      className,
+    )}
+  >
+    {children}
+  </p>
+);
+MenuHeaderEmail.displayName = 'Menu.Header.Email';
+
+/**
+ * Optional role / permission chip beneath the name + email — accent-
+ * tinted pill in mono caps. Use for short labels like "Admin", "Owner",
+ * or org-role descriptors.
+ *
+ * @beta API may evolve before release.
+ */
+const MenuHeaderRole = ({ children, className }: MenuHeaderSlotProps) => (
+  <span
+    className={cn(
+      'self-start mt-2 inline-flex items-center px-2 py-0.5 rounded-full',
+      'font-mono text-[10px] uppercase tracking-wider font-bold',
+      'text-(--accent) bg-[color-mix(in_oklch,var(--accent)_18%,var(--surface))]',
+      'border border-[color-mix(in_oklch,var(--accent)_35%,transparent)]',
+      className,
+    )}
+  >
+    {children}
+  </span>
+);
+MenuHeaderRole.displayName = 'Menu.Header.Role';
+
+const META_SLOTS = new Set<unknown>([MenuHeaderName, MenuHeaderEmail, MenuHeaderRole]);
+
+/**
+ * Identity block for the top of a user-menu dropdown. Composes a
+ * leading node (typically `<Avatar>`) with the meta slots
+ * `Menu.Header.Name`, `Menu.Header.Email`, and `Menu.Header.Role`.
+ *
+ * The component walks its children and groups the meta slots into a
+ * flex column to the right of any non-meta children, so consumers
+ * write the natural reading order without wrapping the meta column
+ * themselves.
+ *
+ * @beta API may evolve before release.
+ *
+ * @example
+ * ```tsx
+ * <Menu.Header>
+ *   <Avatar name="Leo Losen" size="lg" />
+ *   <Menu.Header.Name>Leo Losen</Menu.Header.Name>
+ *   <Menu.Header.Email>leo@losen.com</Menu.Header.Email>
+ *   <Menu.Header.Role>Admin</Menu.Header.Role>
+ * </Menu.Header>
+ * ```
+ */
+const MenuHeader = ({ children, className }: MenuHeaderSlotProps) => {
+  const childArray = Children.toArray(children);
+  const meta: ReactNode[] = [];
+  const lead: ReactNode[] = [];
+  for (const child of childArray) {
+    if (isValidElement(child) && META_SLOTS.has(child.type)) {
+      meta.push(child);
+    } else {
+      lead.push(child);
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3.5 px-4 py-4',
+        'bg-[color-mix(in_oklch,var(--primary)_8%,var(--surface))]',
+        'dark:bg-[color-mix(in_oklch,var(--primary)_16%,var(--surface))]',
+        'border-b border-border-1',
+        className,
+      )}
+    >
+      {lead}
+      {meta.length > 0 && <div className="flex flex-col min-w-0 flex-1">{meta}</div>}
+    </div>
+  );
+};
+MenuHeader.displayName = 'Menu.Header';
 
 export default Object.assign(Menu, {
   Trigger: MenuTrigger,
@@ -201,4 +361,9 @@ export default Object.assign(Menu, {
   Link: MenuLink,
   Button: MenuButton,
   ThemeToggle: MenuThemeToggle,
+  Header: Object.assign(MenuHeader, {
+    Name: MenuHeaderName,
+    Email: MenuHeaderEmail,
+    Role: MenuHeaderRole,
+  }),
 });


### PR DESCRIPTION
## Summary

Add an identity block at the top of the user-menu dropdown and polish the surrounding trigger / popover details so the story matches the canonical user-menu look.

### \`Menu.Header\` (beta)

Composes \`<Avatar>\` (or any leading node) with three meta slots — \`Menu.Header.Name\`, \`Menu.Header.Email\`, \`Menu.Header.Role\` — over a primary-tinted background separated from the menu items by a hairline border.

\`\`\`tsx
<Menu>
  <Menu.Trigger>...</Menu.Trigger>
  <Menu.Header>
    <Avatar name=\"Leo Losen\" size=\"lg\" />
    <Menu.Header.Name>Leo Losen</Menu.Header.Name>
    <Menu.Header.Email>leo@losen.com</Menu.Header.Email>
    <Menu.Header.Role>Admin</Menu.Header.Role>
  </Menu.Header>
  <Menu.Link href=\"/user\">My profile</Menu.Link>
</Menu>
\`\`\`

The header walks its children and groups the meta slots into a flex column to the right of any non-meta children, so callers write the natural reading order without wrapping the meta column themselves.

Marked \`@beta\` on the header and each slot — prop shape and visual treatment may evolve before release without major bumps.

### Polish along the way

- **Menu child-splitting** now special-cases \`Menu.Header\` so it renders inside the Popover but outside \`<AriaMenu>\` (which strips non-\`MenuItem\` children, so the previous version collapsed to zero height).
- **Popover placement** → \`bottom end\` so the right edge of the panel aligns with the right edge of the trigger.
- **Popover width** → \`min-w-[280px] max-w-sm\` (was fixed \`w-56\` / 224px), matching the design's 280px floor.
- **Popover shadow** — theme-aware. Light keeps the multi-layer primary-tinted glow. Dark switches to a thin white top-highlight + black depth shadows since primary-tinted shadows wash out on the dark surface.
- **Pop-in / pop-out animation** on the popover via React Aria's \`data-[entering]\` / \`data-[exiting]\` state attributes — 150ms ease-out fade + scale + translate.
- **\`Menu.Chevron\`** rotates 180° when its trigger has \`aria-expanded=true\`, via the Tailwind v4 \`in-aria-expanded\` ancestor variant.

### Stories

The user-menu storybook stories adopt the new \`Avatar\` component for the trigger pill, switch the demo persona to Leo Losen + leo@losen.com, and demonstrate accent-toned hover / focus-ring / open-state glow on the trigger so the story matches the canonical interactive feel.

## Test plan

- [x] \`pnpm --filter @eventuras/ratio-ui exec tsc --noEmit\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui build\` clean
- [x] \`pnpm --filter @eventuras/ratio-ui test\` — 382 passed (+1 from new story)
- [ ] Visual: Storybook \`Core/Menu / UserMenuWithHeader\` — open & confirm: right-aligned with trigger, identity block at top, popover pops in smoothly, chevron flips, ochre glow when open
- [ ] Visual: dark-mode toggle — confirm popover shadow flips to black + white-highlight
- [ ] Visual: \`Core/Menu / CustomTrigger\` — same look without the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)