### PR TITLE
feat(ratio-ui): add LiveIndicator + Chip.Dot pulse

### DIFF
--- a/.changeset/ratio-ui-live-indicator.md
+++ b/.changeset/ratio-ui-live-indicator.md
@@ -1,0 +1,7 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Add `<LiveIndicator>` at `@eventuras/ratio-ui/core/LiveIndicator` — a pulsing dot + status label. Use for connection status (WebSocket, SignalR, SSE), recording UI, polling monitors, or any "is this happening right now?" affordance. `children` is required so consumers always wire their own (typically translated) label; no English defaults that might leak through missed i18n. Dot color reads from `--live-indicator-dot` (defaults to `--success-solid`); chip chrome is set locally so the page's `--chip-*` defaults stay untouched. Re-skin per status (amber "reconnecting", red "error") via wrapper token overrides. Respects `prefers-reduced-motion`.
+
+Also extends `Chip.Dot` with a `pulse` prop so the expanding-ring animation is available to any chip composition — `LiveIndicator` is now a thin wrapper around `<Chip><Chip.Dot pulse/>…</Chip>`. The keyframe lives in a small `Chip.css` and uses `currentColor`, so the pulse follows whatever color the dot inherits.

--- a/libs/ratio-ui/src/core/Chip/Chip.css
+++ b/libs/ratio-ui/src/core/Chip/Chip.css
@@ -1,0 +1,20 @@
+/*
+ * Chip — only the dot's pulse keyframe lives here. Everything else
+ * (chip surface, layout, variants, dot base styling) is expressed via
+ * Tailwind utilities in Chip.tsx.
+ *
+ * The pulse animates from opaque `currentColor` to fully transparent
+ * while expanding the box-shadow spread. We avoid `color-mix(...,
+ * currentColor, ...)` because some browsers don't resolve `currentColor`
+ * reliably inside `color-mix()` — animating the shadow color itself
+ * from `currentColor` to `transparent` is well-supported everywhere.
+ *
+ * Opt in with `<Chip.Dot pulse />`. Respects `prefers-reduced-motion`
+ * via Tailwind's `motion-reduce:` variant on the consuming class.
+ */
+
+@keyframes chip-dot-pulse {
+  0%   { box-shadow: 0 0 0 0   currentColor; }
+  70%  { box-shadow: 0 0 0 5px transparent;  }
+  100% { box-shadow: 0 0 0 0   transparent;  }
+}

--- a/libs/ratio-ui/src/core/Chip/Chip.stories.tsx
+++ b/libs/ratio-ui/src/core/Chip/Chip.stories.tsx
@@ -75,6 +75,34 @@ export const WithDot: Story = {
   ),
 };
 
