### PR TITLE
feat(ratio-ui): add Chip — theme-scope-aware tag primitive

### DIFF
--- a/.changeset/ratio-ui-chip.md
+++ b/.changeset/ratio-ui-chip.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Add `<Chip>` at `@eventuras/ratio-ui/core/Chip` — a theme-scope-aware tag primitive that reads colors and radius from CSS tokens (`--chip-bg/-fg/-border/-on-solid/-radius`), so any ancestor can re-skin chips locally without forking. Sibling to `Badge` (which carries semantic status); Chip is a neutral primitive that adopts its surrounding palette. Composes freely — use `<Chip.Dot/>` for the conventional `currentColor` dot, or place any icon before/after the label. Variants: `subtle` (default), `outline`, `filled` — outline uses the shared `--alpha-2` token for its background wash. Tokens live in `tokens/chip.css`.

--- a/libs/ratio-ui/src/core/Chip/Chip.stories.tsx
+++ b/libs/ratio-ui/src/core/Chip/Chip.stories.tsx
@@ -1,0 +1,165 @@
+import type * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Chip } from './Chip';
+
+const meta: Meta<typeof Chip> = {
+  title: 'Core/Chip (beta)',
+  component: Chip,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Theme-scope-aware tag primitive. Colors and radius come from CSS tokens (`--chip-bg`, `--chip-fg`, `--chip-border`, `--chip-radius`) so an ancestor can re-skin chips inside its scope. Pairs with `Badge` — Badge carries semantic status, Chip is a neutral primitive that adopts its surrounding palette. Typography (mono, uppercase) is not on Chip — apply via className or compose with a typography primitive.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Chip>;
+
+// Shared utility string for "tag style" — mono uppercase with tighter padding.
+// Once Text gains mono/uppercase props, this can be replaced with
+// `<Chip><Text mono uppercase>…</Text></Chip>`.
+const TAG_CLASS = 'font-mono uppercase tracking-widest font-bold px-2 py-0.5';
+
+export const Default: Story = {
+  render: () => <Chip>v2.4</Chip>,
+};
+
+export const Tag: Story = {
+  name: 'Tag style — via className',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For the dense "env tag" look (mono, uppercase, tighter padding), apply utility classes via `className`. Chip itself stays focused on chip shape — typography is a separate concern.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex gap-2">
+      <Chip className={TAG_CLASS}>prod</Chip>
+      <Chip className={TAG_CLASS}>staging</Chip>
+      <Chip className={TAG_CLASS}>local</Chip>
+    </div>
+  ),
+};
+
+export const WithDot: Story = {
+  name: 'Composing — Chip.Dot before / after text',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Chip is a flex row with `gap-1.5`, so children render side-by-side. Use `<Chip.Dot/>` for the conventional currentColor dot, or compose any icon before/after the label.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <Chip>
+        <Chip.Dot />
+        active
+      </Chip>
+      <Chip className={TAG_CLASS}>
+        <Chip.Dot />
+        live
+      </Chip>
+      <Chip className={TAG_CLASS}>
+        connected
+        <Chip.Dot />
+      </Chip>
+    </div>
+  ),
+};
+
+export const Outline: Story = {
+  name: 'Outline — currentColor tint',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The outline variant uses `currentColor` for both border and a faint background tint (via the shared `--alpha-2` token). Set `color` on the chip — or an ancestor — to tint it to any status.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <span style={{ color: 'var(--info-solid)' }}>
+        <Chip variant="outline" className={TAG_CLASS}>info</Chip>
+      </span>
+      <span style={{ color: 'var(--success-solid)' }}>
+        <Chip variant="outline" className={TAG_CLASS}>success</Chip>
+      </span>
+      <span style={{ color: 'var(--warning-solid)' }}>
+        <Chip variant="outline" className={TAG_CLASS}>warn</Chip>
+      </span>
+      <span style={{ color: 'var(--error-solid)' }}>
+        <Chip variant="outline" className={TAG_CLASS}>error</Chip>
+      </span>
+    </div>
+  ),
+};
+
+export const Filled: Story = {
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <span style={{ color: 'var(--info-solid)' }}>
+        <Chip variant="filled">info</Chip>
+      </span>
+      <span style={{ color: 'var(--success-solid)' }}>
+        <Chip variant="filled">success</Chip>
+      </span>
+    </div>
+  ),
+};
+
+export const ThemeScopeOverride: Story = {
+  name: 'Theme-scope override',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A container can override the chip tokens locally — useful for themed surfaces where the chip should follow the local palette rather than the app theme.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={
+        {
+          padding: '24px',
+          background: 'oklch(0.165 0.030 234)',
+          '--chip-bg': 'rgba(255, 255, 255, 0.08)',
+          '--chip-fg': 'oklch(0.785 0.028 82)',
+          '--chip-border': 'oklch(0.330 0.058 230)',
+        } as React.CSSProperties
+      }
+    >
+      <Chip className={TAG_CLASS}>prod</Chip>
+    </div>
+  ),
+};
+
+export const SquareCorners: Story = {
+  name: 'Sharp corners via --chip-radius',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Override `--chip-radius` on a container to flip all chips inside to sharp corners — useful for retro / brutalist sub-experiences. The component name is shape-agnostic precisely because shape is themable.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{ '--chip-radius': '0' } as React.CSSProperties}
+      className="flex gap-2"
+    >
+      <Chip className={TAG_CLASS}>prod</Chip>
+      <Chip>v2.4</Chip>
+    </div>
+  ),
+};

