### PR TITLE
feat(fides-auth-next): add useHeartbeat hook and handleHeartbeat handler

### DIFF
--- a/.changeset/fides-auth-next-heartbeat.md
+++ b/.changeset/fides-auth-next-heartbeat.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/fides-auth-next': minor
+---
+
+Add `useHeartbeat` React hook and `handleHeartbeat` route handler for activity-driven session keepalive.

--- a/libs/fides-auth-next/package.json
+++ b/libs/fides-auth-next/package.json
@@ -35,6 +35,10 @@
     "./oidc-login": {
       "types": "./dist/oidc-login.d.ts",
       "import": "./dist/oidc-login.js"
+    },
+    "./heartbeat-handler": {
+      "types": "./dist/heartbeat-handler.d.ts",
+      "import": "./dist/heartbeat-handler.js"
     }
   },
   "main": "./dist/index.js",

--- a/libs/fides-auth-next/src/heartbeat-handler.ts
+++ b/libs/fides-auth-next/src/heartbeat-handler.ts
@@ -1,0 +1,84 @@
+/**
+ * Server-side heartbeat handler for Next.js route handlers.
+ *
+ * Pairs with the client-side `useHeartbeat` hook: when the user is active, the
+ * client POSTs here, and this handler exchanges the current refresh token for
+ * a fresh access token (and rotated refresh token, if the IdP rotates).
+ *
+ * Returns:
+ * - 200 with `{ accessTokenExpiresAt }` on success
+ * - 401 when there is no session or the refresh token is dead
+ * - 405 for non-POST methods
+ * - 429 when rate-limited
+ */
+
+import { Logger } from '@eventuras/logger';
+import type { OAuthConfig } from '@eventuras/fides-auth/oauth';
+import { getCurrentSession, refreshCurrentSession } from './session';
+import { globalPOSTRateLimit } from './request';
+
+const logger = Logger.create({ namespace: 'fides-auth-next:heartbeat' });
+
+export interface HeartbeatHandlerConfig {
+  /** OAuth/OIDC configuration used to refresh the access token. */
+  oauthConfig: OAuthConfig;
+}
+
+/**
+ * Handles a heartbeat request — refresh the active session if there is one.
+ *
+ * @example
+ * ```ts
+ * // app/(auth)/api/auth/heartbeat/route.ts
+ * import { handleHeartbeat } from '@eventuras/fides-auth-next/heartbeat-handler';
+ * import { oauthConfig } from '@/utils/oauthConfig';
+ *
+ * export async function POST(request: Request) {
+ *   return handleHeartbeat(request, { oauthConfig });
+ * }
+ * ```
+ */
+export async function handleHeartbeat(
+  request: Request,
+  config: HeartbeatHandlerConfig,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response(null, { status: 405, headers: { Allow: 'POST' } });
+  }
+
+  if (!(await globalPOSTRateLimit())) {
+    logger.warn('Heartbeat rate limit exceeded');
+    return new Response(null, { status: 429 });
+  }
+
+  const session = await getCurrentSession();
+  if (!session) {
+    logger.debug('Heartbeat with no session');
+    return new Response(null, { status: 401 });
+  }
+
+  if (!session.tokens?.refreshToken) {
+    logger.warn('Heartbeat with session but no refresh token');
+    return new Response(null, { status: 401 });
+  }
+
+  const updated = await refreshCurrentSession(config.oauthConfig);
+  if (!updated) {
+    // Refresh failed — most likely invalid_grant (refresh token expired).
+    logger.info('Heartbeat refresh failed');
+    return new Response(null, { status: 401 });
+  }
+
+  logger.debug('Heartbeat refresh succeeded');
+  return Response.json(
+    {
+      accessTokenExpiresAt: updated.tokens?.accessTokenExpiresAt ?? null,
+    },
+    {
+      // Auth/session endpoint — must never be cached by the browser or any
+      // intermediary, or a stale 200 could fool the client into thinking a
+      // refresh succeeded without actually hitting the server.
+      headers: { 'Cache-Control': 'private, no-store' },
+    },
+  );
+}

--- a/libs/fides-auth-next/src/index.ts
+++ b/libs/fides-auth-next/src/index.ts
@@ -4,6 +4,7 @@ export * from './session';
 export * from './cookies';
 export * from './oidc-callback';
 export * from './oidc-login';
+export * from './heartbeat-handler';
 
 // Authentication Store (XState Store)
 export * from './store';

