### PR TITLE
refactor(web): extract RouteErrorView for route error boundaries

### DIFF
--- a/.changeset/web-route-error-view.md
+++ b/.changeset/web-route-error-view.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Extract `RouteErrorView` and route `app/error.tsx` + `admin/error.tsx` through it. Refactor with a visual tweak: error-page actions now use `ratio-ui` `Button` + `Link` instead of hand-rolled tailwind buttons, so they match the rest of the app.

--- a/apps/web/src/app/(admin)/admin/error.tsx
+++ b/apps/web/src/app/(admin)/admin/error.tsx
@@ -1,15 +1,14 @@
-'use client'; // Error boundaries must be Client Components
+'use client';
 
-import { useEffect } from 'react';
-import * as Sentry from '@sentry/nextjs';
-import Link from 'next/link';
-import { usePathname, useSearchParams } from 'next/navigation';
+import { RouteErrorView } from '@/components/RouteErrorView';
 
-import { Logger } from '@eventuras/logger';
-import { ErrorBlock } from '@eventuras/ratio-ui/blocks/Error';
-import { PageOverlay } from '@eventuras/ratio-ui/core/PageOverlay';
-
-const logger = Logger.create({ namespace: 'web:admin:error', context: { section: 'admin' } });
+// Module-level constants so `tags`/`links` don't re-mount the underlying
+// `useEffect` (which would fire duplicate Sentry/logger captures).
+const TAGS = { section: 'admin' } as const;
+const LINKS = [
+  { href: '/admin', label: 'Back to Admin Dashboard' },
+  { href: '/', label: 'Go to Home' },
+] as const;
 
 /**
  * Admin section error boundary
@@ -22,64 +21,15 @@ export default function AdminErrorBoundary({
   error: Error & { digest?: string };
   reset: () => void;
 }>) {
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  useEffect(() => {
-    const search = searchParams?.toString() ?? '';
-
-    logger.error(
-      {
-        error: {
-          message: error.message,
-          stack: error.stack,
-          digest: error.digest,
-        },
-        pathname,
-        search,
-      },
-      'Error in admin section'
-    );
-
-    Sentry.captureException(error, {
-      tags: { section: 'admin' },
-      extra: { pathname, search, digest: error.digest },
-    });
-  }, [error, pathname, searchParams]);
-
   return (
-    <PageOverlay status="error" fullScreen>
-      <ErrorBlock type="server-error" status="error">
-        <ErrorBlock.Title>Admin Error</ErrorBlock.Title>
-        <ErrorBlock.Description>
-          An error occurred in the admin section. This has been logged for investigation.
-        </ErrorBlock.Description>
-        {error.digest && (
-          <ErrorBlock.Details>
-            <div className="text-sm opacity-75">Error ID: {error.digest}</div>
-          </ErrorBlock.Details>
-        )}
-        <ErrorBlock.Actions>
-          <button
-            onClick={reset}
-            className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-          >
-            Try Again
-          </button>
-          <Link
-            href="/admin"
-            className="px-4 py-2 rounded bg-gray-600 text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-          >
-            Back to Admin Dashboard
-          </Link>
-          <Link
-            href="/"
-            className="px-4 py-2 rounded bg-gray-500 text-white hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400"
-          >
-            Go to Home
-          </Link>
-        </ErrorBlock.Actions>
-      </ErrorBlock>
-    </PageOverlay>
+    <RouteErrorView
+      error={error}
+      reset={reset}
+      title="Admin Error"
+      description="An error occurred in the admin section. This has been logged for investigation."
+      loggerNamespace="web:admin:error"
+      tags={TAGS}
+      links={LINKS}
+    />
   );
 }

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,14 +1,9 @@
-'use client'; // Error boundaries must be Client Components
+'use client';
 
-import { useEffect } from 'react';
-import * as Sentry from '@sentry/nextjs';
-import Link from 'next/link';
+import { RouteErrorView } from '@/components/RouteErrorView';
 
-import { Logger } from '@eventuras/logger';
-import { ErrorBlock } from '@eventuras/ratio-ui/blocks/Error';
-import { PageOverlay } from '@eventuras/ratio-ui/core/PageOverlay';
-
-const logger = Logger.create({ namespace: 'web:error' });
+// Module-level constant so `links` stays stable across re-renders.
+const LINKS = [{ href: '/', label: 'Go to Home' }] as const;
 
 /**
  * Root error boundary
@@ -23,50 +18,14 @@ export default function ErrorBoundary({
   error: Error & { digest?: string };
   reset: () => void;
 }>) {
-  useEffect(() => {
-    logger.error(
-      {
-        error: {
-          message: error.message,
-          stack: error.stack,
-          digest: error.digest,
-        },
-      },
-      'Unhandled error in app'
-    );
-
-    Sentry.captureException(error, {
-      extra: { digest: error.digest },
-    });
-  }, [error]);
-
   return (
-    <PageOverlay status="error" fullScreen>
-      <ErrorBlock type="server-error" status="error">
-        <ErrorBlock.Title>Something Went Wrong</ErrorBlock.Title>
-        <ErrorBlock.Description>
-          An unexpected error occurred. Please try again or contact support if the problem persists.
-        </ErrorBlock.Description>
-        {error.digest && (
-          <ErrorBlock.Details>
-            <div className="text-sm opacity-75">Error ID: {error.digest}</div>
-          </ErrorBlock.Details>
-        )}
-        <ErrorBlock.Actions>
-          <button
-            onClick={reset}
-            className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
-          >
-            Try Again
-          </button>
-          <Link
-            href="/"
-            className="px-4 py-2 rounded bg-gray-600 text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-500"
-          >
-            Go to Home
-          </Link>
-        </ErrorBlock.Actions>
-      </ErrorBlock>
-    </PageOverlay>
+    <RouteErrorView
+      error={error}
+      reset={reset}
+      title="Something Went Wrong"
+      description="An unexpected error occurred. Please try again or contact support if the problem persists."
+      loggerNamespace="web:error"
+      links={LINKS}
+    />
   );
 }

--- a/apps/web/src/components/RouteErrorView.tsx
+++ b/apps/web/src/components/RouteErrorView.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { Logger } from '@eventuras/logger';
+import { ErrorBlock } from '@eventuras/ratio-ui/blocks/Error';
+import { Button } from '@eventuras/ratio-ui/core/Button';
+import { PageOverlay } from '@eventuras/ratio-ui/core/PageOverlay';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+export interface RouteErrorViewLink {
+  href: string;
+  label: string;
+}
+
+export interface RouteErrorViewProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+  /** Heading shown on the error page */
+  title: string;
+  /** Short user-facing explanation */
+  description: string;
+  /** Logger namespace, e.g. `web:admin:error`. Reads pathname + search and logs to it. */
+  loggerNamespace: string;
+  /** Searchable key-value tags (low cardinality, e.g. `section`, `tab`). Forwarded to logger context and the underlying error reporter. */
+  tags?: Record<string, string>;
+  /** Action links shown after the "Try Again" button */
+  links?: ReadonlyArray<RouteErrorViewLink>;
+}
+
+/**
+ * Shared body for Next.js route-level error boundaries
+ * (`app/error.tsx`, `app/(admin)/admin/error.tsx`, etc.).
+ *
+ * Captures the error to Sentry and the eventuras logger with consistent
+ * pathname/search context, then renders the standard `PageOverlay` +
+ * `ErrorBlock` shell with a "Try Again" button and optional navigation links.
+ */
+export function RouteErrorView({
+  error,
+  reset,
+  title,
+  description,
+  loggerNamespace,
+  tags,
+  links,
+}: Readonly<RouteErrorViewProps>) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const search = searchParams?.toString() ?? '';
+    const logger = Logger.create({
+      namespace: loggerNamespace,
+      context: tags,
+    });
+
+    logger.error(
+      {
+        error: {
+          message: error.message,
+          stack: error.stack,
+          digest: error.digest,
+        },
+        pathname,
+        search,
+      },
+      'Unhandled error in route'
+    );
+
+    Sentry.captureException(error, {
+      tags,
+      extra: { pathname, search, digest: error.digest },
+    });
+  }, [error, loggerNamespace, pathname, searchParams, tags]);
+
+  return (
+    <PageOverlay status="error" fullScreen>
+      <ErrorBlock type="server-error" status="error">
+        <ErrorBlock.Title>{title}</ErrorBlock.Title>
+        <ErrorBlock.Description>{description}</ErrorBlock.Description>
+        {error.digest && (
+          <ErrorBlock.Details>
+            <div className="text-sm opacity-75">Error ID: {error.digest}</div>
+          </ErrorBlock.Details>
+        )}
+        <ErrorBlock.Actions>
+          <Button variant="danger" onClick={reset}>
+            Try Again
+          </Button>
+          {links?.map(link => (
+            <Link key={link.href} href={link.href} variant="button-secondary">
+              {link.label}
+            </Link>
+          ))}
+        </ErrorBlock.Actions>
+      </ErrorBlock>
+    </PageOverlay>
+  );
+}


