### PR TITLE
ci(deps): self-host renovate via github actions cron

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,63 @@
+# Self-hosted Renovate
+#
+# One-time setup (do once, then forget):
+#   1. Create a new GitHub App: https://github.com/settings/apps/new
+#      - Name: e.g. "eventuras-renovate"
+#      - Homepage URL: anything (e.g. repo URL)
+#      - Webhook: uncheck "Active"
+#      - Permissions (Repository):
+#          Contents: Read and write
+#          Issues: Read and write
+#          Pull requests: Read and write
+#          Workflows: Read and write
+#          Metadata: Read-only
+#          Dependabot alerts: Read-only
+#      - Where can this app be installed: Only on this account
+#   2. After create: note the App ID, generate a private key (.pem), install on losol/eventuras.
+#   3. Add repo secrets:
+#        RENOVATE_APP_ID            -> the numeric App ID
+#        RENOVATE_APP_PRIVATE_KEY   -> contents of the .pem (incl. BEGIN/END lines)
+
+name: Renovate
+
+on:
+  schedule:
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level
+        type: choice
+        default: info
+        options: [info, debug]
+
+permissions: {}
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - uses: renovatebot/github-action@79dc0ba74dc3de28db0a7aeb1d0b95d5bf5fde2a # v46.1.13
+        env:
+          LOG_LEVEL: ${{ github.event.inputs.logLevel || 'info' }}
+          NODE_OPTIONS: --max-old-space-size=8192
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          configurationFile: renovate.json


### PR DESCRIPTION
## Summary
- Adds [.github/workflows/renovate.yml](.github/workflows/renovate.yml): a self-hosted Renovate run on a 6-hourly cron (`0 */6 * * *`), replacing the Mend Renovate GitHub App.
- Uses a dedicated GitHub App for the bot identity — App token minted at runtime via `actions/create-github-app-token`. Avoids PAT expiry headaches and keeps `bot` authorship on Renovate PRs.
- Sets `NODE_OPTIONS: --max-old-space-size=8192` so the monorepo no longer hits the cloud bot's heap ceiling (which is what triggered this move).
- `workflow_dispatch` trigger included for ad-hoc runs with optional `debug` log level.
- Reuses existing [renovate.json](renovate.json) verbatim — no behavior change beyond the runner.

Action versions are SHA-pinned (matching repo convention); Renovate's `helpers:pinGitHubActionDigestsToSemver` keeps them current.

## Required before this works (one-time setup)
Documented in the workflow header. TL;DR:
1. Create a GitHub App at https://github.com/settings/apps/new
   - Permissions: Contents/Issues/PRs/Workflows R+W, Metadata R, Dependabot alerts R
   - Webhook: disabled
2. Generate private key, install on `losol/eventuras`
3. Add repo secrets: `RENOVATE_APP_ID`, `RENOVATE_APP_PRIVATE_KEY`
4. Uninstall the old Mend Renovate GitHub App (already done)

## Test plan
- [x] YAML parses (`js-yaml`)
- [ ] After merge: trigger via Actions → "Renovate" → "Run workflow" with `logLevel=debug` for first run
- [ ] Confirm the Dependency Dashboard #1420 (or a fresh one under the bot's identity) gets updated by the new run

🤖 Generated with [Claude Code](https://claude.com/claude-code)