--- a/libs/fides-auth-next/src/store/index.ts
+++ b/libs/fides-auth-next/src/store/index.ts
@@ -121,6 +121,8 @@ export {
 
 export { useSessionMonitor } from './use-session-monitor';
 
+export { useHeartbeat, type HeartbeatConfig } from './use-heartbeat';
+
 export { configureAuthLogger } from './configure-logger';
 
 // Shared types

--- a/libs/fides-auth-next/src/store/use-heartbeat.ts
+++ b/libs/fides-auth-next/src/store/use-heartbeat.ts
@@ -1,0 +1,217 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import {
+  createActivityTracker,
+  type ActivityTracker,
+} from '@eventuras/fides-auth/activity-tracker';
+import { Logger } from '@eventuras/logger';
+
+/**
+ * Configuration for {@link useHeartbeat}.
+ */
+export interface HeartbeatConfig {
+  /**
+   * Endpoint to POST to in order to refresh the session.
+   * The endpoint must run server-side refresh and return 2xx on success or 401
+   * when the refresh token is no longer valid.
+   * @default '/api/auth/heartbeat'
+   */
+  endpoint?: string;
+
+  /**
+   * Interval between heartbeat ticks, in ms.
+   * @default 300_000 (5 minutes)
+   */
+  intervalMs?: number;
+
+  /**
+   * How recently the user must have interacted for a heartbeat to fire.
+   * Prevents background tabs from extending sessions indefinitely.
+   * @default 120_000 (2 minutes)
+   */
+  idleThresholdMs?: number;
+
+  /**
+   * Called when the heartbeat endpoint returns 401 — refresh token is gone.
+   */
+  onSessionExpired?: () => void;
+
+  /**
+   * Called after a successful refresh tick.
+   */
+  onRefreshed?: () => void;
+
+  /**
+   * Called on transient errors (network failure, 5xx). The hook keeps polling
+   * — this is just an observability hook.
+   */
+  onError?: (error: Error) => void;
+
+  /**
+   * Namespace for the logger.
+   * @default 'fides:heartbeat'
+   */
+  loggerNamespace?: string;
+}
+
+const DEFAULTS = {
+  endpoint: '/api/auth/heartbeat',
+  intervalMs: 5 * 60_000,
+  idleThresholdMs: 2 * 60_000,
+  loggerNamespace: 'fides:heartbeat',
+} as const;
+
+/**
+ * Activity-driven session keepalive.
+ *
+ * Polls a server-side refresh endpoint at a fixed interval, but only when the
+ * user has actually been active recently. Skips ticks when the tab is hidden,
+ * and runs an immediate refresh when the tab regains focus after a long away.
+ *
+ * Intended to be paired with {@link useSessionMonitor}: the monitor *detects*
+ * session loss; this hook *prevents* it for active users.
+ *
+ * @example
+ * ```tsx
+ * 'use client';
+ * import { useHeartbeat, useSessionMonitor } from '@eventuras/fides-auth-next/store';
+ *
+ * function AuthProvider({ children }) {
+ *   useSessionMonitor(authStore, checkAuthStatus);
+ *   useHeartbeat({ onSessionExpired: () => authStore.send({ type: 'sessionExpired' }) });
+ *   return <>{children}</>;
+ * }
+ * ```
+ */
+export function useHeartbeat(config: HeartbeatConfig = {}): void {
+  const endpoint = config.endpoint ?? DEFAULTS.endpoint;
+  const intervalMs = config.intervalMs ?? DEFAULTS.intervalMs;
+  const idleThresholdMs = config.idleThresholdMs ?? DEFAULTS.idleThresholdMs;
+  const loggerNamespace = config.loggerNamespace ?? DEFAULTS.loggerNamespace;
+
+  // Keep callbacks stable across renders without re-running the effect.
+  const callbacksRef = useRef({
+    onSessionExpired: config.onSessionExpired,
+    onRefreshed: config.onRefreshed,
+    onError: config.onError,
+  });
+  callbacksRef.current = {
+    onSessionExpired: config.onSessionExpired,
+    onRefreshed: config.onRefreshed,
+    onError: config.onError,
+  };
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const logger = Logger.create({
+      namespace: loggerNamespace,
+      context: { component: 'Heartbeat' },
+    });
+
+    const tracker: ActivityTracker = createActivityTracker();
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let lastTickAt = Date.now();
+    let stopped = false;
+
+    const teardown = (): void => {
+      if (stopped) return;
+      stopped = true;
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      abortController.abort();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      tracker.dispose();
+    };
+
+    const sendBeat = async (): Promise<void> => {
+      if (stopped) return;
+
+      // Skip while hidden — focus listener will catch up when tab returns.
+      if (document.visibilityState === 'hidden') {
+        logger.debug('Tab hidden, skipping heartbeat');
+        return;
+      }
+
+      if (!tracker.isActiveWithin(idleThresholdMs)) {
+        logger.debug({ idleThresholdMs }, 'No recent activity, skipping heartbeat');
+        return;
+      }
+
+      lastTickAt = Date.now();
+      try {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: { 'content-type': 'application/json' },
+          signal: abortController.signal,
+        });
+
+        // Component unmounted (or 401-driven teardown) during the fetch —
+        // bail before touching callbacks so we don't fire on a dead consumer.
+        if (stopped) return;
+
+        if (response.status === 401) {
+          logger.info('Heartbeat returned 401 — session expired');
+          callbacksRef.current.onSessionExpired?.();
+          // Tear down eagerly so listeners and tracker don't linger until unmount.
+          teardown();
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error(`Heartbeat failed with status ${response.status}`);
+        }
+
+        logger.debug('Heartbeat refresh succeeded');
+        callbacksRef.current.onRefreshed?.();
+      } catch (error) {
+        // Suppress AbortError-from-teardown and any error reported after stop.
+        if (stopped) return;
+        const err = error instanceof Error ? error : new Error(String(error));
+        logger.warn({ error: err.message }, 'Heartbeat tick failed');
+        callbacksRef.current.onError?.(err);
+      }
+    };
+
+    const scheduleNext = (): void => {
+      if (stopped) return;
+      timeoutId = setTimeout(async () => {
+        timeoutId = null;
+        await sendBeat();
+        scheduleNext();
+      }, intervalMs);
+    };
+
+    function onVisibilityChange(): void {
+      if (stopped) return;
+      if (document.visibilityState !== 'visible') return;
+
+      // Tab regained focus. If we've been away longer than one tick, beat now —
+      // but cancel the pending tick first so we don't fire twice back-to-back.
+      const sinceLast = Date.now() - lastTickAt;
+      if (sinceLast >= intervalMs) {
+        logger.debug({ sinceLast }, 'Tab regained focus after long away, beating now');
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+        void sendBeat().then(scheduleNext);
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    scheduleNext();
+
+    logger.debug({ intervalMs, idleThresholdMs, endpoint }, 'Heartbeat started');
+
+    return () => {
+      teardown();
+      logger.debug('Heartbeat stopped');
+    };
+  }, [endpoint, intervalMs, idleThresholdMs, loggerNamespace]);
+}