+export const PulsingDot: Story = {
+  name: 'Composing — Chip.Dot pulse',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass `pulse` to `<Chip.Dot/>` for an expanding-ring animation in `currentColor`. Used by `LiveIndicator`, but available for any "something is happening here" composition. Respects `prefers-reduced-motion`.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex gap-3 items-center">
+      <span style={{ color: 'var(--success-solid)' }}>
+        <Chip>
+          <Chip.Dot pulse />
+          recording
+        </Chip>
+      </span>
+      <span style={{ color: 'var(--warning-solid)' }}>
+        <Chip>
+          <Chip.Dot pulse />
+          reconnecting
+        </Chip>
+      </span>
+    </div>
+  ),
+};
+
 export const Outline: Story = {
   name: 'Outline — transparent + border',
   parameters: {

--- a/libs/ratio-ui/src/core/Chip/Chip.tsx
+++ b/libs/ratio-ui/src/core/Chip/Chip.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { cn } from '../../utils/cn';
+import './Chip.css';
 
 /**
  * Theme-scope-aware tag primitive — a small chip whose colors and radius
@@ -102,14 +103,29 @@ const ChipRoot: React.FC<ChipProps> = ({
 );
 ChipRoot.displayName = 'Chip';
 
+interface DotProps {
+  /**
+   * When true, the dot animates an expanding-ring pulse in its current
+   * color. Used by `LiveIndicator` for live-status pills, but available
+   * to any chip composition (e.g. a recording indicator). Respects
+   * `prefers-reduced-motion`.
+   */
+  pulse?: boolean;
+  className?: string;
+}
+
 /**
  * Small leading/trailing dot in `currentColor`. Compose inside `<Chip>`
- * before or after the label.
+ * before or after the label. Opt-in to a pulsing animation via `pulse`.
  */
-const Dot: React.FC<{ className?: string }> = ({ className }) => (
+const Dot: React.FC<DotProps> = ({ pulse, className }) => (
   <span
     aria-hidden="true"
-    className={cn('size-2 rounded-full bg-current opacity-70 shrink-0', className)}
+    className={cn(
+      'size-2 rounded-full bg-current opacity-70 shrink-0',
+      pulse && 'animate-[chip-dot-pulse_3s_ease-out_infinite] motion-reduce:animate-none',
+      className,
+    )}
   />
 );
 Dot.displayName = 'Chip.Dot';

--- a/libs/ratio-ui/src/core/LiveIndicator/LiveIndicator.stories.tsx
+++ b/libs/ratio-ui/src/core/LiveIndicator/LiveIndicator.stories.tsx
@@ -1,0 +1,89 @@
+import type * as React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LiveIndicator } from './LiveIndicator';
+
+const meta: Meta<typeof LiveIndicator> = {
+  title: 'Core/LiveIndicator (beta)',
+  component: LiveIndicator,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Pulsing dot + status label. A thin wrapper around `<Chip><Chip.Dot pulse/>…</Chip>` with a green success-tinted palette. `children` is required so the consumer always wires their own (typically translated) label — no English defaults that might leak through missed i18n.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LiveIndicator>;
+
+export const Live: Story = {
+  render: () => <LiveIndicator status="live">Live</LiveIndicator>,
+};
+
+export const Paused: Story = {
+  render: () => <LiveIndicator status="paused">Paused</LiveIndicator>,
+};
+
+export const I18nPattern: Story = {
+  name: 'i18n — translated labels per state',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Pass already-translated labels via `children`. Typical pattern: a translation key per state, computed from the same flag that drives `status`.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <LiveIndicator status="live">Tilkoblet</LiveIndicator>
+      <LiveIndicator status="paused">Frakoblet</LiveIndicator>
+    </div>
+  ),
+};
+
+export const Reskinned: Story = {
+  name: 'Re-skinned via token override',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A container can re-skin both the pulse color (`--live-indicator-dot`) and the chip chrome (`--chip-bg`, `--chip-fg`, `--chip-border`) without touching the component. Useful for amber "reconnecting" or red "error" states.',
+      },
+    },
+  },
+  render: () => (
+    <div className="flex gap-2 items-center">
+      <LiveIndicator>Connected</LiveIndicator>
+
+      <div
+        style={
+          {
+            '--live-indicator-dot': 'var(--warning-solid)',
+            '--chip-bg': 'var(--warning-bg)',
+            '--chip-fg': 'var(--warning-text)',
+            '--chip-border': 'var(--warning-border)',
+          } as React.CSSProperties
+        }
+      >
+        <LiveIndicator>Reconnecting</LiveIndicator>
+      </div>
+
+      <div
+        style={
+          {
+            '--live-indicator-dot': 'var(--error-solid)',
+            '--chip-bg': 'var(--error-bg)',
+            '--chip-fg': 'var(--error-text)',
+            '--chip-border': 'var(--error-border)',
+          } as React.CSSProperties
+        }
+      >
+        <LiveIndicator status="paused">Error</LiveIndicator>
+      </div>
+    </div>
+  ),
+};

