### PR TITLE
feat(ratio-ui): add ErrorBoundary component

### DIFF
--- a/.changeset/ratio-ui-error-boundary.md
+++ b/.changeset/ratio-ui-error-boundary.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Add `<ErrorBoundary>` at `@eventuras/ratio-ui/core/ErrorBoundary` for isolating render-time errors in a sub-tree. See the component README for usage.

--- a/libs/ratio-ui/src/core/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/libs/ratio-ui/src/core/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,114 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { ErrorBoundary } from './ErrorBoundary';
+import { Panel } from '../Panel';
+
+const meta: Meta<typeof ErrorBoundary> = {
+  title: 'Core/ErrorBoundary',
+  component: ErrorBoundary,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Catches render-time errors in descendants and shows a fallback. ' +
+          'Does **not** catch errors in event handlers, async callbacks, or SSR.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ErrorBoundary>;
+
+function Boom({ when }: { when: boolean }): React.JSX.Element {
+  if (when) {
+    throw new Error('Boom — synthetic render-time failure');
+  }
+  return <p>Rendering normally.</p>;
+}
+
+/** Default fallback (compound `ErrorBoundary.DefaultFallback`) is used when no `fallback` prop is provided. */
+export const DefaultFallback: Story = {
+  render: () => (
+    <ErrorBoundary>
+      <Boom when={true} />
+    </ErrorBoundary>
+  ),
+};
+
+/** Pass a static `ReactNode` as `fallback` for a simple replacement. */
+export const StaticFallback: Story = {
+  render: () => (
+    <ErrorBoundary
+      fallback={
+        <Panel variant="alert" status="error">
+          Couldn't load this widget. Reload the page to try again.
+        </Panel>
+      }
+    >
+      <Boom when={true} />
+    </ErrorBoundary>
+  ),
+};
+
+/** Pass a render function to access `error` and `reset` in the fallback. */
+export const RenderFunctionFallback: Story = {
+  render: () => (
+    <ErrorBoundary
+      fallback={({ error, reset }) => (
+        <Panel variant="alert" status="error">
+          <p className="font-bold mb-2">{error.message}</p>
+          <button
+            type="button"
+            onClick={reset}
+            className="underline hover:opacity-80"
+          >
+            Reset boundary
+          </button>
+        </Panel>
+      )}
+    >
+      <Boom when={true} />
+    </ErrorBoundary>
+  ),
+};
+
+function ResetKeysDemo() {
+  const [attempt, setAttempt] = useState(0);
+  return (
+    <div className="space-y-4">
+      <button
+        type="button"
+        onClick={() => setAttempt(a => a + 1)}
+        className="px-4 py-2 rounded bg-primary-600 text-white"
+      >
+        Retry (attempt #{attempt})
+      </button>
+      <ErrorBoundary resetKeys={[attempt]}>
+        {/* Throws on even attempts, renders on odd */}
+        <Boom when={attempt % 2 === 0} />
+      </ErrorBoundary>
+    </div>
+  );
+}
+
+/** `resetKeys` clears the error state when any key changes. Useful for "Retry" UX outside the fallback. */
+export const ResetKeys: Story = {
+  render: () => <ResetKeysDemo />,
+};
+
+/** `onError` runs side-effects (logging, Sentry). Open the console to see the log. */
+export const OnErrorLogging: Story = {
+  render: () => (
+    <ErrorBoundary
+      onError={(error, info) => {
+        // eslint-disable-next-line no-console
+        console.error('[ErrorBoundary]', error, info);
+      }}
+    >
+      <Boom when={true} />
+    </ErrorBoundary>
+  ),
+};

--- a/libs/ratio-ui/src/core/ErrorBoundary/ErrorBoundary.tsx
+++ b/libs/ratio-ui/src/core/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { ErrorBlock } from '../../blocks/Error';
+
+export interface ErrorBoundaryRenderProps {
+  error: Error;
+  reset: () => void;
+}
+
+export type ErrorBoundaryFallback =
+  | React.ReactNode
+  | ((args: ErrorBoundaryRenderProps) => React.ReactNode);
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Fallback UI shown when a child throws. Pass a render fn to access `error` and `reset`. */
+  fallback?: ErrorBoundaryFallback;
+  /** Boundary resets when any value in this array changes (shallow compare). */
+  resetKeys?: ReadonlyArray<unknown>;
+  /** Side-effect hook for logging / Sentry. Runs in `componentDidCatch`. */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+function changed(a: ReadonlyArray<unknown> = [], b: ReadonlyArray<unknown> = []) {
+  if (a.length !== b.length) return true;
+  return a.some((v, i) => !Object.is(v, b[i]));
+}
+
+/**
+ * Default fallback used when `<ErrorBoundary>` is rendered without a `fallback`
+ * prop. Shows an inline `ErrorBlock` with a "Try again" button.
+ *
+ * The raw `error.message` is intentionally not rendered — it can include
+ * implementation details or user data. Write a custom `fallback` if you need
+ * to surface details (typically gated behind a dev flag).
+ */
+function DefaultFallback({ reset }: Readonly<ErrorBoundaryRenderProps>) {
+  return (
+    <ErrorBlock type="generic" status="error">
+      <ErrorBlock.Title>Something went wrong</ErrorBlock.Title>
+      <ErrorBlock.Description>
+        This part of the page couldn't be displayed.
+      </ErrorBlock.Description>
+      <ErrorBlock.Actions>
+        <button
+          type="button"
+          onClick={reset}
+          className="px-4 py-2 rounded bg-error-bg border border-error-border text-error-text hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-error-border"
+        >
+          Try again
+        </button>
+      </ErrorBlock.Actions>
+    </ErrorBlock>
+  );
+}
+
+/**
+ * Catches render-time errors thrown by descendants and renders a fallback
+ * instead of letting the error propagate to the nearest route-level boundary.
+ *
+ * Does NOT catch errors in event handlers, async callbacks, or SSR — wrap
+ * those in `try/catch` yourself.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundary fallback={<p>Couldn't load this section.</p>}>
+ *   <FlakyChild />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  static DefaultFallback = DefaultFallback;
+
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps, prevState: ErrorBoundaryState) {
+    // Only auto-reset when we were *already* in the fallback before this update.
+    // Otherwise a resetKeys change that itself triggers a throw would clear the
+    // freshly-captured error and re-render the failing child, firing onError twice.
+    if (prevState.error !== null && changed(prevProps.resetKeys, this.props.resetKeys)) {
+      this.reset();
+    }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    const { fallback } = this.props;
+    if (typeof fallback === 'function') {
+      return fallback({ error, reset: this.reset });
+    }
+    if (fallback !== undefined) {
+      return fallback;
+    }
+    return <DefaultFallback error={error} reset={this.reset} />;
+  }
+}

--- a/libs/ratio-ui/src/core/ErrorBoundary/README.md
+++ b/libs/ratio-ui/src/core/ErrorBoundary/README.md
@@ -1,0 +1,102 @@
+# ErrorBoundary
+
+A class-based React error boundary that catches render-time errors in its descendants and shows a fallback instead of letting the error propagate to the nearest route-level boundary (`error.tsx` in Next.js).
+
+Use it to isolate fragile sub-trees so a single deep crash doesn't take down the surrounding page.
+
+```tsx
+import { ErrorBoundary } from '@eventuras/ratio-ui/core/ErrorBoundary';
+
+<ErrorBoundary>
+  <FlakyChild />
+</ErrorBoundary>
+```
+
+With no `fallback` prop, the built-in `ErrorBoundary.DefaultFallback` renders an inline `ErrorBlock` with a generic message and a "Try again" button that calls `reset`. The raw `error.message` is intentionally not shown — it can leak implementation details or user data. Write a custom `fallback` if you need to surface details (typically gated behind a dev flag).
+
+## What it does (and doesn't) catch
+
+Catches:
+
+- Render-time throws in descendants (during the React render phase).
+- Throws inside lifecycle methods (`useEffect`, `componentDidMount`, etc.) of descendants.
+
+Does **not** catch:
+
+- Errors in event handlers — wrap them in `try/catch` yourself.
+- Async callbacks (`setTimeout`, `Promise.then`) — same.
+- SSR errors — error boundaries are a client-side React feature.
+- Errors thrown by the boundary itself.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Sub-tree to protect |
+| `fallback` | `ReactNode \| ({ error, reset }) => ReactNode` | `ErrorBoundary.DefaultFallback` | UI shown when a child throws |
+| `resetKeys` | `ReadonlyArray<unknown>` | — | Boundary resets when any key changes (`Object.is` compare) |
+| `onError` | `(error, info) => void` | — | Side-effect hook for logging / Sentry |
+
+## Custom fallback
+
+Pass a static `ReactNode`:
+
+```tsx
+<ErrorBoundary
+  fallback={<Panel variant="alert" status="error">Couldn't load this section.</Panel>}
+>
+  <FlakyChild />
+</ErrorBoundary>
+```
+
+Or a render function for access to `error` and `reset`:
+
+```tsx
+<ErrorBoundary
+  fallback={({ error, reset }) => (
+    <div>
+      <p>{error.message}</p>
+      <Button onClick={reset}>Retry</Button>
+    </div>
+  )}
+>
+  <FlakyChild />
+</ErrorBoundary>
+```
+
+## Resetting
+
+The boundary resets in two ways:
+
+1. **`reset()` is called** — typically from inside a render-function fallback or via `ErrorBoundary.DefaultFallback`'s "Try again" button. The error state clears and `children` re-renders.
+2. **`resetKeys` change** — useful when the parent already has UI for retrying (e.g. a route key, a query key). When any value in the array changes, the boundary clears its error.
+
+```tsx
+<ErrorBoundary resetKeys={[pathname]}>
+  <Page />
+</ErrorBoundary>
+```
+
+## Logging
+
+`onError` runs in `componentDidCatch`. Plug it into your logger and Sentry:
+
+```tsx
+<ErrorBoundary
+  onError={(error, info) => {
+    logger.error({ err: error, componentStack: info.componentStack }, 'Editor crashed');
+    Sentry.captureException(error, {
+      tags: { section: 'admin', component: 'MarkdownInput' },
+      extra: { componentStack: info.componentStack },
+    });
+  }}
+>
+  <MarkdownInput />
+</ErrorBoundary>
+```
+
+## Server vs client
+
+The component file has no `'use client'` directive — ratio-ui is framework-agnostic. The consumer's `'use client'` file imports it. In Next.js App Router that means: put `<ErrorBoundary>` inside any file marked `'use client'`, or inside a Client Component sub-tree.
+
+Server Components cannot use error boundaries — for SSR errors, use Next.js's `error.tsx` route boundaries.

--- a/libs/ratio-ui/src/core/ErrorBoundary/index.ts
+++ b/libs/ratio-ui/src/core/ErrorBoundary/index.ts
@@ -1,0 +1,6 @@
+export { ErrorBoundary } from './ErrorBoundary';
+export type {
+  ErrorBoundaryProps,
+  ErrorBoundaryFallback,
+  ErrorBoundaryRenderProps,
+} from './ErrorBoundary';


### PR DESCRIPTION
## Summary
- Adds `@eventuras/ratio-ui/core/ErrorBoundary` — a class-based React error boundary so consumers can isolate fragile sub-trees instead of letting a render-time throw propagate to the nearest route-level `error.tsx` and replace the entire page.
- Built on existing `ErrorBlock`; ships an `ErrorBoundary.DefaultFallback` so drop-in usage requires no fallback markup.

## API
```tsx
<ErrorBoundary
  fallback={({ error, reset }) => <Panel ...>{error.message}</Panel>}  // or a static ReactNode, or omit for the default
  resetKeys={[someId]}                                                 // clears error state when keys change
  onError={(error, info) => Sentry.captureException(error)}            // side-effect hook
>
  <FlakyChild />
</ErrorBoundary>
```

## Why
A deep Lexical init throw in `MarkdownInput` propagated up through `useMemo` and replaced the entire admin shell with the generic `admin/error.tsx` page (see #1463). We want graceful degradation — one broken field or tab should not kill the whole page.

## Design notes
- Class component (only option for `componentDidCatch` in React 19).
- No `'use client'` per the ratio-ui rule; the consumer's `'use client'` file imports it.
- `resetKeys` uses `Object.is` shallow compare, same semantics as `react-error-boundary`.
- `DefaultFallback` is attached as a static (`ErrorBoundary.DefaultFallback`) following the compound-component convention used elsewhere in ratio-ui.

## Follow-up (separate PRs)
- Extract a shared `RouteErrorView` to dedupe the `app/error.tsx`, `app/(admin)/admin/error.tsx`, and `app/global-error.tsx` boilerplate.
- Wrap `MarkdownInput` and admin `Tabs.Item` content in `ErrorBoundary` with Sentry-tagged `onError`.

## Test plan
- [ ] Storybook: open `Core/ErrorBoundary` — all stories render (DefaultFallback, StaticFallback, RenderFunctionFallback, ResetKeys, OnErrorLogging).
- [ ] In `ResetKeys` story, click "Retry" — boundary alternates between fallback and rendered content.
- [ ] Verify `pnpm --filter @eventuras/ratio-ui tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)