--- a/libs/ratio-ui/src/core/Chip/Chip.tsx
+++ b/libs/ratio-ui/src/core/Chip/Chip.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+/**
+ * Theme-scope-aware tag primitive — a small chip whose colors and radius
+ * come from CSS custom properties (`--chip-bg`, `--chip-fg`, `--chip-border`,
+ * `--chip-radius`), so any ancestor can override the palette to match its
+ * local theme.
+ *
+ * Named after the generic concept rather than a shape ("Chip" rather than
+ * "Pill") because the radius is themeable: the default is pill-shaped
+ * (9999px), but consumers can flip it to rounded or square locally
+ * without changing the component.
+ *
+ * Pairs well with — but is intentionally simpler than — `Badge`:
+ *
+ * - **`Badge`** carries semantic status (info / success / warning / error),
+ *   reads from app-level status tokens, and stays consistent across the page.
+ * - **`Chip`** is a neutral tag primitive. It picks up whatever palette its
+ *   ancestor scope provides — perfect for things like env tags inside a
+ *   themed container, or kicker labels that should look "embedded" in their
+ *   surrounding surface.
+ *
+ * ## Composition
+ *
+ * Chip is a flex row with `gap-1.5`, so any children render side-by-side.
+ * Use `<Chip.Dot/>` for the conventional `currentColor` dot, or compose any
+ * icon, text, or other element before/after the label.
+ *
+ * Typography (mono, uppercase, etc.) is intentionally not on Chip — apply
+ * it via `className` or wrap the text in a typography primitive. This keeps
+ * Chip focused on the chip shape itself.
+ *
+ * ```tsx
+ * <Chip>v2.4</Chip>
+ *
+ * // Tag style — typography via className
+ * <Chip className="font-mono uppercase tracking-widest font-bold px-2 py-0.5">
+ *   prod
+ * </Chip>
+ *
+ * // Leading dot
+ * <Chip>
+ *   <Chip.Dot />
+ *   active
+ * </Chip>
+ *
+ * // Themed scope — overrides cascade in
+ * <section style={{ '--chip-bg': '#0a0d09', '--chip-fg': '#b8f2c8' }}>
+ *   <Chip>prod</Chip>
+ * </section>
+ *
+ * // Sharp corners
+ * <div style={{ '--chip-radius': '0' }}>
+ *   <Chip>v2.4</Chip>
+ * </div>
+ * ```
+ *
+ * @beta This component is experimental — prop shape may change before release.
+ */
+export type ChipVariant = 'subtle' | 'outline' | 'filled';
+
+export interface ChipProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
+  children: React.ReactNode;
+  /**
+   * Visual treatment.
+   * - `'subtle'` (default) — tinted background, border, muted text via chip tokens
+   * - `'outline'` — transparent-ish background + border derived from `currentColor`
+   * - `'filled'` — solid `currentColor` background
+   */
+  variant?: ChipVariant;
+}
+
+const ChipRoot: React.FC<ChipProps> = ({
+  children,
+  variant = 'subtle',
+  className,
+  ...rest
+}) => (
+  <span
+    {...rest}
+    className={cn(
+      // Layout + typography baseline
+      'inline-flex items-center gap-1.5 px-2.5 py-1 whitespace-nowrap',
+      'text-xs font-medium leading-none',
+      // Themable surface (overridable by any ancestor scope)
+      'rounded-[var(--chip-radius,9999px)]',
+      'bg-(--chip-bg) text-(--chip-fg) border border-(--chip-border)',
+      // Variant treatments — outline + filled tint from `currentColor`.
+      // Outline uses --alpha-2 (10%) for the background wash — pulled from
+      // the shared alpha scale rather than a magic number.
+      variant === 'outline' && 'bg-current/(--alpha-2) border-current',
+      variant === 'filled' && 'bg-current text-(--chip-on-solid) border-transparent',
+      className,
+    )}
+  >
+    {children}
+  </span>
+);
+ChipRoot.displayName = 'Chip';
+
+/**
+ * Small leading/trailing dot in `currentColor`. Compose inside `<Chip>`
+ * before or after the label.
+ */
+const Dot: React.FC<{ className?: string }> = ({ className }) => (
+  <span
+    aria-hidden="true"
+    className={cn('size-2 rounded-full bg-current opacity-70 shrink-0', className)}
+  />
+);
+Dot.displayName = 'Chip.Dot';
+
+export const Chip = Object.assign(ChipRoot, { Dot });

