### PR TITLE
chore(deps): split @hey-api codegen into its own renovate group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -114,6 +114,11 @@
       "matchPackageNames": ["/^@radix-ui//"]
     },
     {
+      "description": "Group @hey-api codegen — own PR so regenerated SDK diff is reviewable in isolation",
+      "groupName": "hey-api",
+      "matchPackageNames": ["/^@hey-api//"]
+    },
+    {
       "description": "Group Docker base images",
       "matchDatasources": ["docker"],
       "groupName": "docker"


### PR DESCRIPTION
## Summary
- Adds a `hey-api` group in [renovate.json](renovate.json) so `@hey-api/openapi-ts` (and any future `@hey-api/*` packages) ship in their own PR rather than getting buried in the catch-all `npm minor/patch` group.
- Rationale: `@hey-api/openapi-ts` is a codegen tool — bumps regenerate the event-sdk client via `pnpm openapi:update`. Isolating it makes the regenerated diff reviewable on its own and easy to revert if codegen breaks.
- Default `minimumReleaseAge: 5 days` retained (no special hardening per current preference).

## Test plan
- [x] `renovate-config-validator renovate.json` → "Config validated successfully"
- [ ] After merge: next Renovate cycle, watch for a separate `hey-api` group PR if a bump is queued

🤖 Generated with [Claude Code](https://claude.com/claude-code)