### PR TITLE
feat(api): make PowerOffice default sales account configurable per org

### DIFF
--- a/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeConstants.cs
+++ b/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeConstants.cs
@@ -7,4 +7,8 @@ internal static class PowerOfficeConstants
     internal const string ApplicationKeyDescription = "PowerOffice Application key";
     internal const string ClientKey = "POWER_OFFICE_CLIENT_KEY";
     internal const string ClientKeyDescription = "PowerOffice Client key";
+    internal const string DefaultSalesAccountKey = "POWER_OFFICE_DEFAULT_SALES_ACCOUNT";
+    internal const string DefaultSalesAccountDescription =
+        "Default sales account (kontokode) used when a product is first created in PowerOffice. Falls back to 3100 if unset.";
+    internal const int FallbackSalesAccount = 3100;
 }

--- a/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeService.cs
+++ b/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeService.cs
@@ -1,5 +1,6 @@
 #nullable enable annotations
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Eventuras.Services.Invoicing;
@@ -221,10 +222,31 @@ public class PowerOfficeService : IInvoicingProvider
                 Name = line.Description,
                 Description = line.ProductDescription,
                 SalesPrice = line.Price,
-                SalesAccount = 3100
+                SalesAccount = await ResolveDefaultSalesAccountAsync()
             };
             await api.Product.SaveAsync(product);
         }
+    }
+
+    private async Task<int> ResolveDefaultSalesAccountAsync()
+    {
+        var configured = await _organizationSettingsAccessorService
+            .GetOrganizationSettingByNameAsync(PowerOfficeConstants.DefaultSalesAccountKey);
+
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return PowerOfficeConstants.FallbackSalesAccount;
+        }
+
+        if (int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        _logger.LogWarning(
+            "Invalid value {Value} configured for {Key}; falling back to {Fallback}.",
+            configured, PowerOfficeConstants.DefaultSalesAccountKey, PowerOfficeConstants.FallbackSalesAccount);
+        return PowerOfficeConstants.FallbackSalesAccount;
     }
 
     private async Task CreateProductsIfNotExistsAsync(InvoiceInfo info)

--- a/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeSettingsRegistryComponent.cs
+++ b/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeSettingsRegistryComponent.cs
@@ -17,5 +17,11 @@ public class PowerOfficeSettingsRegistryComponent : IOrganizationSettingsRegistr
                 PowerOfficeConstants.SectionName,
                 PowerOfficeConstants.ClientKeyDescription,
                 OrganizationSettingType.String);
+
+        registry
+            .RegisterSetting(PowerOfficeConstants.DefaultSalesAccountKey,
+                PowerOfficeConstants.SectionName,
+                PowerOfficeConstants.DefaultSalesAccountDescription,
+                OrganizationSettingType.Number);
     }
 }

--- a/apps/api/src/Eventuras.Services.PowerOffice/README.md
+++ b/apps/api/src/Eventuras.Services.PowerOffice/README.md
@@ -4,33 +4,16 @@ This service provides integration with PowerOffice Go API for invoice management
 
 ## Features
 
--
-*
-*Email
-Invoicing
-**: Send invoices via email through PowerOffice
--
-*
-*EHF
-Invoicing
-**: Send electronic invoices (EHF) through PowerOffice
--
-*
-*Customer
-Management
-**: Automatically create or update customers in PowerOffice
--
-*
-*Product
-Management
-**: Automatically create products in PowerOffice if they don't exist
+- **Email Invoicing**: Send invoices via email through PowerOffice
+- **EHF Invoicing**: Send electronic invoices (EHF) through PowerOffice
+- **Customer Management**: Automatically create or update customers in PowerOffice
+- **Product Management**: Automatically create products in PowerOffice if they don't exist
 
 ## Configuration
 
 ### Feature Flag
 