--- a/libs/ratio-ui/src/core/LiveIndicator/LiveIndicator.tsx
+++ b/libs/ratio-ui/src/core/LiveIndicator/LiveIndicator.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { cn } from '../../utils/cn';
+import { Chip } from '../Chip';
+
+/**
+ * Pulsing dot + status label. A thin convenience wrapper around
+ * `<Chip><Chip.Dot pulse/>…</Chip>` that ships a green success-tinted
+ * palette and toggles the pulse based on `status`.
+ *
+ * Use for connection status (WebSocket, SignalR, SSE), recording / streaming
+ * UI, polling monitors, or any "is this happening right now?" affordance.
+ *
+ * - Dot color reads from `--live-indicator-dot` (defaults to `--success-solid`)
+ * - Chip chrome is set locally on the indicator so the surrounding page's
+ *   chip tokens aren't polluted
+ * - `children` is required so the consumer always wires their own (typically
+ *   translated) label — no English defaults that might leak through
+ *
+ * For other status colors (amber "reconnecting", red "error"), wrap in a
+ * container that overrides `--chip-bg/-fg/-border` + `--live-indicator-dot`
+ * with the desired semantic palette. For the full power-user case (custom
+ * dot color per chip, non-pulsing dots, etc.), compose `<Chip>` and
+ * `<Chip.Dot pulse/>` directly.
+ *
+ * Respects `prefers-reduced-motion` — the pulse animation stops when the
+ * user has requested reduced motion.
+ *
+ * @beta This component is experimental — prop shape may change before release.
+ *
+ * @example
+ * ```tsx
+ * // Consumer wires its own (typically translated) label per state.
+ * <LiveIndicator status={connected ? 'live' : 'paused'}>
+ *   {connected ? 'Connected' : 'Disconnected'}
+ * </LiveIndicator>
+ *
+ * // Re-skin via local CSS-var override (e.g. amber for "reconnecting").
+ * // Cast via React.CSSProperties so TS accepts the custom-property keys.
+ * <div style={{
+ *   '--live-indicator-dot': 'var(--warning-solid)',
+ *   '--chip-fg': 'var(--warning-text)',
+ *   '--chip-border': 'var(--warning-border)',
+ * } as React.CSSProperties}>
+ *   <LiveIndicator>Reconnecting</LiveIndicator>
+ * </div>
+ * ```
+ */
+export type LiveIndicatorStatus = 'live' | 'paused';
+
+export interface LiveIndicatorProps {
+  /** Defaults to `'live'`. Set `'paused'` to dim the dot and stop the pulse. */
+  status?: LiveIndicatorStatus;
+  /**
+   * Visible label. Required — pass your already-translated text so we don't
+   * ship hardcoded English defaults that might leak through missed i18n.
+   */
+  children: React.ReactNode;
+  className?: string;
+}
+
+// Chip-token overrides — reuse the semantic success palette so the
+// indicator stays in sync with future token tweaks and switches with
+// the page theme automatically. Set locally on the indicator so we
+// don't pollute the page's --chip-* defaults for other chips.
+const CHIP_OVERRIDES = [
+  '[--chip-bg:var(--success-bg)]',
+  '[--chip-fg:var(--success-text)]',
+  '[--chip-border:var(--success-border)]',
+].join(' ');
+
+export const LiveIndicator: React.FC<LiveIndicatorProps> = ({
+  status = 'live',
+  children,
+  className,
+}) => {
+  const paused = status === 'paused';
+  return (
+    <Chip
+      className={cn(
+        CHIP_OVERRIDES,
+        'font-mono text-[11px] font-bold uppercase tracking-[0.14em] px-2.5 py-1',
+        paused && '[--chip-fg:var(--text-subtle)]',
+        className,
+      )}
+      role="status"
+    >
+      <Chip.Dot
+        pulse={!paused}
+        className={paused ? 'text-(--text-subtle)' : 'text-(--live-indicator-dot)'}
+      />
+      <span>{children}</span>
+    </Chip>
+  );
+};
+LiveIndicator.displayName = 'LiveIndicator';

