### PR TITLE
feat(ratio-ui): add ActionButton — compact chrome button

### DIFF
--- a/.changeset/ratio-ui-action-button.md
+++ b/.changeset/ratio-ui-action-button.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Add `<ActionButton>` at `@eventuras/ratio-ui/core/ActionButton` — a compact chrome button for toolbars, close affordances, table-row actions, and other dense surfaces. Sibling to `Button` for cases where a labelled `Button` would be too loud. Composes via `children` so the same component covers icon-only, icon + text, and text-only buttons; `ariaLabel` is the screen-reader name for icon-only usage. Variants `subtle` and `solid` on top of a transparent bordered default. Colors and radius come from CSS tokens (`--action-button-bg/-fg/-border/-radius`, hover variants) so themed containers can re-skin locally without forking. Tokens live in `tokens/action-button.css`.

--- a/libs/ratio-ui/src/core/ActionButton/ActionButton.stories.tsx
+++ b/libs/ratio-ui/src/core/ActionButton/ActionButton.stories.tsx
@@ -1,0 +1,163 @@
+import type * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ActionButton } from './ActionButton';
+import { Text } from '../Text';
+
+const meta: Meta<typeof ActionButton> = {
+  title: 'Core/ActionButton (beta)',
+  component: ActionButton,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Compact chrome button for toolbars, close affordances, table-row actions, and other dense surfaces. Composes children freely — works for icon-only, icon + text, or text-only. `ariaLabel` is required when there is no visible text.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionButton>;
+
+// Minimal inline icons so stories don't depend on an icon pack
+// Decorative icons — aria-hidden + focusable="false" so AT only announces
+// the button's accessible name (text label or ariaLabel), not the icon.
+const X = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+       aria-hidden="true" focusable="false">
+    <path d="M6 6l12 12M18 6 6 18"/>
+  </svg>
+);
+const Pause = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"
+       aria-hidden="true" focusable="false">
+    <rect x="7" y="5" width="3" height="14" rx="0.5"/>
+    <rect x="14" y="5" width="3" height="14" rx="0.5"/>
+  </svg>
+);
+const Download = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+       strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"
+       aria-hidden="true" focusable="false">
+    <path d="M12 4v12"/><path d="m7 11 5 5 5-5"/><path d="M5 20h14"/>
+  </svg>
+);
+
+export const IconOnly: Story = {
+  name: 'Icon-only — ariaLabel required',
+  render: () => <ActionButton ariaLabel="Close"><X /></ActionButton>,
+};
+
+export const IconAndText: Story = {
+  name: 'Icon + text — bare string child',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A bare string child inherits the button\'s font styling — no `<Text>` wrapper needed for the common case.',
+      },
+    },
+  },
+  render: () => (
+    <ActionButton>
+      <Pause />
+      Pause
+    </ActionButton>
+  ),
+};
+
+export const IconAndTextComponent: Story = {
+  name: 'Icon + <Text> — typography control',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When you want explicit typography control (size, weight, variant), compose with `<Text as="span">`. The `as="span"` keeps the layout inline; the default `<p>` would be semantically wrong inside a button.',
+      },
+    },
+  },
+  render: () => (
+    <ActionButton>
+      <Pause />
+      <Text as="span" weight="medium">Pause</Text>
+    </ActionButton>
+  ),
+};
+
+export const TextOnly: Story = {
+  render: () => <ActionButton>Publish</ActionButton>,
+};
+
+export const Subtle: Story = {
+  render: () => (
+    <ActionButton variant="subtle">
+      <Pause />
+      Pause
+    </ActionButton>
+  ),
+};
+
+export const Solid: Story = {
+  render: () => (
+    <ActionButton variant="solid">
+      <Download />
+      Download
+    </ActionButton>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <ActionButton ariaLabel="Pause" size="sm"><Pause /></ActionButton>
+      <ActionButton ariaLabel="Pause" size="md"><Pause /></ActionButton>
+      <ActionButton ariaLabel="Pause" size="lg"><Pause /></ActionButton>
+    </div>
+  ),
+};
+
+export const Toolbar: Story = {
+  name: 'Toolbar — mixed variants and contents',
+  render: () => (
+    <div className="flex gap-1 items-center">
+      <ActionButton ariaLabel="Pause"><Pause /></ActionButton>
+      <ActionButton ariaLabel="Download log"><Download /></ActionButton>
+      <ActionButton ariaLabel="Close panel"><X /></ActionButton>
+      <ActionButton variant="solid">
+        <Download />
+        Export
+      </ActionButton>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => <ActionButton ariaLabel="Pause" disabled><Pause /></ActionButton>,
+};
+
+export const SquareCorners: Story = {
+  name: 'Re-skinned via --action-button-radius',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Override `--action-button-radius` on a container to flip all action buttons inside to sharp corners — useful for retro / brutalist sub-experiences.',
+      },
+    },
+  },
+  render: () => (
+    <div
+      style={{ '--action-button-radius': '0' } as React.CSSProperties}
+      className="flex gap-2"
+    >
+      <ActionButton ariaLabel="Pause"><Pause /></ActionButton>
+      <ActionButton variant="subtle">
+        <Pause />
+        Pause
+      </ActionButton>
+    </div>
+  ),
+};