-Enable PowerOffice in
-`appsettings.json`:
+Enable PowerOffice in `appsettings.json`:
 
 ```json
 {
@@ -42,16 +25,15 @@ Enable PowerOffice in
 
 ### Organization Settings
 
-PowerOffice credentials must be configured per organization through the organization settings interface:
+PowerOffice settings are configured per organization through the organization settings interface:
 
-| Setting Name              | Description                 |
-|---------------------------|-----------------------------|
-| `POWER_OFFICE_APP_KEY`    | PowerOffice Application Key |
-| `POWER_OFFICE_CLIENT_KEY` | PowerOffice Client Key      |
+| Setting Name                         | Type   | Description                                                                                                            |
+| ------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `POWER_OFFICE_APP_KEY`               | String | PowerOffice Application Key                                                                                            |
+| `POWER_OFFICE_CLIENT_KEY`            | String | PowerOffice Client Key                                                                                                 |
+| `POWER_OFFICE_DEFAULT_SALES_ACCOUNT` | Number | Default sales account (kontokode) assigned when a product is first created in PowerOffice. Defaults to `3100` if unset. |
 
-*
-*Note
-**: These settings are stored securely in the database per organization, not in configuration files.
+**Note**: These settings are stored securely in the database per organization, not in configuration files.
 
 ## Usage
 
@@ -59,38 +41,25 @@ PowerOffice credentials must be configured per organization through the organiza
 
 The service handles invoices for the following payment methods:
 
--
-`PaymentProvider.PowerOfficeEmailInvoice` - PDF invoice sent via email
--
-`PaymentProvider.PowerOfficeEHFInvoice` - Electronic invoice (EHF)
+- `PaymentProvider.PowerOfficeEmailInvoice` — PDF invoice sent via email
+- `PaymentProvider.PowerOfficeEHFInvoice` — Electronic invoice (EHF)
 
 ### Invoice Creation Flow
 
-1.
-*
-*Customer
-Lookup/Creation
-**
-  - Searches for existing customer by VAT number
-  - Falls back to search by email if VAT number not found
-  - Creates new customer if not found
+1. **Customer Lookup/Creation**
+   - Searches for existing customer by VAT number
+   - Falls back to search by email if VAT number not found
+   - Creates new customer if not found
 
-2.
-*
-*Product
-Creation
-**
-  - Creates products in PowerOffice if they don't exist
-  - Uses product codes to avoid duplicates
+2. **Product Creation**
+   - Creates products in PowerOffice if they don't exist (matched by product code)
+   - New products are assigned the sales account from `POWER_OFFICE_DEFAULT_SALES_ACCOUNT`, falling back to `3100` if the setting is missing or invalid
+   - Products that already exist in PowerOffice are left unchanged — the sales account on existing PowerOffice products is never overwritten
 
-3.
-*
-*Invoice
-Generation
-**
-  - Creates draft invoice in PowerOffice
-  - Links invoice to customer and products
-  - Returns invoice ID for tracking
+3. **Invoice Generation**
+   - Creates draft invoice in PowerOffice
+   - Links invoice to customer and products
+   - Returns invoice ID for tracking
 
 ### EHF Requirements
 
@@ -106,116 +75,52 @@ If EHF requirements are not met, PowerOffice will return a validation error that
 
 ### InvoicingException
 
-All PowerOffice validation and operational errors are wrapped in
-`InvoicingException` with the original error message from the PowerOffice SDK.
+All PowerOffice validation and operational errors are wrapped in `InvoicingException` with the original error message from the PowerOffice SDK.
 
-*
-*Example
-error
-messages:
-**
+**Example error messages:**
 
--
-_"
-Invoice
-validation
-failed:
-Organization
-no.
-12345678
-is
-not
-registered
-for
-EHF"_
--
-_"
-Invoice
-validation
-failed:
-Invalid
-VAT
-number
-format"_
--
-_"
-PowerOffice
-credentials
-not
-configured
-for
-this
-organization.
-Please
-configure
-POWER_OFFICE_APP_KEY
-and
-POWER_OFFICE_CLIENT_KEY
-in
-organization
-settings."_
+- _"Invoice validation failed: Organization no. 12345678 is not registered for EHF"_
+- _"Invoice validation failed: Invalid VAT number format"_
+- _"PowerOffice credentials not configured for this organization. Please configure POWER_OFFICE_APP_KEY and POWER_OFFICE_CLIENT_KEY in organization settings."_
 
-*
-*HTTP
-Response
-**:
-`400 Bad Request`## Development
+**HTTP Response**: `400 Bad Request`
+
+## Development
 
 ### Running Tests
 
 Tests for PowerOffice integration will only run if:
 
-1.
-`FeatureManagement:UsePowerOffice` is
-`true`
+1. `FeatureManagement:UsePowerOffice` is `true`
 2. Organization settings are configured with valid PowerOffice credentials
 
 ```bash
 dotnet test --filter "FullyQualifiedName~InvoicesControllerTest"
 ```
 
-*
-*Note
-**: Tests will be skipped if PowerOffice credentials are not configured in organization settings.
+**Note**: Tests will be skipped if PowerOffice credentials are not configured in organization settings.
 
 ### Debugging
 
 The service logs important events at different levels:
 
--
-*
-*Information
-**: Customer creation, API usage, successful operations
--
-*
-*Warning
-**: EHF validation failures, missing configurations
--
-*
-*Error
-**: API failures, exception details
+- **Information**: Customer creation, API usage, successful operations
+- **Warning**: EHF validation failures, missing configurations, invalid setting values
+- **Error**: API failures, exception details
 
 ## Architecture
 
 ### Service Dependencies
 
--
-`IOrganizationSettingsAccessorService` - Retrieves organization-specific settings from database
+- `IOrganizationSettingsAccessorService` — Retrieves organization-specific settings from database
 
 ### Configuration Priority
 
-PowerOffice credentials are
-*
-*only
-** loaded from organization settings. There is no fallback to global configuration files.
+PowerOffice credentials are **only** loaded from organization settings. There is no fallback to global configuration files.
 
 ## Security Notes
 
-⚠️
-*
-*Best
-Practice
-**: PowerOffice credentials are stored securely per organization in the database. This approach:
+⚠️ **Best Practice**: PowerOffice credentials are stored securely per organization in the database. This approach:
 
 - Prevents credentials from being committed to source control
 - Allows different organizations to use different PowerOffice accounts
@@ -226,8 +131,7 @@ Practice
 
 - [PowerOffice Go API Documentation](https://go.poweroffice.net/)
 - [EHF Documentation](https://www.anskaffelser.no/electronic-invoicing/about-ehf)
-- Organization Settings: See
-  `Eventuras.Services.Organizations.Settings`
+- Organization Settings: see `Eventuras.Services.Organizations.Settings`
 
 ## Support
 


### PR DESCRIPTION
## Summary
- Adds `POWER_OFFICE_DEFAULT_SALES_ACCOUNT` organization setting (number) under the existing PowerOffice section.
- `PowerOfficeService.CreateProductIfNotExistsAsync` now resolves the sales account from this setting, falling back to `3100` if unset. Existing orgs are unaffected.
- First step of two — follow-up PR will add a per-product `AccountingCode` override on the `Product` domain (used only at first product creation in PowerOffice).

## Test plan
- [ ] Set `POWER_OFFICE_DEFAULT_SALES_ACCOUNT = 3000` for an org with PowerOffice configured; generate an invoice for a product not yet in PowerOffice; verify the new product in PowerOffice gets sales account 3000.
- [ ] Leave the setting unset; verify behavior is unchanged (new products get 3100).
- [ ] Verify nothing changes for products already present in PowerOffice (sales account on existing PO products is never overwritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)