### PR TITLE
Add Accordion compound component (beta)

### DIFF
--- a/.changeset/accordion-component.md
+++ b/.changeset/accordion-component.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Add `Accordion` compound component (beta) wrapping native `<details>`/`<summary>`. Exposes `Accordion`, `Accordion.Item`, `Accordion.Summary`, `Accordion.Content`. Items support the HTML `name` attribute for exclusive (single-open) grouping. Content fades in via `@starting-style` when opened. No `'use client'` required — works in server components.

--- a/libs/ratio-ui/src/core/Accordion/Accordion.stories.tsx
+++ b/libs/ratio-ui/src/core/Accordion/Accordion.stories.tsx
@@ -1,0 +1,93 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { Accordion } from './Accordion';
+
+const meta: Meta<typeof Accordion> = {
+  title: 'Core/Accordion (Beta)',
+  component: Accordion,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Accordion>;
+
+export const Default: Story = {
+  render: () => (
+    <Accordion>
+      <Accordion.Item>
+        <Accordion.Summary>What is Eventuras?</Accordion.Summary>
+        <Accordion.Content>
+          An open-source platform for managing courses, conferences, and event registrations.
+        </Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item>
+        <Accordion.Summary>Is it free to use?</Accordion.Summary>
+        <Accordion.Content>
+          Yes. The source is licensed under the project license — see the repository for details.
+        </Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item>
+        <Accordion.Summary>How do I get started?</Accordion.Summary>
+        <Accordion.Content>
+          Clone the monorepo, install dependencies with pnpm, and follow the setup guide.
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  ),
+};
+
+export const InitiallyOpen: Story = {
+  render: () => (
+    <Accordion>
+      <Accordion.Item open>
+        <Accordion.Summary>This panel starts open</Accordion.Summary>
+        <Accordion.Content>The `open` prop maps to the standard HTML attribute.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item>
+        <Accordion.Summary>This one starts closed</Accordion.Summary>
+        <Accordion.Content>Click the header to expand.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  ),
+};
+
+export const Exclusive: Story = {
+  render: () => (
+    <Accordion>
+      <Accordion.Item name="faq">
+        <Accordion.Summary>Sharing a `name` makes items mutually exclusive</Accordion.Summary>
+        <Accordion.Content>
+          Opening this one closes the others in the same group. This is native HTML behavior.
+        </Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item name="faq">
+        <Accordion.Summary>Second item</Accordion.Summary>
+        <Accordion.Content>Only one item in the group stays open at a time.</Accordion.Content>
+      </Accordion.Item>
+      <Accordion.Item name="faq">
+        <Accordion.Summary>Third item</Accordion.Summary>
+        <Accordion.Content>Try clicking around.</Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  ),
+};
+
+export const TechnicalDetails: Story = {
+  render: () => (
+    <Accordion>
+      <Accordion.Item>
+        <Accordion.Summary>Technical details</Accordion.Summary>
+        <Accordion.Content>
+          <pre className="whitespace-pre-wrap break-all text-xs text-(--text-muted)">
+            {`Error: ENOENT: no such file or directory, open '/tmp/missing.txt'
+    at Object.openSync (node:fs:603:3)
+    at Object.readFileSync (node:fs:471:35)
+    at /app/server.js:42:18`}
+          </pre>
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  ),
+};

--- a/libs/ratio-ui/src/core/Accordion/Accordion.tsx
+++ b/libs/ratio-ui/src/core/Accordion/Accordion.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import clsx from 'clsx';
+import { ChevronDown } from '../../icons';
+import { Stack } from '../../layout/Stack/Stack';
+
+export interface AccordionProps {
+  children: React.ReactNode;
+}
+
+export interface AccordionItemProps
+  extends Omit<React.DetailsHTMLAttributes<HTMLDetailsElement>, 'name'> {
+  children: React.ReactNode;
+  /**
+   * HTML `name` attribute for grouping. When multiple `<details>` share the
+   * same name only one stays open at a time (exclusive accordion behavior).
+   */
+  name?: string;
+}
+
+export interface AccordionSummaryProps
+  extends React.HTMLAttributes<HTMLElement> {
+  children: React.ReactNode;
+  hideChevron?: boolean;
+}
+
+export interface AccordionContentProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+function Root({ children }: Readonly<AccordionProps>) {
+  if (React.Children.count(children) <= 1) {
+    return <>{children}</>;
+  }
+  return <Stack gap="sm">{children}</Stack>;
+}
+
+function Item({ children, className, ...rest }: Readonly<AccordionItemProps>) {
+  return (
+    <details
+      className={clsx(
+        'group rounded-md border border-border-1 bg-card',
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </details>
+  );
+}
+
+function Summary({
+  children,
+  className,
+  hideChevron,
+  ...rest
+}: Readonly<AccordionSummaryProps>) {
+  return (
+    <summary
+      className={clsx(
+        'flex cursor-pointer list-none items-center justify-between gap-2 px-3 py-3 font-medium',
+        'hover:bg-card-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--focus-ring)',
+        '[&::-webkit-details-marker]:hidden',
+        className,
+      )}
+      {...rest}
+    >
+      <span className="flex-1">{children}</span>
+      {!hideChevron && (
+        <ChevronDown
+          className="h-4 w-4 shrink-0 transition-transform duration-200 group-open:rotate-180"
+          aria-hidden="true"
+        />
+      )}
+    </summary>
+  );
+}
+
+function Content({
+  children,
+  className,
+  ...rest
+}: Readonly<AccordionContentProps>) {
+  return (
+    <div
+      className={clsx(
+        'p-3 text-sm',
+        'transition-discrete transition-opacity duration-200 starting:opacity-0',
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Accordion — compound disclosure built on native `<details>`/`<summary>`.
+ *
+ * @beta API may change before 1.0.
+ */
+export const Accordion = Object.assign(Root, {
+  Item,
+  Summary,
+  Content,
+});

--- a/libs/ratio-ui/src/core/Accordion/index.ts
+++ b/libs/ratio-ui/src/core/Accordion/index.ts
@@ -1,0 +1,7 @@
+export { Accordion } from './Accordion';
+export type {
+  AccordionProps,
+  AccordionItemProps,
+  AccordionSummaryProps,
+  AccordionContentProps,
+} from './Accordion';


### PR DESCRIPTION
Introduce a new Accordion component that wraps native `<details>` and `<summary>` elements, allowing for exclusive item grouping and smooth content transitions. This component includes `Accordion.Item`, `Accordion.Summary`, and `Accordion.Content` for structured usage. No client-side rendering is required, making it compatible with server components.