### PR TITLE
fix(web): serve auth status from GET /api/auth/status

### DIFF
--- a/apps/web/src/app/(auth)/api/auth/status/route.ts
+++ b/apps/web/src/app/(auth)/api/auth/status/route.ts
@@ -1,0 +1,36 @@
+import { getCurrentSession } from '@eventuras/fides-auth-next/session';
+import { Logger } from '@eventuras/logger';
+
+import type { AuthStatus } from '@/utils/auth/getAuthStatus';
+
+const logger = Logger.create({ namespace: 'web:api:auth:status' });
+
+export async function GET(): Promise<Response> {
+  try {
+    const session = await getCurrentSession();
+
+    if (!session?.user || !session?.tokens?.accessToken) {
+      return Response.json({ authenticated: false } satisfies AuthStatus, {
+        headers: { 'Cache-Control': 'private, no-store' },
+      });
+    }
+
+    return Response.json(
+      {
+        authenticated: true,
+        user: {
+          name: session.user.name,
+          email: session.user.email,
+          roles: session.user.roles,
+        },
+      } satisfies AuthStatus,
+      { headers: { 'Cache-Control': 'private, no-store' } }
+    );
+  } catch (error) {
+    logger.error({ error }, 'Auth status check failed');
+    return Response.json({ authenticated: false } satisfies AuthStatus, {
+      status: 500,
+      headers: { 'Cache-Control': 'private, no-store' },
+    });
+  }
+}

--- a/apps/web/src/utils/auth/getAuthStatus.ts
+++ b/apps/web/src/utils/auth/getAuthStatus.ts
@@ -1,9 +1,4 @@
-'use server';
-
-import { getCurrentSession } from '@eventuras/fides-auth-next/session';
 import { Logger } from '@eventuras/logger';
-
-import { oauthConfig } from '@/utils/oauthConfig';
 
 const logger = Logger.create({ namespace: 'web:utils:getAuthStatus' });
 
@@ -18,29 +13,28 @@ export type AuthStatus = {
 };
 
 /**
- * Get the current authentication status
- * Server action that can be called from client components
+ * Fetches the current authentication status from the server.
+ *
+ * Backed by `GET /api/auth/status` rather than a Server Action: Server Actions
+ * POST to the current route URL, which can race with in-flight client
+ * navigations and silently cancel them in the Next.js app router.
  */
 export async function getAuthStatus(): Promise<AuthStatus> {
   try {
-    const session = await getCurrentSession(oauthConfig);
+    const response = await fetch('/api/auth/status', {
+      method: 'GET',
+      credentials: 'same-origin',
+      cache: 'no-store',
+      headers: { Accept: 'application/json' },
+    });
 
-    if (!session?.user || !session?.tokens?.accessToken) {
+    if (!response.ok) {
       return { authenticated: false };
     }
 
-    logger.debug({ roles: session.user.roles }, 'User authenticated');
-
-    return {
-      authenticated: true,
-      user: {
-        name: session.user.name,
-        email: session.user.email,
-        roles: session.user.roles,
-      },
-    };
+    return (await response.json()) as AuthStatus;
   } catch (error) {
-    logger.debug({ error }, 'No active session');
+    logger.debug({ error }, 'Auth status fetch failed');
     return { authenticated: false };
   }
 }


### PR DESCRIPTION
## Summary

- Move auth-status read out of a `'use server'` action and into a dedicated `GET /api/auth/status` route handler.
- Client `getAuthStatus()` now `fetch`es that endpoint. Function signature consumed by `initializeAuth`, `startSessionMonitor`, and `checkAuth` is unchanged.

## Why

While running the e2e baseline against the test env, the admin event-create flow consistently failed: clicking `<Link href="/admin/events/create">` did not navigate. Trace analysis showed Next.js fetched the RSC payload for `/admin/events/create` successfully (200, valid stream including `CreateEventForm`), but the URL bar never updated.

Root cause: `getAuthStatus` was a Server Action, called on mount by `Providers.tsx` via `initializeAuth(authStore, getAuthStatus)`. Server Actions POST to the *current* route URL with a `Next-Action` header. The trace showed exactly that:

```
POST https://web.eventuras.losol.no/admin -> 200
content-type: text/x-component
next-action: 0009f266ba7d79159b0659a0e5cccb11bef6cc2c82

response: 1:{"authenticated":true,"user":{...,"roles":["Admin","SystemAdmin"]}}
```

When this auth-init POST is in flight against `/admin` and the user clicks a Link to a new route, the Next.js 16 client router resolves the Server Action result against the *original* URL after the navigation has started — silently cancelling the route transition. Result: RSC for the new page is fetched, the URL never changes, and the page sits frozen.

Server Actions are for mutations; reading session state belongs in a route handler.

## Test plan

- [ ] `pnpm --filter @eventuras/web build` — green (verified locally)
- [ ] e2e admin event-create test passes against the test env after deploy
- [ ] Anonymous load of `/` still works (status endpoint returns `{authenticated: false}` for missing cookie)
- [ ] Authenticated user still sees their email in the header after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)