### PR TITLE
fix(api): block self-service registration when event has reached capacity

### DIFF
--- a/.changeset/api-block-registration-when-full.md
+++ b/.changeset/api-block-registration-when-full.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/api': patch
+---
+
+Block self-service registration when an event has reached `MaxParticipants`, and flip the event to `RegistrationsClosed` (not `WaitingList`) when the filling registration is created. Admins keep the manual-overbook path via `EnforceCapacity = false`.

--- a/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/RegistrationManagementService.cs
@@ -80,9 +80,39 @@ internal class RegistrationManagementService : IRegistrationManagementService
         var eventInfo = await _eventInfoRetrievalService.GetEventInfoByIdAsync(eventId,
             new EventInfoRetrievalOptions { ForUpdate = true, LoadRegistrations = true, LoadProducts = true },
             cancellationToken);
-        var user = await _userRetrievalService.GetUserByIdAsync(userId, null, cancellationToken);
 
-        var registration = new Registration { EventInfoId = eventId, UserId = userId, ParticipantName = user.Name };
+        options ??= new RegistrationOptions();
+
+        var registration = new Registration { EventInfoId = eventId, UserId = userId };
+
+        // Access check runs before the capacity gate: a non-admin hitting an
+        // event that is already RegistrationsClosed should get 403 (semantic
+        // "not for you") rather than 400 (the post-fill capacity error). The
+        // gate below is for the in-flight overflow case while the event is
+        // still nominally Open.
+        await _registrationAccessControlService.CheckRegistrationCreateAccessAsync(registration, cancellationToken);
+
+        // Hard capacity gate for self-service flows. Until the waitlist email
+        // flow is in place, refuse new registrations when the event has
+        // reached MaxParticipants instead of silently sending a welcome letter
+        // to participant N+1. Admin flows pass EnforceCapacity=false to
+        // override (manual overbooking).
+        if (options.EnforceCapacity && eventInfo.MaxParticipants > 0)
+        {
+            var activeCount = eventInfo.Registrations
+                .Count(reg => reg.Status != Registration.RegistrationStatus.Cancelled);
+            if (activeCount >= eventInfo.MaxParticipants)
+            {
+                _logger.LogInformation(
+                    "Refusing registration: EventId {EventId} at capacity ({Active}/{Max})",
+                    eventId, activeCount, eventInfo.MaxParticipants);
+                throw new InvalidOperationServiceException(
+                    $"Event {eventId} has reached its maximum participant capacity ({eventInfo.MaxParticipants}).");
+            }
+        }
+
+        var user = await _userRetrievalService.GetUserByIdAsync(userId, null, cancellationToken);
+        registration.ParticipantName = user.Name;
 
         // Use the active default payment method from the database if available
         var defaultPaymentMethod = await _context.PaymentMethods
@@ -93,12 +123,10 @@ internal class RegistrationManagementService : IRegistrationManagementService
         }
 
         // Check if the registration should be verified, and only set it if it's a draft
-        if (options?.Verified == true && registration.Status == Registration.RegistrationStatus.Draft)
+        if (options.Verified && registration.Status == Registration.RegistrationStatus.Draft)
         {
             registration.Status = Registration.RegistrationStatus.Verified;
         }
-
-        await _registrationAccessControlService.CheckRegistrationCreateAccessAsync(registration, cancellationToken);
 
         if (eventInfo.Status == EventInfo.EventInfoStatus.WaitingList)
         {
@@ -106,7 +134,6 @@ internal class RegistrationManagementService : IRegistrationManagementService
         }
 
         await _context.CreateAsync(registration, true, cancellationToken);
