### PR TITLE
chore(ratio-ui): drop forced 100vh on Storybook story wrapper

### DIFF
--- a/libs/ratio-ui/.storybook/modeDecorator.tsx
+++ b/libs/ratio-ui/.storybook/modeDecorator.tsx
@@ -37,7 +37,6 @@ export const ModeDecorator = (Story: any, context: any) => {
         data-theme={isDarkMode ? 'dark' : 'light'}
         style={{
           minWidth: '100%',
-          minHeight: '100vh',
           backgroundColor: 'var(--surface)',
           color: 'var(--text)',
           padding: noPadding ? '0' : '2rem',


### PR DESCRIPTION
## Summary

The Storybook `ModeDecorator` set `minHeight: 100vh` on its wrapper to keep the themed body background visible — but the cost was that every single story (a 30px chip, a 28px button) took the full viewport height, making the preview pane scroll forever in the docs view.

Drops just `minHeight: 100vh`. The wrapper still sets:
- `data-theme` attribute (so theming cascades)
- `backgroundColor: var(--surface)` (so theme background is still visible)
- Padding via the existing `noPadding` parameter

Stories that genuinely want a tall page-shell can render their own `min-h-screen` wrapper inside (e.g. Console stories already use `h-[700px]` wrappers).

## Test plan
- [ ] `pnpm storybook` — verify small components (Chip, Badge, Button) no longer dominate the preview pane
- [ ] Stories that pre-size themselves (Console, Strip) render unchanged
- [ ] Theming still applies (light/dark toggle still works, body color matches the variant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)