### PR TITLE
feat(ratio-ui): add Console for streaming logs and event feeds

### DIFF
--- a/.changeset/ratio-ui-console.md
+++ b/.changeset/ratio-ui-console.md
@@ -1,0 +1,11 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+Add `<Console>` at `@eventuras/ratio-ui/console` — a themable presentational log/event console (light / dark / retro CRT) with sticky title bar, severity-tagged rows, sticky time-bucket groups, controlled inline expand for detail payloads, and container-query responsiveness that collapses columns based on the console's own width.
+
+Final piece of the chip/button/indicator stack: composes `Chip` for the env tag and severity badge, `LiveIndicator` for the live-tail status, and `ActionButton` for chrome buttons. Themed containers re-skin those primitives via local CSS-variable overrides — no per-theme rules per primitive.
+
+Pure presentation: consumers own data, expansion, pause/play, filter selections, and scroll. Use for streaming logs, business-event feeds, audit trails, liveblogs. Lives as its own top-level folder (like `toast/`) to give room for upcoming logic helpers (auto-scroll, stream adapters, filter utilities) without crowding `core/`.
+
+Also adds `tokens/retro.css` with the shared retro palette (used by `Console`'s `--theme-retro`, available to any future component wanting the CRT aesthetic) and `--debug-*` status tokens.

--- a/libs/ratio-ui/package.json
+++ b/libs/ratio-ui/package.json
@@ -60,6 +60,10 @@
       "types": "./dist/toast/index.d.ts",
       "import": "./dist/toast/index.js"
     },