-        options ??= new RegistrationOptions();
 
         if (options.CreateOrder && registration.Status != Registration.RegistrationStatus.WaitingList)
         {
@@ -131,9 +158,14 @@ internal class RegistrationManagementService : IRegistrationManagementService
         if (eventInfo.MaxParticipants > 0
             && nonCancelledRegistrationsCount + 1 >= eventInfo.MaxParticipants)
         {
-            _logger.LogInformation("Event {EventId} has reached max participants, changing status to WaitingList",
+            // Flip to RegistrationsClosed (not WaitingList) so the public
+            // event page renders the "closed" badge and the next registration
+            // attempt is refused by the capacity gate above. Will move to
+            // WaitingList once the waitlist-email flow is in place.
+            _logger.LogInformation(
+                "Event {EventId} has reached max participants, closing registrations",
                 eventId);
-            eventInfo.Status = EventInfo.EventInfoStatus.WaitingList;
+            eventInfo.Status = EventInfo.EventInfoStatus.RegistrationsClosed;
             await _context.SaveChangesAsync(cancellationToken);
         }
 

--- a/apps/api/src/Eventuras.Services/Registrations/RegistrationOptions.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/RegistrationOptions.cs
@@ -16,4 +16,12 @@ public class RegistrationOptions
     ///     Send a welcome letter to the user.
     /// </summary>
     public bool SendWelcomeLetter { get; set; } = true;
+
+    /// <summary>
+    ///     Refuse the registration if the event has already reached
+    ///     <see cref="Domain.EventInfo.MaxParticipants" />. Admin flows that
+    ///     need to override capacity (manual overbooking) can set this to
+    ///     false; self-service registrations keep it true.
+    /// </summary>
+    public bool EnforceCapacity { get; set; } = true;
 }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Registrations/RegistrationsController.cs
@@ -146,12 +146,16 @@ public class RegistrationsController : ControllerBase
         [FromBody] NewRegistrationDto dto,
         CancellationToken cancellationToken)
     {
+        // Only true admins skip the capacity gate. Non-admins can hit this
+        // endpoint to register themselves (CheckOwnerOrAdminAccessAsync allows
+        // self-registration), so they must still be subject to MaxParticipants.
         var registration = await _registrationManagementService.CreateRegistrationAsync(dto.EventId, dto.UserId!.Value,
             new RegistrationOptions
             {
                 CreateOrder = dto.CreateOrder,
                 Verified = true,
-                SendWelcomeLetter = dto.SendWelcomeLetter
+                SendWelcomeLetter = dto.SendWelcomeLetter,
+                EnforceCapacity = !User.IsAdmin()
             }, cancellationToken);
 
         if (!dto.Empty)

--- a/apps/api/tests/Eventuras.Services.Tests/Registrations/RegistrationManagementServiceTests.cs
+++ b/apps/api/tests/Eventuras.Services.Tests/Registrations/RegistrationManagementServiceTests.cs
@@ -1,0 +1,135 @@
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Eventuras.Domain;
+using Eventuras.Infrastructure;
+using Eventuras.Services.BusinessEvents;
+using Eventuras.Services.Exceptions;
+using Eventuras.Services.Notifications;
+using Eventuras.Services.Orders;
+using Eventuras.Services.Registrations;
+using Eventuras.Services.Users;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Eventuras.Services.Tests.Registrations;
+
+public class RegistrationManagementServiceTests : IDisposable
+{
+    private readonly ApplicationDbContext _context;
+
+    public RegistrationManagementServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task CreateRegistrationAsync_ThrowsInvalidOperation_WhenEventAtCapacity_AndEnforceCapacityTrue()
+    {
+        var eventInfo = MakeFullEvent(maxParticipants: 2, verifiedRegistrations: 2);
+        var service = BuildService(eventInfo);
+        var userId = Guid.NewGuid();
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationServiceException>(() =>
+            service.CreateRegistrationAsync(
+                eventInfo.EventInfoId,
+                userId,
+                new RegistrationOptions { EnforceCapacity = true, SendWelcomeLetter = false }));
+
+        Assert.Contains("maximum participant capacity", ex.Message);
+    }
+
+    [Fact]
+    public async Task CreateRegistrationAsync_BypassesCapacityGate_AndFlipsEventToClosed_WhenEnforceCapacityFalse()
+    {
+        // Admin path: event is already at max, EnforceCapacity=false lets the
+        // overbook through. The post-save flip should still fire and move
+        // the event into RegistrationsClosed.
+        var eventInfo = MakeFullEvent(maxParticipants: 2, verifiedRegistrations: 2);
+        var adminUserId = Guid.NewGuid();
+        var service = BuildService(eventInfo, callerUserId: adminUserId);
+
+        var registration = await service.CreateRegistrationAsync(
+            eventInfo.EventInfoId,
+            adminUserId,
+            new RegistrationOptions
+            {
+                EnforceCapacity = false,
+                Verified = true,
+                SendWelcomeLetter = false,
+            });
+
+        Assert.NotNull(registration);
+        Assert.Equal(Registration.RegistrationStatus.Verified, registration.Status);
+        Assert.Equal(EventInfo.EventInfoStatus.RegistrationsClosed, eventInfo.Status);
+    }
+
+    private static EventInfo MakeFullEvent(int maxParticipants, int verifiedRegistrations)
+    {
+        var eventInfo = new EventInfo
+        {
+            EventInfoId = 42,
+            Title = "Test Event",
+            Status = EventInfo.EventInfoStatus.RegistrationsOpen,
+            MaxParticipants = maxParticipants,
+            Registrations = Enumerable.Range(0, verifiedRegistrations)
+                .Select(_ => new Registration
+                {
+                    EventInfoId = 42,
+                    UserId = Guid.NewGuid(),
+                    Status = Registration.RegistrationStatus.Verified,
+                })
+                .ToList(),
+            Products = new System.Collections.Generic.List<Product>(),
+        };
+        return eventInfo;
+    }
+
+    private RegistrationManagementService BuildService(EventInfo eventInfo, Guid? callerUserId = null)
+    {
+        var eventInfoRetrieval = ServiceMocks.MockEventInfoRetrievalService(out _, eventInfo);
+
+        var userRetrieval = new Mock<IUserRetrievalService>();
+        userRetrieval
+            .Setup(u => u.GetUserByIdAsync(It.IsAny<Guid>(), It.IsAny<UserRetrievalOptions?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid id, UserRetrievalOptions? _, CancellationToken _) => new ApplicationUser
+            {
+                Id = id,
+                Email = "leo@losen.com",
+                GivenName = "Leo",
+                FamilyName = "Losen",
+            });
+
+        var httpContextAccessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+
+        return new RegistrationManagementService(
+            Mock.Of<IRegistrationAccessControlService>(),
+            Mock.Of<IRegistrationRetrievalService>(),
+            Mock.Of<IOrderManagementService>(),
+            eventInfoRetrieval,
+            Mock.Of<INotificationDeliveryService>(),
+            Mock.Of<INotificationManagementService>(),
+            userRetrieval.Object,
+            Mock.Of<IBusinessEventService>(),
+            httpContextAccessor,
+            NullLogger<RegistrationManagementService>.Instance,
+            _context);
+    }
+}

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Registrations/RegistrationsControllerTest.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Registrations/RegistrationsControllerTest.cs
@@ -260,7 +260,10 @@ public class RegistrationsControllerTest(CustomWebApiApplicationFactory<Program>
     [Fact]
     public async Task Should_Return_Not_Found_For_Unknown_User_Id()
     {
-        var client = factory.CreateClient().Authenticated();
+        // Use a SystemAdmin client so access control doesn't refuse the call
+        // before the unknown-user lookup runs — we want to assert what
+        // happens when the user ID itself is bogus.
+        var client = factory.CreateClient().AuthenticatedAsSystemAdmin();
         using var scope = factory.Services.NewTestScope();
         using var e = await scope.CreateEventAsync();
         var response = await client.PostAsync("/v3/registrations",
@@ -433,7 +436,7 @@ public class RegistrationsControllerTest(CustomWebApiApplicationFactory<Program>
     }
 
     [Fact]
-    public async Task Should_Move_Event_To_Waiting_List_Status()
+    public async Task Should_Close_Event_When_Filling_Last_Spot()
     {
         using var scope = factory.Services.NewTestScope();
         using var user = await scope.CreateUserAsync();
@@ -456,7 +459,72 @@ public class RegistrationsControllerTest(CustomWebApiApplicationFactory<Program>
 
         var updatedEvent = await scope.Db.EventInfos.AsNoTracking()
             .SingleAsync(e => e.EventInfoId == evt.Entity.EventInfoId);
-        Assert.Equal(EventInfo.EventInfoStatus.WaitingList, updatedEvent.Status);
+        Assert.Equal(EventInfo.EventInfoStatus.RegistrationsClosed, updatedEvent.Status);
+    }
+
+    [Fact]
+    public async Task Should_Refuse_Self_Service_Registration_When_Event_At_Capacity()
+    {
+        // Event at capacity, status still RegistrationsOpen (no one has flipped
+        // it yet): the in-service capacity gate must refuse with 400 to prevent
+        // a race where two requests slip past the status flip.
+        using var scope = factory.Services.NewTestScope();
+        using var existing = await scope.CreateUserAsync();
+        using var newcomer = await scope.CreateUserAsync();
+        using var evt =
+            await scope.CreateEventAsync(status: EventInfo.EventInfoStatus.RegistrationsOpen, maxParticipants: 1);
+        using var _ = await scope.CreateRegistrationAsync(evt.Entity, existing.Entity,
+            status: Registration.RegistrationStatus.Verified);
+
+        var client = factory.CreateClient().AuthenticatedAs(newcomer.Entity);
+        var response = await client.PostAsync("/v3/registrations",
+            new { userId = newcomer.Entity.Id, eventId = evt.Entity.EventInfoId });
+
+        response.CheckBadRequest();
+    }
+
+    [Fact]
+    public async Task Should_Forbid_Self_Service_Registration_When_Event_Registrations_Closed()
+    {
+        // Once the event has flipped to RegistrationsClosed (typically after a
+        // previous registration filled the last spot), self-service callers
+        // should be refused by the access-control layer with 403 — not by the
+        // capacity gate with 400. Admins are unaffected.
+        using var scope = factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt =
+            await scope.CreateEventAsync(status: EventInfo.EventInfoStatus.RegistrationsClosed);
+
+        var client = factory.CreateClient().AuthenticatedAs(user.Entity);
+        var response = await client.PostAsync("/v3/registrations",
+            new { userId = user.Entity.Id, eventId = evt.Entity.EventInfoId });
+
+        response.CheckForbidden();
+    }
+
+    [Fact]
+    public async Task Admin_Can_Overbook_Event_That_Is_Closed_And_Status_Stays_Closed()
+    {
+        // Admin overbooks an already-Closed event (EnforceCapacity=false in the
+        // controller). The status must remain Closed afterwards so self-service
+        // attempts continue to hit the 403 path.
+        using var scope = factory.Services.NewTestScope();
+        using var existing = await scope.CreateUserAsync();
+        using var admin = await scope.CreateUserAsync(role: Roles.SystemAdmin);
+        using var target = await scope.CreateUserAsync();
+        using var evt =
+            await scope.CreateEventAsync(status: EventInfo.EventInfoStatus.RegistrationsClosed, maxParticipants: 1);
+        using var _ = await scope.CreateRegistrationAsync(evt.Entity, existing.Entity,
+            status: Registration.RegistrationStatus.Verified);
+
+        var client = factory.CreateClient().AuthenticatedAs(admin.Entity, Roles.SystemAdmin);
+        var response = await client.PostAsync("/v3/registrations",
+            new { userId = target.Entity.Id, eventId = evt.Entity.EventInfoId });
+        response.CheckOk();
+
+        var updatedEvent = await scope.Db.EventInfos.AsNoTracking()
+            .SingleAsync(e => e.EventInfoId == evt.Entity.EventInfoId);
+        Assert.Equal(EventInfo.EventInfoStatus.RegistrationsClosed, updatedEvent.Status);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Two coordinated changes that together close the "participant N+1 gets a welcome letter for a full event" hole:

1. **Hard capacity gate** in `CreateRegistrationAsync`, gated on a new `RegistrationOptions.EnforceCapacity` flag (default `true`). Both endpoints decide whether to enforce:
   - **Self-service** (`POST /v3/registrations/me/{eventId}`) uses the default — refuses with HTTP 400 when `MaxParticipants` is reached.
   - **Admin endpoint** (`POST /v3/registrations`) sets it to `!User.IsAdmin()`. The endpoint's class-level `[Authorize]` permits any authenticated caller — and `CheckOwnerOrAdminAccessAsync` lets non-admins create a registration *for themselves* — so a blanket `EnforceCapacity = false` would let non-admins bypass the gate by hitting this endpoint with their own `UserId`. Only true admins skip the gate now.
2. **Flip event status to `RegistrationsClosed`** (was `WaitingList`) when the registration that fills the event lands. [`EventRegistrationButton`](apps/web/src/app/(public)/events/EventRegistrationButton.tsx) already renders a "closed" badge for non-open statuses, so the public page updates with no frontend changes.

The team's manual workaround has been to set the event status to `RegistrationsClosed` by hand once it fills — this automates that.

## Scope notes

- Temporary safety net. When the waitlist-email flow is in place, the flip-target should switch back to `WaitingList` and the capacity gate relaxed to "block only when event is `RegistrationsOpen`".
- Defense in depth: capacity gate (400) for the first refused self-service attempt; access-control (403) for subsequent ones once `EventInfo.Status` is `RegistrationsClosed`.
- Small cleanup: moved `options ??= new RegistrationOptions()` earlier so the rest of the method drops the null-conditional `options?.Verified` reads.

## Test plan

- [ ] CI build passes (local dotnet build skipped — SDK 10.0.202 mismatch)
- [ ] Integration: create event with `MaxParticipants=2`, register two self-service users → both get welcome letter, event flips to `RegistrationsClosed`, public page shows "closed" badge
- [ ] Third self-service attempt returns 400 with the capacity message
- [ ] **Non-admin** hitting `POST /v3/registrations` with own `UserId` after the event is full → also 400 (gate enforced because `!User.IsAdmin()` is true)
- [ ] Admin hitting `POST /v3/registrations` after the event is full → succeeds (gate skipped, manual overbook still possible)

## Follow-up

- Unit test in `apps/api/tests/Eventuras.Services.Tests/Registrations/RegistrationManagementServiceTests.cs` (file doesn't exist yet — queued with the waitlist work).
- When waitlist-email lands: switch `RegistrationsClosed` back to `WaitingList`, and gate capacity check on event status rather than count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)