### PR TITLE
fix(scribo): handle root parent in callout import to avoid Lexical #53

### DIFF
--- a/.changeset/scribo-callout-import-fix.md
+++ b/.changeset/scribo-callout-import-fix.md
@@ -1,0 +1,9 @@
+---
+'@eventuras/scribo': patch
+---
+
+Fix Lexical error #53 ("Can't replace root node") when importing markdown containing a GitHub callout (`> [!NOTE]` etc.).
+
+`CalloutTransformer.replace` called `parentNode.replace(calloutNode)` on the import path, but `@lexical/markdown` passes the actual `RootNode` as `parentNode` during `$convertFromMarkdownString`, and `RootNode.replace` always throws. Use `parentNode.append` on the import path (mirroring Lexical's own `CODE` transformer) and keep `parentNode.replace` for the keyboard-shortcut path where `parentNode` is a `ParagraphNode`.
+
+Also harden `MarkdownEditor`'s `editorState` initializer: catch parse failures and fall back to inserting the raw markdown as plain text instead of letting the throw propagate up through the React render and tear down the surrounding tree.

--- a/libs/scribo/src/MarkdownEditor.tsx
+++ b/libs/scribo/src/MarkdownEditor.tsx
@@ -3,7 +3,7 @@ import {
   $convertToMarkdownString,
   TRANSFORMERS,
 } from "@lexical/markdown";
-import { $getRoot } from 'lexical';
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
@@ -91,7 +91,19 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = (props) => {
       ? () => {
           // Unescape backslash-escaped markdown characters
           const unescapedMarkdown = props.initialMarkdown!.replaceAll(/\\([*_`\[\]()#+-])/g, '$1');
-          $convertFromMarkdownString(unescapedMarkdown, allTransformers);
+          try {
+            $convertFromMarkdownString(unescapedMarkdown, allTransformers);
+          } catch (err) {
+            // Markdown parsing threw (e.g. a transformer bug). Fall back to plain
+            // text so the field stays editable and content isn't lost — better
+            // than crashing the whole tree and propagating to the page boundary.
+            console.error('Scribo: markdown parse failed, falling back to plain text', err);
+            const root = $getRoot();
+            root.clear();
+            const paragraph = $createParagraphNode();
+            paragraph.append($createTextNode(unescapedMarkdown));
+            root.append(paragraph);
+          }
         }
       : undefined,
   };

--- a/libs/scribo/src/nodes/callout/CalloutTransformer.ts
+++ b/libs/scribo/src/nodes/callout/CalloutTransformer.ts
@@ -48,7 +48,7 @@ export const CALLOUT_TRANSFORMER: MultilineElementTransformer = {
     return `> [!${calloutType}]\n${quoted}`;
   },
 
-  replace: (rootNode, _children, startMatch, _endMatch, linesInBetween) => {
+  replace: (parentNode, _children, startMatch, _endMatch, linesInBetween, isImport) => {
     const calloutType = startMatch[1] as CalloutType;
     if (!CALLOUT_TYPES.includes(calloutType)) return false;
 
@@ -75,7 +75,13 @@ export const CALLOUT_TRANSFORMER: MultilineElementTransformer = {
       calloutNode.append($createParagraphNode());
     }
 
-    rootNode.replace(calloutNode);
+    // On import, parentNode is the RootNode (which can't be replaced — Lexical #53).
+    // On keyboard-shortcut, parentNode is a ParagraphNode we should replace.
+    if (isImport) {
+      parentNode.append(calloutNode);
+    } else {
+      parentNode.replace(calloutNode);
+    }
     return true;
   },
 };


### PR DESCRIPTION
## Summary
- Switch `CalloutTransformer.replace` to `parentNode.append` on the import path so `$convertFromMarkdownString` no longer calls `RootNode.replace` (which always throws Lexical error #53). Keep `parentNode.replace` for the keyboard-shortcut path where `parentNode` is a real `ParagraphNode`.
- Harden `MarkdownEditor` initialization: wrap `$convertFromMarkdownString` in a try/catch and fall back to plain text on parse failure, instead of letting the throw propagate up through `useMemo` to the page-level error boundary.
- Add changeset bumping `@eventuras/scribo` patch.

## Why
GlitchTip surfaced `Minified Lexical error #53` ("Can't replace root node") repeatedly from `/admin/events/{id}?tab=descriptions`. The stack pointed at `editorState` init → `runMultilineElementTransformer` → callout transformer's `rootNode.replace(...)`. `@lexical/markdown` passes the actual `RootNode` as the first arg during import, but Lexical's `RootNode.replace` always throws (verified in `Lexical.prod.js`). Lexical's own `CODE` multiline transformer handles this by using `parentNode.append(...)` on the import path — same pattern we adopt here.

Any event whose description, program, etc. contains a GitHub callout (`> [!NOTE]`, `> [!WARNING]`, …) currently crashes the admin descriptions tab on open.

## Test plan
- [ ] Open an event description containing `> [!NOTE]\n> body` in the admin descriptions tab — editor renders without error and shows the callout block.
- [ ] Type `> [!NOTE]` + Enter in an empty paragraph — keyboard shortcut still converts the paragraph into a callout (the non-import code path).
- [ ] Verify GlitchTip stops receiving `KURSINORD-WEB-6` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)