### PR TITLE
feat(web): enable activity-driven session heartbeat

### DIFF
--- a/apps/web/src/app/(auth)/api/auth/heartbeat/route.ts
+++ b/apps/web/src/app/(auth)/api/auth/heartbeat/route.ts
@@ -1,0 +1,7 @@
+import { handleHeartbeat } from '@eventuras/fides-auth-next/heartbeat-handler';
+
+import { oauthConfig } from '@/utils/oauthConfig';
+
+export async function POST(request: Request): Promise<Response> {
+  return handleHeartbeat(request, { oauthConfig });
+}

--- a/apps/web/src/app/Providers.tsx
+++ b/apps/web/src/app/Providers.tsx
@@ -1,11 +1,15 @@
 'use client';
 import { useEffect } from 'react';
 
-import { initializeAuth, startSessionMonitor } from '@eventuras/fides-auth-next/store';
+import {
+  initializeAuth,
+  startSessionMonitor,
+  useHeartbeat,
+} from '@eventuras/fides-auth-next/store';
 import { Logger } from '@eventuras/logger';
 import { ToastRenderer } from '@eventuras/ratio-ui/toast';
 
-import { authStore } from '@/auth/authStore';
+import { authStore, useAuthStore } from '@/auth/authStore';
 import { LoginSuccessHandler } from '@/components/auth/LoginSuccessHandler';
 import { SessionWarningOverlay } from '@/components/SessionWarningOverlay';
 import { SentryUserContext } from '@/providers/sentry/SentryUserContext';
@@ -21,7 +25,25 @@ type ProvidersProps = {
   children: React.ReactNode;
 };
 
+/**
+ * Activity-driven session keepalive. Lives behind an `isAuthenticated` gate so
+ * we don't POST `/api/auth/heartbeat` for anonymous users (which would return
+ * 401 and incorrectly mark the session as expired). On logout/expiry this
+ * unmounts; on next login it remounts with a fresh effect.
+ */
+function HeartbeatRunner() {
+  useHeartbeat({
+    onSessionExpired: () => {
+      logger.warn('Heartbeat detected expired refresh token');
+      authStore.send({ type: 'sessionExpired' });
+    },
+  });
+  return null;
+}
+
 export default function Providers({ children }: Readonly<ProvidersProps>) {
+  const { isAuthenticated } = useAuthStore();
+
   // Initialize auth store and start session monitoring
   useEffect(() => {
     logger.info('Initializing auth store');
@@ -64,6 +86,7 @@ export default function Providers({ children }: Readonly<ProvidersProps>) {
       <LoginSuccessHandler />
       <SentryUserContext />
       <SessionWarningOverlay />
+      {isAuthenticated && <HeartbeatRunner />}
       {children}
     </ThemeProvider>
   );


### PR DESCRIPTION
## Summary

Wires the heartbeat machinery from #1470 (activity tracker) and #1473 (hook + handler) into the web app:

- New `POST /api/auth/heartbeat` route that delegates to `handleHeartbeat({ oauthConfig })`
- `useHeartbeat` invoked from the root `Providers` so every authenticated user benefits. On 401, dispatches `sessionExpired` to the existing `authStore`.

**Final 3/3** of the heartbeat work:
- #1470 — `fides-auth`: activity tracker primitive (merged)
- #1473 — `fides-auth-next`: hook + handler (merged)
- This PR — `apps/web`: route + provider wiring

## Why

Auth0's idle refresh-token lifetime cuts off active users who don't navigate — typically someone editing a long form or scribo callout. Symptom: "logged out while typing." With this in place, the client refreshes the access token every ~5 min while the user is actually interacting (mouse/keyboard/touch/focus within the last 2 min). Background tabs are skipped, and a tab regaining focus after a long away triggers an immediate refresh.

Together with the planned Auth0 lifetime adjustment (access 15 min / idle 30 min / max 8 h), this should eliminate the reports.

## Test plan
- [ ] `pnpm dev` in `apps/web` — log in, leave a form open for >5 min while typing occasionally, confirm `/api/auth/heartbeat` returns 200 and the session cookie is rotated
- [ ] DevTools → Network: heartbeat tick fires every 5 min, only when interacting in the last 2 min
- [ ] DevTools → switch tab away for 6 min, switch back: immediate heartbeat fires
- [ ] Force-expire the refresh token (e.g. Auth0 revoke session): next heartbeat returns 401 and `sessionExpired` is dispatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)