--- a/libs/ratio-ui/src/core/ActionButton/ActionButton.tsx
+++ b/libs/ratio-ui/src/core/ActionButton/ActionButton.tsx
@@ -1,0 +1,132 @@
+import React, { forwardRef } from 'react';
+import { cn } from '../../utils/cn';
+
+/**
+ * A compact chrome button for toolbars, close affordances, table-row
+ * actions, and other dense surfaces. Sibling to `Button` — use
+ * `ActionButton` when a labelled `Button` would be too loud.
+ *
+ * Composes via `children` — works for icon-only, icon + text, or
+ * text-only buttons:
+ *
+ * ```tsx
+ * <ActionButton ariaLabel="Close" onClick={onClose}>
+ *   <XIcon />
+ * </ActionButton>
+ *
+ * <ActionButton onClick={onPause}>
+ *   <PauseIcon />
+ *   Pause
+ * </ActionButton>
+ *
+ * <ActionButton onClick={onPublish} variant="solid">
+ *   Publish
+ * </ActionButton>
+ * ```
+ *
+ * Colors and radius come from CSS tokens (`--action-button-bg`,
+ * `--action-button-fg`, `--action-button-border`,
+ * `--action-button-radius`, hover variants), so themed containers
+ * (e.g. `Console`) can re-skin locally without forking.
+ *
+ * ## Accessibility
+ *
+ * If the button has no visible text (icon-only), pass `ariaLabel` so
+ * screen readers can announce its purpose. The label is the only way
+ * an icon-only button is identifiable — without it the button has no
+ * accessible name and AT-users can't tell what it does. Linters and
+ * AT will flag the omission; we don't enforce at the type level since
+ * TypeScript can't inspect `children` for textual content.
+ *
+ * @beta This component is experimental — prop shape may change before release.
+ */
+export type ActionButtonVariant = 'subtle' | 'solid';
+export type ActionButtonSize = 'sm' | 'md' | 'lg';
+
+export interface ActionButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
+  /**
+   * Required when there is no visible text inside (e.g. icon-only). Read by
+   * screen readers as the button's accessible name. Optional when `children`
+   * contains a text label.
+   */
+  ariaLabel?: string;
+  /**
+   * Visual treatment. Default (no variant) is a transparent, bordered chrome
+   * button that hovers in — quiet enough for dense toolbars.
+   *
+   * - `'subtle'` — bg-card baseline, more chrome, for standalone actions
+   * - `'solid'` — primary-tinted, for the one prominent action per toolbar
+   */
+  variant?: ActionButtonVariant;
+  /** Frame height — sm (24) / md (28, default) / lg (36). Width auto-fits content. */
+  size?: ActionButtonSize;
+  className?: string;
+  testId?: string;
+}
+
+const SIZE_CLASSES: Record<ActionButtonSize, string> = {
+  sm: 'h-6 min-w-6 px-2.5',
+  md: 'h-7 min-w-7 px-3',
+  lg: 'h-9 min-w-9 px-4',
+};
+
+const SUBTLE_VARIANT =
+  '[--action-button-bg:var(--card)] [--action-button-bg-hover:var(--card-hover)]';
+
+const SOLID_VARIANT = [
+  '[--action-button-bg:var(--primary)]',
+  '[--action-button-fg:var(--text-on-primary)]',
+  '[--action-button-border:transparent]',
+  '[--action-button-bg-hover:color-mix(in_oklch,var(--primary)_92%,black)]',
+  '[--action-button-fg-hover:var(--text-on-primary)]',
+].join(' ');
+
+export const ActionButton = forwardRef<HTMLButtonElement, ActionButtonProps>(function ActionButton(
+  {
+    ariaLabel,
+    variant,
+    size = 'md',
+    children,
+    className,
+    type = 'button',
+    testId,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      aria-label={ariaLabel}
+      className={cn(
+        // Layout + typography
+        'inline-flex items-center justify-center gap-1.5 shrink-0',
+        'text-sm leading-none whitespace-nowrap cursor-pointer',
+        // Themable surface (overridable by any ancestor scope)
+        'rounded-[var(--action-button-radius,6px)]',
+        'bg-(--action-button-bg) text-(--action-button-fg) border border-(--action-button-border)',
+        // Interactions
+        'transition-colors duration-150 ease-out',
+        'enabled:hover:bg-(--action-button-bg-hover) enabled:hover:text-(--action-button-fg-hover)',
+        'enabled:active:scale-95',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-(--focus-ring)',
+        'disabled:opacity-40 disabled:cursor-not-allowed',
+        // Sizes — height fixed; horizontal padding auto-strips when the
+        // button only contains a single svg (icon-only stays square).
+        SIZE_CLASSES[size],
+        'has-[>svg:only-child]:px-0',
+        // Variants (default = no class = transparent + bordered)
+        variant === 'subtle' && SUBTLE_VARIANT,
+        variant === 'solid' && SOLID_VARIANT,
+        className,
+      )}
+      data-testid={testId}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+});
+ActionButton.displayName = 'ActionButton';

--- a/libs/ratio-ui/src/core/ActionButton/index.ts
+++ b/libs/ratio-ui/src/core/ActionButton/index.ts
@@ -1,0 +1,2 @@
+export { ActionButton } from './ActionButton';
+export type { ActionButtonProps, ActionButtonVariant, ActionButtonSize } from './ActionButton';

--- a/libs/ratio-ui/src/tokens/action-button.css
+++ b/libs/ratio-ui/src/tokens/action-button.css
@@ -1,0 +1,22 @@
+/*
+ * ActionButton tokens — defaults consumed by `core/ActionButton` and
+ * anywhere it's composed. Overridable per-scope (any ancestor can set
+ * `--action-button-bg` etc. to re-skin the button inside its subtree
+ * without forking the component).
+ *
+ * Default radius is `6px`. Flip `--action-button-radius` on a container
+ * to round or square all action buttons inside that scope.
+ */
+
+:root {
+  --action-button-bg:        transparent;
+  --action-button-fg:        var(--text-muted);
+  --action-button-border:    var(--border-1);
+  --action-button-bg-hover:  var(--card-hover);
+  --action-button-fg-hover:  var(--text);
+  --action-button-radius:    6px;
+}
+
+/* No dark-mode override block needed — every value resolves through a
+   semantic token (--text-muted, --border-1, --card-hover, --text) that
+   already switches with the page theme. */

--- a/libs/ratio-ui/src/tokens/index.css
+++ b/libs/ratio-ui/src/tokens/index.css
@@ -4,3 +4,4 @@
 @import "./spacing.css";
 @import "./border.css";
 @import "./chip.css";
+@import "./action-button.css";


### PR DESCRIPTION
## Summary

Adds `<ActionButton>` at `@eventuras/ratio-ui/core/ActionButton` — a compact chrome button for toolbars, close affordances, table-row actions, and other dense surfaces. Sibling to `Button`; use `ActionButton` when a labelled `Button` would be too loud.

## API

Composes via `children` — same component covers icon-only, icon + text, and text-only patterns:

```tsx
// Icon-only (ariaLabel for the screen-reader name)
<ActionButton ariaLabel="Close"><XIcon /></ActionButton>

// Icon + text (bare string inherits button typography)
<ActionButton onClick={onPause}>
  <PauseIcon />
  Pause
</ActionButton>

// Icon + <Text> when you want typography control
<ActionButton onClick={onPause}>
  <PauseIcon />
  <Text as="span" weight="medium">Pause</Text>
</ActionButton>

// Text-only
<ActionButton onClick={onPublish} variant="solid">Publish</ActionButton>
```

Variants on top of a transparent bordered default:
- `subtle` — bg-card chrome for standalone actions
- `solid` — primary-tinted for the one prominent action per toolbar

Sizes `sm` (24) / `md` (28, default) / `lg` (36) — height fixed, width auto-fits content. Icon-only buttons stay square via `has-[>svg:only-child]:px-0`.

## Design tokens

New `tokens/action-button.css` with light + dark defaults — same pattern as `tokens/chip.css`:

```
--action-button-bg          : transparent
--action-button-fg          : var(--text-muted)
--action-button-border      : var(--border-1)
--action-button-bg-hover    : var(--card-hover)
--action-button-fg-hover    : var(--text)
--action-button-radius      : 6px        (flip on any scope)
```

Themed containers (e.g. Console retro mode) can override the radius locally to flip all action buttons to sharp corners.

## Naming rationale

"ActionButton" not "IconButton" — borrowed from React Spectrum. The component is no longer icon-only, so a name that describes the role (action) rather than the assumed content (icon) reads honestly across all three usage patterns.

## Accessibility

`ariaLabel` is required when there's no visible text inside (icon-only). Documented in the JSDoc and demonstrated in stories; not enforced at the type level because TypeScript can't inspect `children` for textual content. Linters and AT flag missing accessible names.

## Test plan
- [ ] `pnpm --filter @eventuras/ratio-ui build` clean
- [ ] Storybook: IconOnly, IconAndText, IconAndTextComponent, TextOnly, variants, sizes, Toolbar, SquareCorners
- [ ] No leftover `IconButton` references in repo

## Follow-up PRs (separately staged, not in this one)

- `LiveIndicator` (composes Chip with pulse)
- `Console` (uses Chip + LiveIndicator + ActionButton; final piece of the stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)