+    "./console": {
+      "types": "./dist/console/index.d.ts",
+      "import": "./dist/console/index.js"
+    },
     "./tokens": {
       "types": "./dist/tokens/index.d.ts",
       "import": "./dist/tokens/index.js"

--- a/libs/ratio-ui/src/console/Console.css
+++ b/libs/ratio-ui/src/console/Console.css
@@ -1,0 +1,434 @@
+/*
+ * Console — themable terminal-style log/timeline component.
+ *
+ * Three themes via root class:
+ *   .console.--theme-light  (default)
+ *   .console.--theme-dark
+ *   .console.--theme-retro  (CRT phosphor, scanlines, monospace)
+ *
+ * Console-local tokens (`--c-*`) drive everything; severity colors map
+ * to the existing status tokens (`--info-solid` etc.), and the retro
+ * theme reads from the shared `--retro-*` tokens in `tokens/retro.css`.
+ * Consumers can override individual `--c-*` vars to tweak the palette
+ * without forking the theme.
+ *
+ * Chip primitives inside Console (env tag, severity badge) follow the
+ * console theme via local `--chip-*` overrides.
+ */
+
+.console {
+  --c-bg:        oklch(0.985 0.004 88);
+  --c-bg-strip:  oklch(0.962 0.012 88);
+  --c-row-hover: oklch(0.948 0.018 230 / 0.30);
+  --c-border:    var(--border-1);
+  --c-border-2:  var(--border-2);
+  --c-text:      var(--color-neutral-900);
+  --c-muted:     var(--color-neutral-700);
+  --c-subtle:    var(--color-neutral-500);
+  --c-accent:    var(--color-primary-700);
+  --c-mono:      ui-monospace, "SF Mono", "Cascadia Code", monospace;
+
+  --c-debug:   var(--debug-solid);
+  --c-info:    var(--info-solid);
+  --c-success: var(--success-solid);
+  --c-warning: var(--warning-solid);
+  --c-error:   var(--error-solid);
+
+  /* Chips inside Console pick up the console palette. LiveIndicator
+     inherits these too (it composes Chip). */
+  --chip-bg:     rgba(255, 255, 255, 0.04);
+  --chip-fg:     var(--c-muted);
+  --chip-border: var(--c-border);
+
+  /* ActionButton chrome follows the console palette. */
+  --action-button-bg:        transparent;
+  --action-button-fg:        var(--c-muted);
+  --action-button-border:    var(--c-border);
+  --action-button-bg-hover:  var(--c-row-hover);
+  --action-button-fg-hover:  var(--c-text);
+
+  --console-radius: 12px;
+
+  display: flex;
+  flex-direction: column;
+  background: var(--c-bg);
+  color: var(--c-text);
+  border: 1px solid var(--c-border);
+  border-radius: var(--console-radius);
+  overflow: hidden;
+  font-family: var(--font-sans);
+  min-height: 0;
+}
+
+.console.--theme-dark {
+  --c-bg:        oklch(0.165 0.030 234);
+  --c-bg-strip:  oklch(0.220 0.040 232);
+  --c-row-hover: oklch(0.260 0.046 232);
+  --c-border:    oklch(0.330 0.058 230);
+  --c-border-2:  oklch(0.420 0.072 228);
+  --c-text:      var(--color-secondary-100);
+  --c-muted:     oklch(0.785 0.028 82);
+  --c-subtle:    oklch(0.640 0.030 82);
+  --c-accent:    var(--color-accent-300);
+
+  --c-debug:   var(--debug-text);
+  --c-info:    var(--info-text);
+  --c-success: var(--success-text);
+  --c-warning: var(--warning-text);
+  --c-error:   var(--error-text);
+
+  --chip-bg:     rgba(255, 255, 255, 0.06);
+  --chip-fg:     var(--c-muted);
+  --chip-border: var(--c-border);
+}
+
+.console.--theme-retro {
+  --c-bg:        var(--retro-bg);
+  --c-bg-strip:  var(--retro-bg-strip);
+  --c-row-hover: var(--retro-row-hover);
+  --c-border:    var(--retro-border);
+  --c-border-2:  var(--retro-border-2);
+  --c-text:      var(--retro-fg);
+  --c-muted:     var(--retro-muted);
+  --c-subtle:    var(--retro-subtle);
+  --c-accent:    var(--retro-accent);
+  --c-mono:      var(--retro-mono-font);
+
+  --c-debug:   var(--retro-debug);
+  --c-info:    var(--retro-info);
+  --c-success: var(--retro-success);
+  --c-warning: var(--retro-warning);
+  --c-error:   var(--retro-error);
+
+  --chip-bg:     rgba(86, 224, 130, 0.08);
+  --chip-fg:     var(--c-muted);
+  --chip-border: var(--c-border);
+
+  /* Retro tightens all the corners. Tokens cascade to every pill,
+     icon button, and the console root itself. */
+  --chip-radius:        2px;
+  --action-button-radius: 0;
+  --console-radius:     0;
+
+  /* LiveIndicator in retro mode reads the saturated retro green. */
+  --live-indicator-dot: var(--retro-success);
+
+  box-shadow:
+    0 0 0 1px rgba(86, 224, 130, 0.15),
+    0 0 40px rgba(86, 224, 130, 0.06) inset;
+  position: relative;
+}
+
+.console.--theme-retro * {
+  letter-spacing: 0.01em;
+}
+
+/* Retro scanlines — reuse the shared utility via the same ::after pattern.
+   We can't apply `.retro-scanlines` directly without changing markup, so we
+   mirror its definition here keyed to the retro theme. */
+.console.--theme-retro::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 2px,
+    rgba(0, 0, 0, 0.18) 2px,
+    rgba(0, 0, 0, 0.18) 3px
+  );
+  mix-blend-mode: multiply;
+  z-index: 5;
+}
+
+/* ── Title bar ────────────────────────────────────────────── */
+.console-titlebar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 18px;
+  background: var(--c-bg-strip);
+  border-bottom: 1px solid var(--c-border);
+}
+.console.--theme-retro .console-titlebar {
+  font-family: var(--c-mono);
+  border-bottom-style: dashed;
+}
+
+.console-title {
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: 16px;
+  letter-spacing: -0.01em;
+  color: var(--c-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+.console.--theme-retro .console-title {
+  font-family: var(--c-mono);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-shadow: 0 0 6px var(--retro-glow);
+}
+
+/* LiveIndicator + ActionButton live in core/. Console only overrides their
+   tokens (above, in the theme blocks) — no local styling needed here. */
+
+.console-counter {
+  font-family: var(--c-mono);
+  font-size: 11px;
+  color: var(--c-subtle);
+  margin-left: auto;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+.console-counter b {
+  color: var(--c-text);
+  font-weight: 600;
+}
+
+/* ── Chip styling for env tag + severity badge ────────────── */
+/* Chip itself stays generic — Console applies its tight tag-style
+   typography (mono/uppercase/tighter padding) here, so the chip
+   primitive doesn't need typography props. */
+.console-tag,
+.console-entry-level {
+  font-family: var(--c-mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  padding: 2px 8px;
+}
+
+.console-entry-level {
+  align-self: center;
+  justify-self: start;
+  border-radius: 4px;
+}
+.console-entry-level.--debug   { color: var(--c-debug); }
+.console-entry-level.--info    { color: var(--c-info); }
+.console-entry-level.--success { color: var(--c-success); }
+.console-entry-level.--warning { color: var(--c-warning); }
+.console-entry-level.--error   { color: var(--c-error); }
+.console.--theme-retro .console-entry-level {
+  border-radius: 0;
+}
+
+/* ── Body + group headers ────────────────────────────────── */
+.console-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  container-type: inline-size;
+  container-name: consolebody;
+  position: relative;
+}
+.console-body::-webkit-scrollbar { width: 10px; }
+.console-body::-webkit-scrollbar-track { background: transparent; }
+.console-body::-webkit-scrollbar-thumb {
+  background: var(--c-border);
+  border-radius: 5px;
+}
+.console-body::-webkit-scrollbar-thumb:hover {
+  background: var(--c-border-2);
+}
+
+.console-group {
+  font-family: var(--c-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--c-subtle);
+  padding: 14px 22px 8px;
+  border-bottom: 1px dashed var(--c-border);
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  backdrop-filter: blur(8px);
+  background-color: color-mix(in oklch, var(--c-bg) 80%, transparent);
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+.console-group-count {
+  color: var(--c-subtle);
+  font-weight: 600;
+}
+
+/* ── Entry rows ──────────────────────────────────────────── */
+.console-entry {
+  display: grid;
+  grid-template-columns: 92px 78px 110px 1fr auto;
+  gap: 14px;
+  align-items: baseline;
+  padding: 9px 22px;
+  border-bottom: 1px solid color-mix(in oklch, var(--c-border) 60%, transparent);
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--c-text);
+  text-align: left;
+  background: transparent;
+  border-left: 0;
+  border-right: 0;
+  border-top: 0;
+  width: 100%;
+  cursor: pointer;
+  transition: background 0.12s ease;
+}
+.console-entry:hover { background: var(--c-row-hover); }
+.console-entry.--expanded { background: var(--c-row-hover); }
+.console-entry:focus-visible {
+  outline: 2px solid var(--c-accent);
+  outline-offset: -2px;
+}
+.console-entry[data-static="true"] { cursor: default; }
+.console-entry[data-static="true"]:hover { background: transparent; }
+
+.console-entry-time {
+  font-family: var(--c-mono);
+  font-size: 11.5px;
+  color: var(--c-subtle);
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+}
+.console-entry-time-ms { opacity: 0.6; }
+
+.console-entry-source {
+  font-family: var(--c-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--c-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.10em;
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.console-entry-source-swatch {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.console-entry-msg {
+  color: var(--c-text);
+  line-height: 1.4;
+  min-width: 0;
+  text-wrap: pretty;
+  align-self: center;
+}
+.console-entry-msg b {
+  font-weight: 600;
+  color: var(--c-text);
+}
+.console-entry-msg code {
+  font-family: var(--c-mono);
+  font-size: 12.5px;
+  background: color-mix(in oklch, currentColor 8%, transparent);
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--c-accent);
+}
+.console.--theme-retro .console-entry-msg {
+  text-shadow: 0 0 6px var(--retro-glow);
+}
+.console.--theme-retro .console-entry-msg b { color: var(--retro-fg-strong); }
+.console.--theme-retro .console-entry-msg code { color: var(--retro-accent); }
+
+.console-entry-meta {
+  font-family: var(--c-mono);
+  font-size: 11px;
+  color: var(--c-subtle);
+  text-align: right;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  align-self: center;
+  white-space: nowrap;
+}
+.console-entry-chev {
+  display: inline-flex;
+  transition: transform 0.18s;
+  color: var(--c-subtle);
+}
+.console-entry.--expanded .console-entry-chev {
+  transform: rotate(90deg);
+}
+
+.console-entry-expand {
+  grid-column: 1 / -1;
+  padding: 4px 22px 16px 92px;
+  display: grid;
+  grid-template-columns: 1fr 280px;
+  gap: 22px;
+  border-top: 1px dashed color-mix(in oklch, var(--c-border) 60%, transparent);
+  margin-top: 6px;
+}
+.console-entry-expand-detail {
+  margin: 0;
+  font-family: var(--c-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--c-text);
+  background: var(--c-bg-strip);
+  border: 1px solid var(--c-border);
+  border-radius: 6px;
+  padding: 12px 14px;
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* ── Container-query responsiveness ──────────────────────── */
+@container consolebody (max-width: 720px) {
+  .console-entry {
+    grid-template-columns: 70px 70px 1fr auto;
+    gap: 10px;
+  }
+  .console-entry .console-entry-source { display: none; }
+  .console-entry-expand {
+    grid-template-columns: 1fr;
+    padding-left: 22px;
+  }
+}
+@container consolebody (max-width: 480px) {
+  .console-entry {
+    grid-template-columns: 56px 1fr;
+    padding: 10px 14px;
+  }
+  .console-entry .console-entry-level { grid-column: 2; }
+  .console-entry .console-entry-meta  {
+    grid-column: 1 / -1;
+    padding-left: 70px;
+    font-size: 10.5px;
+  }
+  .console-group { padding: 12px 14px 6px; }
+}
+
+/* ── Empty-state cursor (retro) ──────────────────────────── */
+.console-retro-cursor {
+  display: inline-block;
+  width: 8px;
+  height: 14px;
+  background: var(--retro-success);
+  margin-left: 4px;
+  vertical-align: middle;
+  animation: console-retro-blink 1.1s steps(1) infinite;
+}
+@keyframes console-retro-blink {
+  0%, 50%       { opacity: 1; }
+  50.01%, 100%  { opacity: 0; }
+}

--- a/libs/ratio-ui/src/console/Console.stories.tsx
+++ b/libs/ratio-ui/src/console/Console.stories.tsx
@@ -1,0 +1,317 @@
+import type * as React from 'react';
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Console, type ConsoleLevel } from './Console';
+
+const meta: Meta<typeof Console> = {
+  title: 'Console/Stream',
+  component: Console,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Themable terminal-style log / event console. Purely presentational — the consumer owns data, expansion, pause/play, filtering, and scroll. Use for streaming logs, business-event feeds, audit trails, liveblogs.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Console>;
+
+/* ── Sample data shared across stories ─────────────────────── */
+
+interface SampleEntry {
+  id: string;
+  hh: string;
+  mm: string;
+  ss: string;
+  ms: string;
+  level: ConsoleLevel;
+  source: string;
+  sourceColor: string;
+  message: React.ReactNode;
+  meta: string;
+  payload: Record<string, unknown>;
+}
+
+const SOURCE_COLORS = {
+  Realtime: 'oklch(0.55 0.13 280)',
+  HTTP: 'oklch(0.45 0.15 226)',
+  Audit: 'oklch(0.52 0.10 78)',
+  Job: 'oklch(0.55 0.10 200)',
+  Email: 'oklch(0.52 0.12 320)',
+  Payment: 'oklch(0.50 0.10 145)',
+  Health: 'oklch(0.55 0 0)',
+  Enrollment: 'oklch(0.52 0.13 28)',
+} as const;
+
+const SAMPLE: SampleEntry[] = [
+  {
+    id: 'e1', hh: '18', mm: '42', ss: '11', ms: '234',
+    level: 'info', source: 'Realtime', sourceColor: SOURCE_COLORS.Realtime,
+    message: (<>Client connected: <b>leo@losen.com</b> · connection <code>conn_7g3hx</code></>),
+    meta: '12 active',
+    payload: { user: 'leo@losen.com', connectionId: 'conn_7g3hx', transport: 'WebSockets', activeConnections: 12 },
+  },
+  {
+    id: 'e2', hh: '18', mm: '42', ss: '35', ms: '012',
+    level: 'debug', source: 'HTTP', sourceColor: SOURCE_COLORS.HTTP,
+    message: (<><code>GET</code> /api/articles?status=published → <b>200 OK</b></>),
+    meta: '38 ms',
+    payload: { method: 'GET', path: '/api/articles', status: 200, durationMs: 38, requestId: 'req_91kf2' },
+  },
+  {
+    id: 'e3', hh: '18', mm: '42', ss: '58', ms: '441',
+    level: 'info', source: 'Enrollment', sourceColor: SOURCE_COLORS.Enrollment,
+    message: (<>New enrollment: <b>Workshop: System design</b> · 18 / 30 seats</>),
+    meta: 'Leo Losen',
+    payload: { workshopId: 'wsh_42', attendee: { name: 'Leo Losen', id: 'usr_881' }, seatsTaken: 18, seatsTotal: 30 },
+  },
+  {
+    id: 'e4', hh: '18', mm: '43', ss: '02', ms: '108',
+    level: 'success', source: 'Payment', sourceColor: SOURCE_COLORS.Payment,
+    message: (<>Payment captured: <code>ord_7K2J</code> · 49 EUR · card</>),
+    meta: '✓ captured',
+    payload: { orderId: 'ord_7K2J', amount: 49, currency: 'EUR', provider: 'card', status: 'captured' },
+  },
+  {
+    id: 'e5', hh: '18', mm: '43', ss: '19', ms: '772',
+    level: 'warning', source: 'HTTP', sourceColor: SOURCE_COLORS.HTTP,
+    message: (<><code>POST</code> /api/payments/charge → <b>429 Too Many Requests</b></>),
+    meta: 'retry 1/3',
+    payload: { method: 'POST', path: '/api/payments/charge', status: 429, retry: 1, maxRetries: 3 },
+  },
+  {
+    id: 'e6', hh: '18', mm: '43', ss: '41', ms: '015',
+    level: 'error', source: 'Job', sourceColor: SOURCE_COLORS.Job,
+    message: (<>SMTP timeout after 30 s · queue: <b>3</b> pending emails</>),
+    meta: 'mail-out',
+    payload: { error: 'ETIMEDOUT', host: 'mail-relay-01', queueRemaining: 3, willRetry: true },
+  },
+  {
+    id: 'e7', hh: '18', mm: '43', ss: '52', ms: '230',
+    level: 'info', source: 'Audit', sourceColor: SOURCE_COLORS.Audit,
+    message: (<><b>Leo Losen</b> updated workshop price: <code>wsh_19</code> · 39 → 49 EUR</>),
+    meta: 'settings',
+    payload: { actor: 'Leo Losen', action: 'workshop.price.update', before: 39, after: 49 },
+  },
+];
+
+function groupByMinute(entries: SampleEntry[]) {
+  const groups = new Map<string, SampleEntry[]>();
+  for (const e of entries) {
+    const key = `${e.hh}:${e.mm}`;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(e);
+  }
+  return [...groups.entries()];
+}
+
+function renderJson(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/* ── Helper component used by stories ──────────────────────── */
+
+interface FullConsoleProps {
+  theme: 'light' | 'dark' | 'retro';
+  envTag?: string;
+  paused?: boolean;
+  title?: React.ReactNode;
+}
+
+const FullConsole: React.FC<FullConsoleProps> = ({
+  theme,
+  envTag = 'prod',
+  paused = false,
+  title,
+}) => {
+  const [expandedId, setExpandedId] = useState<string | null>('e4');
+  const groups = groupByMinute(SAMPLE);
+
+  return (
+    <Console theme={theme} aria-label="System log" className="h-[640px]">
+      <Console.TitleBar>
+        <Console.Title>
+          {title ?? (
+            <>
+              System log <Console.Tag>{envTag}</Console.Tag>
+            </>
+          )}
+        </Console.Title>
+        <Console.LiveIndicator status={paused ? 'paused' : 'live'}>
+          {paused ? 'Paused' : 'Live'}
+        </Console.LiveIndicator>
+        <Console.Counter>
+          <b>{SAMPLE.length}</b> events · last 10 min
+        </Console.Counter>
+      </Console.TitleBar>
+      <Console.Body>
+        {groups.map(([label, items]) => (
+          <div key={label}>
+            <Console.Group label={label} count={items.length} />
+            {items.map((ev) => (
+              <Console.Entry
+                key={ev.id}
+                timestamp={<Console.Time hhmmss={`${ev.hh}:${ev.mm}:${ev.ss}`} ms={ev.ms} />}
+                level={ev.level}
+                source={ev.source}
+                sourceColor={ev.sourceColor}
+                message={ev.message}
+                meta={ev.meta}
+                expanded={expandedId === ev.id}
+                onToggle={(next) => setExpandedId(next ? ev.id : null)}
+              >
+                <Console.EntryDetail>{renderJson(ev.payload)}</Console.EntryDetail>
+              </Console.Entry>
+            ))}
+          </div>
+        ))}
+      </Console.Body>
+    </Console>
+  );
+};
+
+/* ── Stories ───────────────────────────────────────────────── */
+
+const LIGHT_FRAME = 'h-[700px] p-6 bg-secondary-200';
+const DARK_FRAME = 'h-[700px] p-6 bg-[oklch(0.14_0.02_234)]';
+const RETRO_FRAME =
+  'h-[700px] p-6 bg-[radial-gradient(ellipse_at_center,_#0d130c_0%,_#050803_100%)]';
+
+export const Light: Story = {
+  name: 'Theme — Light',
+  render: () => (
+    <div className={LIGHT_FRAME}>
+      <FullConsole theme="light" />
+    </div>
+  ),
+};
+
+export const Dark: Story = {
+  name: 'Theme — Dark',
+  render: () => (
+    <div className={DARK_FRAME}>
+      <FullConsole theme="dark" />
+    </div>
+  ),
+};
+
+export const Retro: Story = {
+  name: 'Theme — Retro CRT',
+  render: () => (
+    <div className={RETRO_FRAME}>
+      <FullConsole theme="retro" title="platform.sys // console" envTag="prod" />
+    </div>
+  ),
+};
+
+export const Paused: Story = {
+  name: 'State — Paused',
+  render: () => (
+    <div className={LIGHT_FRAME}>
+      <FullConsole theme="light" paused />
+    </div>
+  ),
+};
+
+export const Compact720: Story = {
+  name: 'Responsive — 720px (drops source column)',
+  render: () => (
+    <div className={`w-[720px] ${LIGHT_FRAME}`}>
+      <FullConsole theme="light" />
+    </div>
+  ),
+};
+
+export const Compact440: Story = {
+  name: 'Responsive — 440px (two-line rows)',
+  render: () => (
+    <div className="w-[440px] h-[700px] p-4 bg-secondary-200">
+      <FullConsole theme="light" />
+    </div>
+  ),
+};
+
+/* ── Minimal example for docs ──────────────────────────────── */
+
+export const MinimalApi: Story = {
+  name: 'Minimal API',
+  render: () => (
+    <div className="h-[400px] p-6 bg-secondary-200">
+      <Console theme="light" aria-label="Activity">
+        <Console.TitleBar>
+          <Console.Title>Activity</Console.Title>
+          <Console.LiveIndicator>Live</Console.LiveIndicator>
+        </Console.TitleBar>
+        <Console.Body>
+          <Console.Entry
+            timestamp={<Console.Time hhmmss="10:00:00" />}
+            level="info"
+            message="Service started"
+          />
+          <Console.Entry
+            timestamp={<Console.Time hhmmss="10:00:42" />}
+            level="warning"
+            message="Cache miss for key user_881"
+            meta="lookup"
+          />
+          <Console.Entry
+            timestamp={<Console.Time hhmmss="10:01:15" />}
+            level="error"
+            message="Failed to send confirmation email"
+            meta="3 retries"
+          />
+        </Console.Body>
+      </Console>
+    </div>
+  ),
+};
+
+/* ── Liveblog variant — same primitives, no console chrome ─── */
+
+export const Liveblog: Story = {
+  name: 'Use case — Liveblog',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Same primitives can drive a non-technical liveblog: severity becomes a content type (update / heads-up / decision), and the message slot carries prose. No expansion.',
+      },
+    },
+  },
+  render: () => (
+    <div className="h-[600px] p-6 bg-secondary-200">
+      <Console theme="light" aria-label="Liveblog">
+        <Console.TitleBar>
+          <Console.Title>Conference liveblog</Console.Title>
+          <Console.LiveIndicator>Live</Console.LiveIndicator>
+        </Console.TitleBar>
+        <Console.Body>
+          <Console.Group label="10:00" />
+          <Console.Entry
+            timestamp={<Console.Time hhmmss="10:02" />}
+            level="info"
+            levelLabel="update"
+            message="Doors open. Coffee in the foyer."
+          />
+          <Console.Entry
+            timestamp={<Console.Time hhmmss="10:14" />}
+            level="warning"
+            levelLabel="heads-up"
+            message="Track 2 has moved to room 204."
+          />
+          <Console.Entry
+            timestamp={<Console.Time hhmmss="10:31" />}
+            level="success"
+            levelLabel="decision"
+            message="Closing keynote confirmed for 16:30."
+          />
+        </Console.Body>
+      </Console>
+    </div>
+  ),
+};

--- a/libs/ratio-ui/src/console/Console.tsx
+++ b/libs/ratio-ui/src/console/Console.tsx
@@ -1,0 +1,377 @@
+import React from 'react';
+import { cn } from '../utils/cn';
+import { Chip } from '../core/Chip';
+import { LiveIndicator, type LiveIndicatorProps } from '../core/LiveIndicator';
+import { ActionButton, type ActionButtonProps } from '../core/ActionButton';
+import './Console.css';
+
+/* ──────────────────────────────────────────────────────────────
+ * Console — themed terminal-style log / event timeline.
+ *
+ * A purely presentational compound component. All state lives in
+ * the consumer: data, expansion, pause/play, filtering, scroll.
+ *
+ * Use it for streaming logs, business-event feeds, audit trails,
+ * liveblogs — anywhere a chronological, dense, optionally-grouped
+ * row list with a terminal feel makes sense.
+ * ────────────────────────────────────────────────────────────── */
+
+export type ConsoleTheme = 'light' | 'dark' | 'retro';
+
+export type ConsoleLevel = 'debug' | 'info' | 'success' | 'warning' | 'error';
+
+export type ConsoleLiveStatus = 'live' | 'paused';
+
+export interface ConsoleProps extends React.HTMLAttributes<HTMLElement> {
+  /**
+   * Visual treatment.
+   * - `'light'` (default) — Linen surface, serif title, monospace tags
+   * - `'dark'` — Linseed-950 surface, serif title, suited for ops dashboards
+   * - `'retro'` — CRT phosphor, scanlines, monospace everywhere
+   */
+  theme?: ConsoleTheme;
+  testId?: string;
+}
+
+const ConsoleRoot: React.FC<ConsoleProps> = ({
+  theme = 'light',
+  children,
+  className,
+  testId,
+  ...rest
+}) => (
+  <section
+    {...rest}
+    className={cn('console', `--theme-${theme}`, className)}
+    data-testid={testId}
+  >
+    {children}
+  </section>
+);
+ConsoleRoot.displayName = 'Console';
+
+/* ── Title bar ───────────────────────────────────────────── */
+
+export interface ConsoleTitleBarProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const TitleBar: React.FC<ConsoleTitleBarProps> = ({ children, className }) => (
+  <div className={cn('console-titlebar', className)}>{children}</div>
+);
+TitleBar.displayName = 'Console.TitleBar';
+
+export interface ConsoleTitleProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+const Title: React.FC<ConsoleTitleProps> = ({ children, className }) => (
+  <h2 className={cn('console-title', className)}>{children}</h2>
+);
+Title.displayName = 'Console.Title';
+
+/**
+ * Small environment/scope chip displayed next to the title (e.g. "prod").
+ * Renders as a {@link Chip}; the console theme overrides chip tokens so it
+ * reads correctly in dark / retro modes.
+ */
+const Tag: React.FC<ConsoleTitleProps> = ({ children, className }) => (
+  <Chip className={cn('console-tag', className)}>
+    {children}
+  </Chip>
+);
+Tag.displayName = 'Console.Tag';
+
+/**
+ * Re-export of {@link core/LiveIndicator} as `Console.LiveIndicator`. Use either
+ * import path; the Console theme overrides the chip tokens so the indicator
+ * adopts the surrounding palette automatically.
+ */
+export type ConsoleLiveIndicatorProps = LiveIndicatorProps;
+
+export interface ConsoleCounterProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/** Trailing counter ("32 events · last 10 min"). Pushed right via margin-left:auto. */
+const Counter: React.FC<ConsoleCounterProps> = ({ children, className }) => (
+  <span className={cn('console-counter', className)}>{children}</span>
+);
+Counter.displayName = 'Console.Counter';
+
+/**
+ * Re-export of {@link core/ActionButton} as `Console.ActionButton`. The Console
+ * theme overrides `--action-button-*` tokens so chrome buttons follow the
+ * local palette.
+ */
+export type ConsoleActionButtonProps = ActionButtonProps;
+
+/* ── Body + group headers ────────────────────────────────── */
+
+export interface ConsoleBodyProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * Scrollable container holding the rows. Forwarded ref lets consumers
+ * implement their own auto-scroll-to-bottom behavior.
+ */
+const Body = React.forwardRef<HTMLDivElement, ConsoleBodyProps>(
+  ({ children, className }, ref) => (
+    <div ref={ref} className={cn('console-body', className)} role="log">
+      {children}
+    </div>
+  ),
+);
+Body.displayName = 'Console.Body';
+
+export interface ConsoleGroupProps {
+  /** Group label (e.g. "18:42"). */
+  label: React.ReactNode;
+  /** Optional event count — rendered as "· N event(s)" next to the label. */
+  count?: number;
+  /** Override the auto-rendered count text (e.g. for i18n). */
+  countLabel?: React.ReactNode;
+  className?: string;
+}
+
+const Group: React.FC<ConsoleGroupProps> = ({
+  label,
+  count,
+  countLabel,
+  className,
+}) => (
+  <div className={cn('console-group', className)}>
+    <span>{label}</span>
+    {(countLabel !== undefined || count !== undefined) && (
+      <span className="console-group-count">
+        · {countLabel ?? `${count} event${count === 1 ? '' : 's'}`}
+      </span>
+    )}
+  </div>
+);
+Group.displayName = 'Console.Group';
+
+/* ── Entry rows ──────────────────────────────────────────── */
+
+export interface ConsoleEntryProps {
+  /** Render as time string (e.g. "18:42:11.234"). Use a small subcomponent so
+   *  the milliseconds can be visually muted; see {@link Time}. */
+  timestamp: React.ReactNode;
+  /** Severity. Controls the colored badge on the left. */
+  level: ConsoleLevel;
+  /** Severity label. Defaults to the `level` value uppercased. */
+  levelLabel?: React.ReactNode;
+  /** Optional source name (e.g. "SignalR"). Hidden on narrow widths. */
+  source?: React.ReactNode;
+  /** Inline color for the source swatch + label. */
+  sourceColor?: string;
+  /** Main message. Can include `<b>` and `<code>` for emphasis. */
+  message: React.ReactNode;
+  /** Right-aligned meta (e.g. duration, actor). */
+  meta?: React.ReactNode;
+  /** Expanded detail content. When provided, the row is clickable and shows
+   *  a chevron that rotates on expand. */
+  children?: React.ReactNode;
+  /** Whether the expanded content is visible. Fully controlled. */
+  expanded?: boolean;
+  /** Called when the row is clicked. Receives the new expanded state. */
+  onToggle?: (next: boolean) => void;
+  className?: string;
+  testId?: string;
+}
+
+const LEVEL_LABELS: Record<ConsoleLevel, string> = {
+  debug: 'debug',
+  info: 'info',
+  success: 'success',
+  warning: 'warn',
+  error: 'error',
+};
+
+const Entry: React.FC<ConsoleEntryProps> = ({
+  timestamp,
+  level,
+  levelLabel,
+  source,
+  sourceColor,
+  message,
+  meta,
+  children,
+  expanded,
+  onToggle,
+  className,
+  testId,
+}) => {
+  const interactive = children != null;
+  const handleClick = () => {
+    if (interactive) onToggle?.(!expanded);
+  };
+  const rowClassName = cn('console-entry', expanded && '--expanded', className);
+  const inner = (
+    <>
+      <div className="console-entry-time">{timestamp}</div>
+      <Chip
+        variant="outline"
+        className={cn('console-entry-level', `--${level}`)}
+      >
+        {levelLabel ?? LEVEL_LABELS[level]}
+      </Chip>
+      {source !== undefined ? (
+        <div
+          className="console-entry-source"
+          style={sourceColor ? { color: sourceColor } : undefined}
+        >
+          <span className="console-entry-source-swatch" aria-hidden="true" />
+          {source}
+        </div>
+      ) : (
+        <div className="console-entry-source" aria-hidden="true" />
+      )}
+      <div className="console-entry-msg">{message}</div>
+      <div className="console-entry-meta">
+        {meta !== undefined && <span>{meta}</span>}
+        {interactive && (
+          <span className="console-entry-chev" aria-hidden="true">
+            <Chevron />
+          </span>
+        )}
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      {interactive ? (
+        <button
+          type="button"
+          className={rowClassName}
+          onClick={handleClick}
+          aria-expanded={!!expanded}
+          data-testid={testId}
+        >
+          {inner}
+        </button>
+      ) : (
+        <div
+          className={rowClassName}
+          data-static="true"
+          data-testid={testId}
+        >
+          {inner}
+        </div>
+      )}
+      {interactive && expanded && (
+        <div className="console-entry-expand">{children}</div>
+      )}
+    </>
+  );
+};
+Entry.displayName = 'Console.Entry';
+
+/** Tabular time rendered with muted milliseconds — pass as `timestamp`. */
+const Time: React.FC<{ hhmmss: string; ms?: string; className?: string }> = ({
+  hhmmss,
+  ms,
+  className,
+}) => (
+  <span className={className}>
+    {hhmmss}
+    {ms && <span className="console-entry-time-ms">.{ms}</span>}
+  </span>
+);
+Time.displayName = 'Console.Time';
+
+export interface ConsoleEntryDetailProps {
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/** Preformatted detail block (e.g. JSON dump) inside `Entry`'s expand area. */
+const EntryDetail: React.FC<ConsoleEntryDetailProps> = ({ children, className }) => (
+  <pre className={cn('console-entry-expand-detail', className)}>{children}</pre>
+);
+EntryDetail.displayName = 'Console.EntryDetail';
+
+/* ── Retro accent ────────────────────────────────────────── */
+
+/** Blinking block cursor — for empty states or banners in `retro` theme. */
+const RetroCursor: React.FC<{ className?: string }> = ({ className }) => (
+  <span className={cn('console-retro-cursor', className)} aria-hidden="true" />
+);
+RetroCursor.displayName = 'Console.RetroCursor';
+
+/* ── Built-in chevron (avoids an icon-pack dependency) ───── */
+
+const Chevron: React.FC = () => (
+  <svg
+    width="12"
+    height="12"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.8"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    viewBox="0 0 24 24"
+  >
+    <path d="m9 6 6 6-6 6" />
+  </svg>
+);
+
+/* ── Compound export ─────────────────────────────────────── */
+
+/**
+ * Themable, presentational log/event console. Compose with `TitleBar`,
+ * `LiveIndicator`, `Body`, `Group`, and `Entry`.
+ *
+ * @beta This component is experimental — prop shape and visual treatment
+ * may change before release.
+ *
+ * @example
+ * ```tsx
+ * <Console theme="dark" aria-label="System log">
+ *   <Console.TitleBar>
+ *     <Console.Title>System log</Console.Title>
+ *     <Console.Tag>prod</Console.Tag>
+ *     <Console.LiveIndicator status={paused ? 'paused' : 'live'} />
+ *     <Console.Counter><b>{events.length}</b> events · last 10 min</Console.Counter>
+ *   </Console.TitleBar>
+ *   <Console.Body ref={bodyRef}>
+ *     <Console.Group label="18:42" count={3} />
+ *     {events.map((ev) => (
+ *       <Console.Entry
+ *         key={ev.id}
+ *         timestamp={<Console.Time hhmmss={ev.hhmmss} ms={ev.ms} />}
+ *         level={ev.level}
+ *         source={ev.source}
+ *         message={ev.message}
+ *         meta={ev.meta}
+ *         expanded={expandedId === ev.id}
+ *         onToggle={(next) => setExpandedId(next ? ev.id : null)}
+ *       >
+ *         <Console.EntryDetail>{JSON.stringify(ev.payload, null, 2)}</Console.EntryDetail>
+ *       </Console.Entry>
+ *     ))}
+ *   </Console.Body>
+ * </Console>
+ * ```
+ */
+export const Console = Object.assign(ConsoleRoot, {
+  TitleBar,
+  Title,
+  Tag,
+  LiveIndicator,
+  Counter,
+  ActionButton,
+  Body,
+  Group,
+  Entry,
+  Time,
+  EntryDetail,
+  RetroCursor,
+});

--- a/libs/ratio-ui/src/console/README.md
+++ b/libs/ratio-ui/src/console/README.md
@@ -1,0 +1,133 @@
+# Console
+
+A themable terminal-style log / event console. Renders a dense, optionally-grouped list of timestamped rows with severity badges, source tags, an inline expand area for detail payloads, and a sticky title bar with live-tail indicator.
+
+Purely presentational. The consumer owns all state: data array, expansion, pause/play, filter selections, scroll position. The component never fetches, polls, throttles, filters, or scrolls on its own.
+
+```tsx
+import { Console } from '@eventuras/ratio-ui/console';
+```
+
+## When to use it
+
+- **System logs / business events** — streaming events from realtime channels, queues, webhooks
+- **Audit trails** — chronological "who did what" surfaces in admin views
+- **Liveblogs / running commentary** — short prose updates with a "live" feel
+- **Import/export progress** — long-running operations that emit per-step events
+
+For a sparser vertical timeline with a dot rail (order history, single-thread audit), prefer [`Timeline`](../core/Timeline) (`@eventuras/ratio-ui/core/Timeline`).
+
+## Themes
+
+| Theme | Surface | Typography | Use |
+|---|---|---|---|
+| `light` (default) | Linen | Serif title + monospace tags | Admin pages, sidebars |
+| `dark` | Linseed-950 | Same | Standalone dashboards, ops surfaces |
+| `retro` | Phosphor black + CRT scanlines | All monospace, green-on-black, blinking cursor | "Things are happening" hero surfaces |
+
+The theme is an explicit prop. It does NOT follow the app's `.dark` class — wrap your own conditional if you want it to.
+
+## Anatomy
+
+```
+<Console theme>                              ← themed root
+  <Console.TitleBar>                         ← sticky top
+    <Console.Title>                          ← serif heading
+    <Console.Tag>                            ← env chip (e.g. "prod")
+    <Console.LiveIndicator status>           ← pulsing pill
+    <Console.Counter>                        ← right-pushed counter
+    <Console.ActionButton>                   ← chrome buttons (icon, text, or both)
+  </Console.TitleBar>
+  <Console.Body ref>                         ← scrollable, container-queried
+    <Console.Group label count/>             ← sticky time-bucket header
+    <Console.Entry timestamp level source message meta expanded onToggle>
+      <Console.EntryDetail>                  ← preformatted JSON/text
+    </Console.Entry>
+  </Console.Body>
+</Console>
+```
+
+`Console.Time` is a small helper for tabular-mono timestamps with muted milliseconds — pass it as the `timestamp` prop of `Entry`.
+
+Three sub-components are re-exports of standalone primitives — use either import path:
+
+| `Console.X` | Standalone | Notes |
+|---|---|---|
+| `Console.Tag` | [`Chip`](../core/Chip) | Console overrides `--chip-bg/-fg/-border/-radius` per theme |
+| `Console.LiveIndicator` | [`LiveIndicator`](../core/LiveIndicator) | Pulsing dot + label; reads `--live-indicator-dot` (retro flips to phosphor green) |
+| `Console.ActionButton` | [`ActionButton`](../core/ActionButton) | Chrome button (icon, text, or both); reads `--action-button-*` (retro flips to sharp corners) |
+
+Because the standalone primitives all read from CSS tokens, the console theme cascades into them automatically — no per-theme rules per primitive.
+
+## Radius tokens
+
+The console root, pills inside it, and chrome buttons all expose their radius as a token (`--console-radius`, `--chip-radius`, `--action-button-radius`). The retro theme flips all three to sharp corners in one block. Consumers can override any of them per-scope (e.g. a brutalist sub-experience) without touching the components.
+
+## Severity levels
+
+`debug` · `info` · `success` · `warning` · `error`
+
+`debug` reads as a quiet gray; the rest map to the same status colors as `Badge` and `Panel`. The label defaults to the level value (with `warning` rendered as `warn` to fit the 4-char terminal vibe) — override with `levelLabel` for i18n or alternate vocabularies (e.g. "decision", "heads-up" in a liveblog).
+
+## Controlled expansion
+
+Expansion is fully controlled — there is no internal state. Pass `expanded` and `onToggle` per row. Children of `Entry` are only rendered when `expanded === true`.
+
+```tsx
+const [openId, setOpenId] = useState<string | null>(null);
+
+<Console.Entry
+  expanded={openId === ev.id}
+  onToggle={(next) => setOpenId(next ? ev.id : null)}
+  ...
+>
+  <Console.EntryDetail>{JSON.stringify(ev.payload, null, 2)}</Console.EntryDetail>
+</Console.Entry>
+```
+
+When `Entry` has no children, the chevron disappears and the row becomes non-interactive — fine for read-only feeds.
+
+## Live tail / auto-scroll
+
+The component does not auto-scroll. Get a ref on `Console.Body` and scroll yourself:
+
+```tsx
+const bodyRef = useRef<HTMLDivElement>(null);
+useEffect(() => {
+  if (!paused) bodyRef.current?.scrollTo({ top: bodyRef.current.scrollHeight, behavior: 'smooth' });
+}, [events, paused]);
+
+<Console.Body ref={bodyRef}>...</Console.Body>
+```
+
+This keeps the component free of policy decisions (smooth vs instant, pin-to-bottom when scrolled up, etc.) that vary per consumer.
+
+## Responsive
+
+`Console.Body` is a CSS container (`container-type: inline-size`). Two breakpoints kick in based on the body's own width, not the viewport:
+
+- **≤720px** — the source column is hidden; columns become `time / level / message / meta`
+- **≤480px** — rows collapse to two visual lines (time + level on top, meta on bottom)
+
+This means a narrow drawer renders compactly even when the page itself is wide. No media queries needed in the consumer.
+
+## Source colors
+
+Pass `sourceColor` on `Entry` to tint the source label and its leading dot. Use any CSS color string. The component does not maintain a source registry — callers map source names to colors however they like.
+
+## Accessibility
+
+- `Console.Body` is `role="log"` — screen readers treat it as a live region of chronological events.
+- `Console.LiveIndicator` is `role="status"` but `aria-live="off"` — the dot is decorative; the visible "Live"/"Paused" text is what's read on demand.
+- Entries with children get `aria-expanded`. Entries without children are non-interactive (`data-static="true"`).
+
+## Not in scope
+
+These belong in the consumer, not here:
+
+- Streaming transport (EventSource, WebSocket, SignalR, SSE)
+- Pause/play state (just toggle the indicator)
+- Filter UI and filter state (compose your own header above the console; see ratio-ui's `Strip`, `Badge`, and `forms/` for primitives)
+- Auto-scroll behavior (consumer scrolls via ref)
+- Persistence, copy-all, export-as-JSON
+- A built-in JSON viewer (use any pretty-printer — `JSON.stringify(x, null, 2)` is usually enough inside `EntryDetail`)

--- a/libs/ratio-ui/src/console/index.ts
+++ b/libs/ratio-ui/src/console/index.ts
@@ -1,0 +1,16 @@
+export { Console } from './Console';
+export type {
+  ConsoleProps,
+  ConsoleTheme,
+  ConsoleLevel,
+  ConsoleLiveStatus,
+  ConsoleTitleBarProps,
+  ConsoleTitleProps,
+  ConsoleLiveIndicatorProps,
+  ConsoleCounterProps,
+  ConsoleActionButtonProps,
+  ConsoleBodyProps,
+  ConsoleGroupProps,
+  ConsoleEntryProps,
+  ConsoleEntryDetailProps,
+} from './Console';

--- a/libs/ratio-ui/src/tokens/index.css
+++ b/libs/ratio-ui/src/tokens/index.css
@@ -6,3 +6,4 @@
 @import "./chip.css";
 @import "./action-button.css";
 @import "./live-indicator.css";
+@import "./retro.css";

--- a/libs/ratio-ui/src/tokens/retro.css
+++ b/libs/ratio-ui/src/tokens/retro.css
@@ -1,0 +1,73 @@
+/*
+ * Retro tokens — opt-in CRT/phosphor aesthetic + debug status family.
+ *
+ * The retro palette is theme-agnostic (not bound to light/dark mode).
+ * Components opt in by reading from these vars — currently used by
+ * `console`'s `--theme-retro` variant; available to any future
+ * component that wants the same vibe.
+ *
+ * Debug status tokens (`--debug-*`) live here because Console is the
+ * only consumer today. If we add debug-tagged Badges, alerts, etc.
+ * later, these belong in `theme.css` next to info/success/warning/error.
+ */
+
+:root {
+  /* Retro palette */
+  --retro-bg:           #0a0d09;
+  --retro-bg-strip:     #11160f;
+  --retro-fg:           #b8f2c8;
+  --retro-fg-strong:    #d8ffe2;
+  --retro-muted:        #6fbf85;
+  --retro-subtle:       #4f8f63;
+  --retro-accent:       #ffb84a;
+  --retro-border:       rgba(86, 224, 130, 0.22);
+  --retro-border-2:     rgba(86, 224, 130, 0.35);
+  --retro-glow:         rgba(86, 224, 130, 0.35);
+  --retro-row-hover:    rgba(86, 224, 130, 0.06);
+
+  /* Severity colors in the retro palette — kept bright + saturated
+     so they read against the phosphor green field. */
+  --retro-debug:   #6fbf85;
+  --retro-info:    #8fd8ff;
+  --retro-success: #56e082;
+  --retro-warning: #ffb84a;
+  --retro-error:   #ff6b6b;
+
+  --retro-mono-font: "Source Code Pro", ui-monospace, monospace;
+
+  /* Debug status — same gray family as neutral, named separately so
+     consumers can differentiate verbose-info from "no status". */
+  --debug-solid:     var(--color-neutral-500);
+  --debug-on-solid:  var(--color-neutral-50);
+  --debug-bg:        var(--color-neutral-100);
+  --debug-border:    var(--color-neutral-300);
+  --debug-text:      var(--color-neutral-700);
+}
+
+:root[data-theme="dark"] {
+  --debug-bg:     rgba(100, 100, 100, 0.16);
+  --debug-border: rgba(100, 100, 100, 0.28);
+  --debug-text:   var(--color-neutral-300);
+}
+
+/* CRT scanline overlay — apply to any container that wants the look.
+   The container needs `position: relative`; lines render via mix-blend
+   so they tint without obscuring content. */
+.retro-scanlines {
+  position: relative;
+}
+.retro-scanlines::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0,
+    transparent 2px,
+    rgba(0, 0, 0, 0.18) 2px,
+    rgba(0, 0, 0, 0.18) 3px
+  );
+  mix-blend-mode: multiply;
+  z-index: 5;
+}


### PR DESCRIPTION
## Summary

Adds `<Console>` at `@eventuras/ratio-ui/console` — a themable presentational log/event console (light / dark / retro CRT) with sticky title bar, severity-tagged rows, sticky time-bucket groups, controlled inline expand for detail payloads, and container-query responsiveness that collapses columns based on the console's own width.

**Final piece** of the chip/button/indicator stack from the last week. Composes:
- `Chip` for the env tag and severity badge
- `LiveIndicator` for the live-tail status pill
- `ActionButton` for chrome buttons in the title bar

Themed containers re-skin those primitives via local CSS-variable overrides — no per-theme rules per primitive.

## Anatomy

```tsx
<Console theme="light | dark | retro" aria-label="System log">
  <Console.TitleBar>
    <Console.Title>System log <Console.Tag>prod</Console.Tag></Console.Title>
    <Console.LiveIndicator status={paused ? 'paused' : 'live'}>
      {paused ? 'Paused' : 'Live'}
    </Console.LiveIndicator>
    <Console.Counter><b>{events.length}</b> events · last 10 min</Console.Counter>
  </Console.TitleBar>
  <Console.Body ref={bodyRef}>
    <Console.Group label="18:42" count={3} />
    {events.map((ev) => (
      <Console.Entry
        key={ev.id}
        timestamp={<Console.Time hhmmss={ev.hhmmss} ms={ev.ms} />}
        level={ev.level}
        source={ev.source}
        sourceColor={ev.sourceColor}
        message={ev.message}
        meta={ev.meta}
        expanded={expandedId === ev.id}
        onToggle={(next) => setExpandedId(next ? ev.id : null)}
      >
        <Console.EntryDetail>{JSON.stringify(ev.payload, null, 2)}</Console.EntryDetail>
      </Console.Entry>
    ))}
  </Console.Body>
</Console>
```

## Themes

| Theme | Surface | Typography | Use |
|---|---|---|---|
| `light` (default) | Linen | Serif title + monospace tags | Admin pages, sidebars |
| `dark` | Linseed-950 | Same | Standalone dashboards, ops surfaces |
| `retro` | Phosphor black + CRT scanlines | All monospace, green-on-black, blinking cursor | "Things are happening" hero surfaces |

## Why its own top-level folder?

Consoles will likely accumulate logic helpers (auto-scroll, stream adapters, filter utilities). Putting it in `core/Console/` would mix presentation primitives with logic in the same dir; a top-level `console/` mirrors `toast/`'s pattern where component + supporting logic live together.

## Design tokens

New `tokens/retro.css` with the shared retro palette (theme-agnostic, opt-in via the `--theme-retro` class) and `--debug-*` status tokens. Both are available to any future component that wants the CRT aesthetic or a debug-status indicator.

## Test plan
- [ ] `pnpm --filter @eventuras/ratio-ui build` clean
- [ ] Storybook stories: Light / Dark / Retro / Paused / Compact720 / Compact440 / MinimalApi / Liveblog
- [ ] Retro theme renders scanlines + blinking cursor + sharp corners (radius tokens flipped to 0)
- [ ] Container queries collapse columns when `Console.Body` shrinks below 720px and 480px
- [ ] No tenant references in stories or code

## Stack recap

Five PRs over the past week land the full set:
- #1477 — Chip
- #1478 — Chip variants fix
- #1479 — ActionButton  
- #1485 — LiveIndicator + Chip.Dot pulse
- This — Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)