### PR DESCRIPTION
## Summary
- Extracts `apps/web/src/components/RouteErrorView.tsx` to host the shared body of Next.js route-level error boundaries.
- Routes `app/error.tsx` and `app/(admin)/admin/error.tsx` through it — each drops from 70–85 lines to ~25.
- Swaps hand-rolled `<button>` / `<Link>` tailwind blocks for `ratio-ui` `Button` + `Link` for visual consistency.

## Scope
This is for **route-level** boundaries only, where Next.js has already replaced the entire route content with the fallback. It always renders inside `PageOverlay`. Sub-tree fallbacks use `ErrorBoundary.DefaultFallback` from #1465 (inline `ErrorBlock`, no overlay) — different concern, kept separate.

## API
```tsx
<RouteErrorView
  error={error}
  reset={reset}
  title="Admin Error"
  description="An error occurred in the admin section."
  loggerNamespace="web:admin:error"
  tags={{ section: 'admin' }}
  links={[{ href: '/admin', label: 'Back to Admin Dashboard' }]}
/>
```

Vendor-neutral `tags` (not `sentryTags`) — mapped to Sentry tags and logger context inside the component. If we swap reporters later, consumers stay unchanged.

## Not touched
- `app/global-error.tsx` stays standalone — it must avoid importing the eventuras logger to prevent re-triggering whatever broke the root layout.

## Test plan
- [ ] Force an error inside `/admin/events/{id}` — admin error page renders with new design, has the same three links (Try Again, Back to Admin Dashboard, Go to Home).
- [ ] Force an error outside `/admin` — root error page renders with Try Again + Go to Home.
- [ ] Check GlitchTip — `section: admin` tag present for admin route, absent for root route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)