--- a/libs/ratio-ui/src/core/Chip/index.ts
+++ b/libs/ratio-ui/src/core/Chip/index.ts
@@ -1,0 +1,2 @@
+export { Chip } from './Chip';
+export type { ChipProps, ChipVariant } from './Chip';

--- a/libs/ratio-ui/src/tokens/chip.css
+++ b/libs/ratio-ui/src/tokens/chip.css
@@ -1,0 +1,23 @@
+/*
+ * Chip tokens — defaults consumed by `core/Chip` and any component that
+ * composes it. Overridable per-scope (any ancestor can set `--chip-bg`
+ * etc. to re-skin chips inside its subtree without forking the
+ * component).
+ *
+ * Radius defaults to pill-shape (9999px). Flip `--chip-radius` on a
+ * container to round or square all chips inside that scope.
+ */
+
+:root {
+  --chip-bg: var(--card);
+  --chip-fg: var(--text-muted);
+  --chip-border: var(--border-1);
+  --chip-on-solid: var(--color-neutral-50);
+  --chip-radius: 9999px;
+}
+
+:root[data-theme="dark"] {
+  --chip-bg: rgba(255, 255, 255, 0.06);
+  --chip-fg: var(--text-muted);
+  --chip-border: var(--border-1);
+}

--- a/libs/ratio-ui/src/tokens/index.css
+++ b/libs/ratio-ui/src/tokens/index.css
@@ -3,3 +3,4 @@
 @import "./typography.css";
 @import "./spacing.css";
 @import "./border.css";
+@import "./chip.css";


### PR DESCRIPTION
## Summary

Adds `<Chip>` at `@eventuras/ratio-ui/core/Chip` — a themable tag chip whose colors and radius come from CSS custom properties, so any ancestor can re-skin chips inside its scope without forking the component.

Designed as a sibling to `Badge`:

- **`Badge`** carries semantic status (info / success / warning / error), reads from app-level status tokens, stays consistent across the page.
- **`Chip`** is a neutral tag primitive. It picks up whatever palette its ancestor scope provides — perfect for env tags inside themed containers, kicker labels embedded in surfaces, etc.

## API (minimal by design)

```tsx
<Chip variant="subtle | outline | filled">{children}</Chip>
<Chip.Dot />
```

Composes freely — use `<Chip.Dot/>` for the conventional `currentColor` dot, or place any icon/element before/after the label.

Variants:
- `subtle` (default) — tinted background + border via chip tokens
- `outline` — `currentColor` border + faint background tint (uses shared `--alpha-2` token)
- `filled` — solid `currentColor` background

## Design tokens

New `tokens/chip.css` file with light + dark defaults:

```
--chip-bg          : var(--card) | rgba(255,255,255,0.06)
--chip-fg          : var(--text-muted)
--chip-border      : var(--border-1)
--chip-on-solid    : var(--color-neutral-50)
--chip-radius      : 9999px            (pill by default — flip on any scope)
```

Pattern: one tokens file per component, imported from `tokens/index.css`. Future component PRs follow the same pattern without touching `theme.css`.

## Naming rationale

"Chip" not "Pill" — radius is themable (`--chip-radius` can be flipped to 0 for a square chip in a brutalist sub-experience). Component name describes the concept, not a default shape.

## Test plan
- [ ] `pnpm --filter @eventuras/ratio-ui build` clean
- [ ] Storybook stories render across variants + sharp-corners + theme-scope-override
- [ ] Outline variant tint reads from `--alpha-2` (visually consistent with future tokenization)

## Follow-up PRs (separately staged, not in this one)

- `LiveIndicator` (composes Chip with its own pulse animation)
- `IconButton` (square chrome button, sibling to Button)
- `Console` (uses all three above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)