--- a/libs/fides-auth-next/vite.config.ts
+++ b/libs/fides-auth-next/vite.config.ts
@@ -6,6 +6,7 @@ export default defineNextLibConfig({
     session: 'src/session.ts',
     request: 'src/request.ts',
     'store/index': 'src/store/index.ts',
+    'heartbeat-handler': 'src/heartbeat-handler.ts',
   },
   external: [
     // State management


### PR DESCRIPTION
## Summary

Activity-driven session keepalive on top of the `createActivityTracker` primitive landed in #1470.

- **`useHeartbeat`** — React hook that ticks every 5 min, gated on user activity within the last 2 min. Pauses on hidden tabs, beats immediately on tab refocus after a long away, and emits `onSessionExpired` when the refresh endpoint returns 401.
- **`handleHeartbeat`** — Next.js route-handler factory that runs `refreshCurrentSession` and returns 401 when the refresh token is gone. Rate-limited via the existing `globalPOSTRateLimit`.
- New subpath exports: `@eventuras/fides-auth-next/store` (adds `useHeartbeat`) and `@eventuras/fides-auth-next/heartbeat-handler`.

**Part 2/3** of the session heartbeat work:
- #1470 — `fides-auth`: activity tracker primitive (merged)
- This PR — `fides-auth-next`: hook + handler
- PR #3 (next) — `apps/web`: route + provider wiring

No app behavior change in this PR — these are unused exports until wired up in PR #3.

## Motivation

Auth0 idle refresh-token lifetime kicks in even for active users who don't navigate — e.g. long form editing. This is the bridge between "user is interacting" (PR #1) and "tokens get refreshed" (PR #3).

## Design notes

- 5 min interval / 2 min idle threshold chosen so a user typing continuously never lets the access token (15 min default) get within close range of the Auth0 idle refresh window (typically 30+ min)
- Tab visibility check prevents background tabs from indefinitely extending sessions
- Callbacks are kept in a ref so re-renders don't restart the timer
- No unit tests in this PR — `libs/fides-auth-next` has no vitest setup yet; planned as a follow-up (logged separately)

## Test plan
- [ ] `pnpm --filter @eventuras/fides-auth-next build` emits `dist/heartbeat-handler.{js,d.ts}` and `dist/store/use-heartbeat.{js,d.ts}`
- [ ] Changeset present (`.changeset/fides-auth-next-heartbeat.md`)
- [ ] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)