--- a/libs/ratio-ui/src/core/LiveIndicator/index.ts
+++ b/libs/ratio-ui/src/core/LiveIndicator/index.ts
@@ -1,0 +1,2 @@
+export { LiveIndicator } from './LiveIndicator';
+export type { LiveIndicatorProps, LiveIndicatorStatus } from './LiveIndicator';

--- a/libs/ratio-ui/src/tokens/index.css
+++ b/libs/ratio-ui/src/tokens/index.css
@@ -5,3 +5,4 @@
 @import "./border.css";
 @import "./chip.css";
 @import "./action-button.css";
+@import "./live-indicator.css";

--- a/libs/ratio-ui/src/tokens/live-indicator.css
+++ b/libs/ratio-ui/src/tokens/live-indicator.css
@@ -1,0 +1,12 @@
+/*
+ * LiveIndicator tokens — only the dot color lives here. The chip chrome
+ * (bg/fg/border) is set locally on `.live-indicator` so we don't pollute
+ * the global `--chip-*` defaults for every chip on the page.
+ *
+ * Override `--live-indicator-dot` on a wrapper to switch the pulse color
+ * (e.g. amber for "reconnecting", red for "error" states).
+ */
+
+:root {
+  --live-indicator-dot: var(--success-solid);
+}


### PR DESCRIPTION
## Summary

Adds `<LiveIndicator>` at `@eventuras/ratio-ui/core/LiveIndicator` and extends `Chip.Dot` with a `pulse` prop. LiveIndicator is a thin wrapper around `<Chip><Chip.Dot pulse/>…</Chip>` that ships a green success-tinted palette.

## API

```tsx
// Consumer wires its own (typically translated) label per state.
<LiveIndicator status={connected ? 'live' : 'paused'}>
  {connected ? 'Connected' : 'Disconnected'}
</LiveIndicator>

// Re-skin via local CSS-var override (amber "reconnecting", red "error")
<div style={{
  '--live-indicator-dot': 'var(--warning-solid)',
  '--chip-bg': 'var(--warning-bg)',
  '--chip-fg': 'var(--warning-text)',
  '--chip-border': 'var(--warning-border)',
} as React.CSSProperties}>
  <LiveIndicator>Reconnecting</LiveIndicator>
</div>
```

`children` is required — no English defaults that might leak through missed i18n.

## Chip.Dot pulse

The expanding-ring animation is now a generic `Chip.Dot` capability, available to any chip composition:

```tsx
<Chip><Chip.Dot pulse />recording</Chip>
```

The pulse uses `currentColor` for the ring, so it follows whatever color the dot inherits. LiveIndicator is just a convenience preset on top of this primitive.

## Implementation notes

- **`color-mix(in oklch, currentColor, ...)`** and **`rgb(from currentColor r g b / α)`** both broke in testing — browsers don't reliably resolve `currentColor` inside color functions. The keyframe instead uses plain `currentColor` going to `transparent`, which is universally supported. The shadow spread is 5px (small enough not to be visually loud) and duration is 3s (relaxed "I'm alive" cadence).
- **`prefers-reduced-motion`** is respected via `motion-reduce:animate-none` on the pulse class.
- **Tokens** live in `tokens/live-indicator.css` (`--live-indicator-dot`).

## Test plan
- [ ] `pnpm --filter @eventuras/ratio-ui build` clean
- [ ] Storybook: Live + Paused + I18nPattern + Reskinned stories render with pulse working in light + dark
- [ ] Storybook: Chip's new PulsingDot story renders a green pulse + amber pulse using parent `color`
- [ ] DevTools → emulate `prefers-reduced-motion: reduce` → pulse stops, dot stays

## Follow-up

- Console PR (final piece — uses Chip, LiveIndicator, ActionButton)

🤖 Generated with [Claude Code](https://claude.com/claude-code)