### PR TITLE
fix(web): emit Sentry config as inline script tag

### DIFF
--- a/.changeset/web-sentry-init-inline-script.md
+++ b/.changeset/web-sentry-init-inline-script.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Fix Sentry init timing in `InitSentry`. In the App Router, `<Script strategy="beforeInteractive">` is queued into Next's `__next_s` runtime instead of emitted as an inline `<script>`, so it executes *after* the client bundle. `instrumentation-client.ts` reads `window.__SENTRY_CONFIG__` at module top-level and saw `undefined`, so `Sentry.init` never ran. Render the config as a plain `<script dangerouslySetInnerHTML>` so it executes synchronously at parse time, before any module.

--- a/apps/web/src/providers/sentry/InitSentry.tsx
+++ b/apps/web/src/providers/sentry/InitSentry.tsx
@@ -1,5 +1,3 @@
-import Script from 'next/script';
-
 import { appConfig } from '@/config.server';
 
 export type SentryClientConfig = {
@@ -39,9 +37,25 @@ export const InitSentry = () => {
     ...(release && release !== 'unknown' ? { release } : {}),
   };
 
+  // `<Script strategy="beforeInteractive">` queues into __next_s and runs
+  // after the client bundle, so `instrumentation-client.ts` would read
+  // `window.__SENTRY_CONFIG__` as undefined. An inline `<script>` executes
+  // synchronously at parse time, before any module.
+  //
+  // Escape HTML-significant characters so a value containing `</script>`
+  // can't terminate the tag and inject markup, even though every field
+  // comes from server-side env.
+  const json = JSON.stringify(config)
+    .replaceAll('<', String.raw`\u003c`)
+    .replaceAll('>', String.raw`\u003e`)
+    .replaceAll('&', String.raw`\u0026`);
+
   return (
-    <Script id="sentry-config" strategy="beforeInteractive">
-      {`window.__SENTRY_CONFIG__ = ${JSON.stringify(config)};`}
-    </Script>
+    <script
+      id="sentry-config"
+      dangerouslySetInnerHTML={{
+        __html: `window.__SENTRY_CONFIG__ = ${json};`,
+      }}
+    />
   );
 };


### PR DESCRIPTION
## Summary

- `<Script strategy="beforeInteractive">` from `next/script` is rewritten in the App Router into a `__next_s` queue entry that runs after the client bundle — not an inline `<script>` in the HTML. The bundle's `instrumentation-client.ts` reads `window.__SENTRY_CONFIG__` at module top-level, so it always saw `undefined` and `Sentry.init` never ran.
- Render the config as a plain `<script dangerouslySetInnerHTML>` so it executes synchronously at HTML parse time, before any module.

## Test plan

- [x] `pnpm --filter @eventuras/web exec tsc --noEmit` — clean
- [ ] After rebuild + deploy: open browser devtools, confirm the rendered HTML contains a literal `<script id="sentry-config">window.__SENTRY_CONFIG__ = {...}</script>` (not a `__next_s.push` entry)
- [ ] Trigger a Sentry diagnostic (admin → system page) and confirm the event lands in the Sentry project

🤖 Generated with [Claude Code](https://claude.com/claude-code)