### PR TITLE
fix(ratio-ui): simplify Chip variants to token-driven subtle + outline

### DIFF
--- a/.changeset/ratio-ui-chip-variants-fix.md
+++ b/.changeset/ratio-ui-chip-variants-fix.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Fix `<Chip>` variants. The previous `outline` and `filled` variants used `bg-current` to inherit a parent's `color` for tinting — but Chip's own `text-(--chip-fg)` override resolved `currentColor` to the chip's own text color, making `filled` chips render as muted bg + muted text (invisible label) and `outline` chips render as gray instead of tinted. Simplified to two token-driven variants: `subtle` (default — filled background via `--chip-bg`) and `outline` (transparent background, `--chip-border` outline). To tint chips per status, wrap in a container that overrides `--chip-bg/-fg/-border` with the semantic palette. The `filled` variant is removed; consumers wanting a solid-color chip override `--chip-bg` directly.

--- a/libs/ratio-ui/src/core/Chip/Chip.stories.tsx
+++ b/libs/ratio-ui/src/core/Chip/Chip.stories.tsx
@@ -76,53 +76,69 @@ export const WithDot: Story = {
 };
 
 export const Outline: Story = {
-  name: 'Outline — currentColor tint',
+  name: 'Outline — transparent + border',
   parameters: {
     docs: {
       description: {
         story:
-          'The outline variant uses `currentColor` for both border and a faint background tint (via the shared `--alpha-2` token). Set `color` on the chip — or an ancestor — to tint it to any status.',
+          'Outline has no fill — just `--chip-border` outline and `--chip-fg` text. To tint per-chip, wrap in a container that overrides those tokens with the semantic status palette.',
       },
     },
   },
   render: () => (
     <div className="flex gap-2 items-center">
-      <span style={{ color: 'var(--info-solid)' }}>
+      <Chip variant="outline">draft</Chip>
+      <div
+        style={
+          {
+            '--chip-fg': 'var(--info-text)',
+            '--chip-border': 'var(--info-border)',
+          } as React.CSSProperties
+        }
+      >
         <Chip variant="outline" className={TAG_CLASS}>info</Chip>
-      </span>
-      <span style={{ color: 'var(--success-solid)' }}>
+      </div>
+      <div
+        style={
+          {
+            '--chip-fg': 'var(--success-text)',
+            '--chip-border': 'var(--success-border)',
+          } as React.CSSProperties
+        }
+      >
         <Chip variant="outline" className={TAG_CLASS}>success</Chip>
-      </span>
-      <span style={{ color: 'var(--warning-solid)' }}>
+      </div>
+      <div
+        style={
+          {
+            '--chip-fg': 'var(--warning-text)',
+            '--chip-border': 'var(--warning-border)',
+          } as React.CSSProperties
+        }
+      >
         <Chip variant="outline" className={TAG_CLASS}>warn</Chip>
-      </span>
-      <span style={{ color: 'var(--error-solid)' }}>
+      </div>
+      <div
+        style={
+          {
+            '--chip-fg': 'var(--error-text)',
+            '--chip-border': 'var(--error-border)',
+          } as React.CSSProperties
+        }
+      >
         <Chip variant="outline" className={TAG_CLASS}>error</Chip>
-      </span>
-    </div>
-  ),
-};
-
-export const Filled: Story = {
-  render: () => (
-    <div className="flex gap-2 items-center">
-      <span style={{ color: 'var(--info-solid)' }}>
-        <Chip variant="filled">info</Chip>
-      </span>
-      <span style={{ color: 'var(--success-solid)' }}>
-        <Chip variant="filled">success</Chip>
-      </span>
+      </div>
     </div>
   ),
 };
 
 export const ThemeScopeOverride: Story = {
-  name: 'Theme-scope override',
+  name: 'Theme-scope override — full chip palette',
   parameters: {
     docs: {
       description: {
         story:
-          'A container can override the chip tokens locally — useful for themed surfaces where the chip should follow the local palette rather than the app theme.',
+          'The canonical way to tint chips: a container overrides `--chip-bg`, `--chip-fg`, and `--chip-border` so every chip inside adopts the local palette. Used by themed surfaces (Console, dark panels, etc.) to re-skin pills without touching the component.',
       },
     },
   },

--- a/libs/ratio-ui/src/core/Chip/Chip.tsx
+++ b/libs/ratio-ui/src/core/Chip/Chip.tsx
@@ -21,6 +21,21 @@ import { cn } from '../../utils/cn';
  *   themed container, or kicker labels that should look "embedded" in their
  *   surrounding surface.
  *
+ * ## Variants
+ *
+ * Both variants read from the same `--chip-*` tokens — the only difference
+ * is whether the background is filled (`subtle`) or transparent (`outline`).
+ * Override tokens on a wrapper to tint chips semantically:
+ *
+ * ```tsx
+ * <div style={{
+ *   '--chip-fg': 'var(--info-text)',
+ *   '--chip-border': 'var(--info-border)',
+ * } as React.CSSProperties}>
+ *   <Chip variant="outline">info</Chip>
+ * </div>
+ * ```
+ *
  * ## Composition
  *
  * Chip is a flex row with `gap-1.5`, so any children render side-by-side.
@@ -28,45 +43,35 @@ import { cn } from '../../utils/cn';
  * icon, text, or other element before/after the label.
  *
  * Typography (mono, uppercase, etc.) is intentionally not on Chip — apply
- * it via `className` or wrap the text in a typography primitive. This keeps
- * Chip focused on the chip shape itself.
+ * it via `className` or wrap the text in a typography primitive.
  *
  * ```tsx
- * <Chip>v2.4</Chip>
+ * <Chip>v2.4</Chip>                              // default
+ * <Chip variant="outline">draft</Chip>           // just a border
+ * <Chip><Chip.Dot/> active</Chip>                // with leading dot
  *
- * // Tag style — typography via className
- * <Chip className="font-mono uppercase tracking-widest font-bold px-2 py-0.5">
- *   prod
- * </Chip>
- *
- * // Leading dot
- * <Chip>
- *   <Chip.Dot />
- *   active
- * </Chip>
- *
- * // Themed scope — overrides cascade in
- * <section style={{ '--chip-bg': '#0a0d09', '--chip-fg': '#b8f2c8' }}>
+ * // Themed scope — custom-property casts via React.CSSProperties so TS
+ * // accepts the `--chip-*` keys (CSSProperties doesn't type custom props).
+ * <section style={{ '--chip-bg': '#0a0d09' } as React.CSSProperties}>
  *   <Chip>prod</Chip>
  * </section>
  *
  * // Sharp corners
- * <div style={{ '--chip-radius': '0' }}>
+ * <div style={{ '--chip-radius': '0' } as React.CSSProperties}>
  *   <Chip>v2.4</Chip>
  * </div>
  * ```
  *
  * @beta This component is experimental — prop shape may change before release.
  */
-export type ChipVariant = 'subtle' | 'outline' | 'filled';
+export type ChipVariant = 'subtle' | 'outline';
 
 export interface ChipProps extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'children'> {
   children: React.ReactNode;
   /**
    * Visual treatment.
-   * - `'subtle'` (default) — tinted background, border, muted text via chip tokens
-   * - `'outline'` — transparent-ish background + border derived from `currentColor`
-   * - `'filled'` — solid `currentColor` background
+   * - `'subtle'` (default) — `--chip-bg` background + border + text
+   * - `'outline'` — transparent background, `--chip-border` outline + `--chip-fg` text
    */
   variant?: ChipVariant;
 }
@@ -85,12 +90,10 @@ const ChipRoot: React.FC<ChipProps> = ({
       'text-xs font-medium leading-none',
       // Themable surface (overridable by any ancestor scope)
       'rounded-[var(--chip-radius,9999px)]',
-      'bg-(--chip-bg) text-(--chip-fg) border border-(--chip-border)',
-      // Variant treatments — outline + filled tint from `currentColor`.
-      // Outline uses --alpha-2 (10%) for the background wash — pulled from
-      // the shared alpha scale rather than a magic number.
-      variant === 'outline' && 'bg-current/(--alpha-2) border-current',
-      variant === 'filled' && 'bg-current text-(--chip-on-solid) border-transparent',
+      'text-(--chip-fg) border border-(--chip-border)',
+      // Subtle has a filled background; outline is transparent
+      variant === 'subtle' && 'bg-(--chip-bg)',
+      variant === 'outline' && 'bg-transparent',
       className,
     )}
   >


### PR DESCRIPTION
## Summary

Chip's `outline` and `filled` variants from #1477 had a `currentColor` bug:

- `Chip` base sets `text-(--chip-fg)` (overrides `color` to the chip's own text token)
- `filled`/`outline` then used `bg-current` to inherit the parent's color for tinting
- But `currentColor` resolves to the chip's *own* `color` — not the parent's — so `bg-current` ended up as the same color as the text

Result: `filled` chips rendered white-on-white (invisible label). `outline` chips were gray-tinted instead of color-tinted.

## Fix

Two token-driven variants, no `currentColor` magic:

- `subtle` (default) — `--chip-bg` background + `--chip-border` outline + `--chip-fg` text
- `outline` — transparent background, `--chip-border` outline + `--chip-fg` text

To tint per status, wrap in a container that overrides the chip tokens:

```tsx
<div style={{
  '--chip-fg': 'var(--info-text)',
  '--chip-border': 'var(--info-border)',
}}>
  <Chip variant="outline">info</Chip>
</div>
```

`filled` is removed — consumers wanting a solid-color chip override `--chip-bg` directly. This is consistent with our "one way to tint chips" model.

## Visual changes

- `Filled` story removed
- `Outline` story rewritten to demonstrate per-status tinting via wrapper token overrides
- `ThemeScopeOverride` story unchanged (was already the canonical pattern, now even more central)

## Test plan
- [ ] Storybook: Outline story shows visibly tinted info/success/warn/error chips
- [ ] Storybook: ThemeScopeOverride still renders correctly on dark wrapper
- [ ] No remaining `bg-current`-based stories appear washed out

🤖 Generated with [Claude Code](https://claude.com/claude-code)