### PR TITLE
chore(deps): expand renovate grouping and add dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,9 @@
   "minimumReleaseAge": "5 days",
   "prConcurrentLimit": 4,
   "branchConcurrentLimit": 1,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Renovate Dependency Dashboard",
+  "postUpdateOptions": ["pnpmDedupe"],
   "lockFileMaintenance": {
     "enabled": false
   },
@@ -64,6 +67,53 @@
       "matchPackageNames": ["/eslint/"]
     },
     {
+      "description": "Group typescript-eslint family (must come after broad eslint rule)",
+      "groupName": "typescript-eslint",
+      "matchPackageNames": ["/^typescript-eslint$/", "/^@typescript-eslint//"]
+    },
+    {
+      "description": "Group React core + types — must always move together",
+      "groupName": "react",
+      "matchPackageNames": ["/^react$/", "/^react-dom$/", "@types/react", "@types/react-dom"]
+    },
+    {
+      "description": "Group Next.js core + first-party plugins",
+      "groupName": "next",
+      "matchPackageNames": ["/^next$/", "/^@next//", "next-intl", "next-sitemap"]
+    },
+    {
+      "description": "Group Vite + Vitest ecosystem",
+      "groupName": "vite",
+      "matchPackageNames": ["/^vite$/", "/^@vitejs//", "/^vitest$/", "/^@vitest//"]
+    },
+    {
+      "description": "Group Tailwind ecosystem",
+      "groupName": "tailwind",
+      "matchPackageNames": [
+        "/^tailwindcss$/",
+        "/^@tailwindcss//",
+        "tailwind-merge",
+        "tailwindcss-react-aria-components",
+        "autoprefixer",
+        "postcss"
+      ]
+    },
+    {
+      "description": "Group testing-library + jsdom",
+      "groupName": "testing-library",
+      "matchPackageNames": ["/^@testing-library//", "jsdom"]
+    },
+    {
+      "description": "Group TanStack packages",
+      "groupName": "tanstack",
+      "matchPackageNames": ["/^@tanstack//"]
+    },
+    {
+      "description": "Group Radix UI packages",
+      "groupName": "radix",
+      "matchPackageNames": ["/^@radix-ui//"]
+    },
+    {
       "description": "Group Docker base images",
       "matchDatasources": ["docker"],
       "groupName": "docker"
@@ -72,6 +122,11 @@
       "description": "Group GitHub Actions",
       "matchManagers": ["github-actions"],
       "groupName": "github-actions"
+    },
+    {
+      "description": "Label major updates so they're easy to spot in the PR list",
+      "matchUpdateTypes": ["major"],
+      "addLabels": ["major"]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds eight new grouping rules so related packages land in a single PR: `react` (+ types), `next` (+ next-intl/sitemap), `vite` (+ vitest/@vitejs), `tailwind`, `typescript-eslint`, `testing-library` (+ jsdom), `tanstack`, `radix`.
- Enables the Renovate **Dependency Dashboard** issue for visibility into queued/blocked updates (concurrency limit is 4 PRs / 1 branch, so the queue matters).
- Adds `postUpdateOptions: ["pnpmDedupe"]` so transitive duplicates get cleaned up after each update.
- Labels major updates with `major` for easier triage in the PR list.

No change to *what* gets updated — `@types/node` and `lexical` remain pinned via `pnpm.updateConfig.ignoreDependencies` and the existing disabled rules. No auto-merge, no schedule (per current preference).

Rule order is significant (last-match-wins): `typescript-eslint` is placed after the broad `/eslint/` rule so it wins for `@typescript-eslint/*` packages; the `major` label rule is last so it applies on top of all groups via `addLabels` (additive, preserves group routing).

## Test plan
- [x] `node -e` JSON parse check
- [x] `pnpm dlx --package=renovate -- renovate-config-validator renovate.json` → "Config validated successfully"
- [ ] After merge: confirm a "Renovate Dependency Dashboard" issue appears on the next Renovate run
- [ ] Watch the next batch of PRs to confirm grouping (e.g. `react` + `react-dom` arrive together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)