### PR TITLE
feat(web): isolate admin event tabs behind ErrorBoundary

### DIFF
--- a/.changeset/web-admin-tab-error-boundaries.md
+++ b/.changeset/web-admin-tab-error-boundaries.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Isolate each tab in the admin event editor behind an `ErrorBoundary` so a deep crash inside one tab no longer takes down the whole admin page. Logs to Sentry with `section: admin` and `tab: <id>` tags.

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventPageTabs.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventPageTabs.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
 import { Logger } from '@eventuras/logger';
 import { Button } from '@eventuras/ratio-ui/core/Button';
+import { ErrorBoundary } from '@eventuras/ratio-ui/core/ErrorBoundary';
 import { Tabs } from '@eventuras/ratio-ui/core/Tabs';
 import { ActionBar } from '@eventuras/ratio-ui/layout/ActionBar';
 import { useToast } from '@eventuras/ratio-ui/toast';
@@ -34,6 +36,31 @@ import ParticipantsSection from './ParticipantsSection';
 import EventProductsEditor from './products/EventProductsEditor';
 import { updateEvent } from '../actions';
 import { AdminCertificatesActionsMenu } from '../AdminCertificatesActionsMenu';
+
+// Isolates a tab's content so a crash there doesn't propagate to the page boundary.
+const TabErrorBoundary = ({ tabId, children }: { tabId: string; children: ReactNode }) => (
+  <ErrorBoundary
+    onError={(error, info) => {
+      const logger = Logger.create({
+        namespace: 'web:admin:events',
+        context: { section: 'admin', tab: tabId },
+      });
+      logger.error(
+        {
+          error: { message: error.message, stack: error.stack },
+          componentStack: info.componentStack,
+        },
+        'Tab content crashed'
+      );
+      Sentry.captureException(error, {
+        tags: { section: 'admin', tab: tabId },
+        extra: { componentStack: info.componentStack },
+      });
+    }}
+  >
+    {children}
+  </ErrorBoundary>
+);
 
 // Auto-save wrapper component that watches form changes
 const AutoSaveHandler = ({ onAutoSave }: { onAutoSave: (data: EventFormDto) => void }) => {
@@ -231,22 +258,28 @@ export default function EventPageTabs({
           title={t('admin.events.tabs.participants')}
           testId="tab-participants"
         >
-          <ParticipantsSection
-            eventInfo={eventinfo}
-            participants={participants}
-            statistics={statistics}
-            eventProducts={eventProducts}
-          />
+          <TabErrorBoundary tabId="participants">
+            <ParticipantsSection
+              eventInfo={eventinfo}
+              participants={participants}
+              statistics={statistics}
+              eventProducts={eventProducts}
+            />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item id="overview" title={t('admin.events.tabs.overview')} testId="tab-overview">
-          <OverviewSection organizationId={organizationId} />
-          <SaveActionBar onSave={handleAutoSave} />
+          <TabErrorBoundary tabId="overview">
+            <OverviewSection organizationId={organizationId} />
+            <SaveActionBar onSave={handleAutoSave} />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item id="dates" title={t('admin.events.tabs.dates')} testId="tab-dates">
-          <DatesLocationSection />
-          <SaveActionBar onSave={handleAutoSave} />
+          <TabErrorBoundary tabId="dates">
+            <DatesLocationSection />
+            <SaveActionBar onSave={handleAutoSave} />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item
@@ -254,8 +287,10 @@ export default function EventPageTabs({
           title={t('admin.events.tabs.descriptions')}
           testId="tab-descriptions"
         >
-          <DescriptionsSection />
-          <SaveActionBar onSave={handleAutoSave} />
+          <TabErrorBoundary tabId="descriptions">
+            <DescriptionsSection />
+            <SaveActionBar onSave={handleAutoSave} />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item
@@ -263,10 +298,12 @@ export default function EventPageTabs({
           title={t('admin.events.tabs.certificate')}
           testId="tab-certificate"
         >
-          <CertificateSection />
-          <SaveActionBar onSave={handleAutoSave}>
-            <AdminCertificatesActionsMenu eventinfo={eventinfo} />
-          </SaveActionBar>
+          <TabErrorBoundary tabId="certificate">
+            <CertificateSection />
+            <SaveActionBar onSave={handleAutoSave}>
+              <AdminCertificatesActionsMenu eventinfo={eventinfo} />
+            </SaveActionBar>
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item
@@ -274,20 +311,28 @@ export default function EventPageTabs({
           title={t('admin.events.tabs.communication')}
           testId="tab-communication"
         >
-          <CommunicationSection eventinfo={eventinfo} notifications={notifications} />
+          <TabErrorBoundary tabId="communication">
+            <CommunicationSection eventinfo={eventinfo} notifications={notifications} />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item id="products" title={t('admin.events.tabs.products')} testId="tab-products">
-          <EventProductsEditor eventInfo={eventinfo} products={eventProducts} />
+          <TabErrorBoundary tabId="products">
+            <EventProductsEditor eventInfo={eventinfo} products={eventProducts} />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item id="advanced" title={t('admin.events.tabs.advanced')} testId="tab-advanced">
-          <AdvancedSection eventId={eventinfo.id} />
-          <SaveActionBar onSave={handleAutoSave} />
+          <TabErrorBoundary tabId="advanced">
+            <AdvancedSection eventId={eventinfo.id} />
+            <SaveActionBar onSave={handleAutoSave} />
+          </TabErrorBoundary>
         </Tabs.Item>
 
         <Tabs.Item id="economy" title={t('admin.events.tabs.economy')} testId="tab-economy">
-          <EconomySection participants={participants} />
+          <TabErrorBoundary tabId="economy">
+            <EconomySection participants={participants} />
+          </TabErrorBoundary>
         </Tabs.Item>
       </Tabs>
     </Form>


### PR DESCRIPTION
## Summary
- Wraps each `Tabs.Item` content in `EventPageTabs` with the new `@eventuras/ratio-ui/core/ErrorBoundary` (from #1465).
- Local `TabErrorBoundary` helper logs to the eventuras logger + Sentry, tagged with `section: admin` and `tab: <id>` for triage.

## Why
A render-time crash deep inside one tab (e.g. a Lexical issue inside the descriptions tab, like the one we just fixed in #1463) was escalating all the way to `admin/error.tsx` and replacing the entire admin shell. With tab-level boundaries, only the broken tab shows the fallback; the rest of the editor stays usable, and the user can navigate to another tab without reloading.

## Scope
- **Outer (per-tab):** done here.
- **Inner (per-MarkdownInput):** intentionally **not** added in this PR. Scribo has no `@eventuras/ratio-ui` dependency (it's published standalone), and after #1463's defensive parse fallback the practical Lexical crash is already handled. If we later see a need to isolate single fields, it can be added in `EventEditorSections.tsx` without touching scribo.

## API shape

```tsx
<Tabs.Item id="descriptions" title={...}>
  <TabErrorBoundary tabId="descriptions">
    <DescriptionsSection />
    <SaveActionBar onSave={handleAutoSave} />
  </TabErrorBoundary>
</Tabs.Item>
```

`TabErrorBoundary` is local to `EventPageTabs.tsx` for now — easy to lift into a shared component if we adopt the pattern elsewhere.

## Test plan
- [ ] Inject a throw inside `DescriptionsSection` (e.g. `throw new Error('test')`) — descriptions tab shows the boundary fallback; switching to other tabs still works.
- [ ] Remove the throw, reload — descriptions tab works normally.
- [ ] Verify the Sentry event lands with `tab: descriptions` and `section: admin` tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)