### PR TITLE
feat(api): add Eventuras.Libs.DocComposer for Fluid template rendering

### DIFF
--- a/.changeset/api-doc-composer.md
+++ b/.changeset/api-doc-composer.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/api': patch
+---
+
+Add `Eventuras.Libs.DocComposer` for rendering localized Liquid templates with Fluid. Provides a core `IDocumentComposer` for HTML output (intended for emails, certificates, invoices) and a thin `IEmailComposer` wrapper that derives subject and plain-text body.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -11,6 +11,7 @@ COPY ./src/common.props ./src/common.props
 # Copy all src csproj files
 COPY ./src/Eventuras.Domain/*.csproj ./src/Eventuras.Domain/
 COPY ./src/Eventuras.Infrastructure/*.csproj ./src/Eventuras.Infrastructure/
+COPY ./src/Eventuras.Libs.DocComposer/*.csproj ./src/Eventuras.Libs.DocComposer/
 COPY ./src/Eventuras.Libs.Pdf/*.csproj ./src/Eventuras.Libs.Pdf/
 COPY ./src/Eventuras.Services/*.csproj ./src/Eventuras.Services/
 COPY ./src/Eventuras.Services.Converto/*.csproj ./src/Eventuras.Services.Converto/
@@ -27,6 +28,7 @@ COPY ./src/Losol.Communication.Sms/*.csproj ./src/Losol.Communication.Sms/
 
 # Copy test csproj files
 COPY ./tests/TestProject.props ./tests/TestProject.props
+COPY ./tests/Eventuras.Libs.DocComposer.Tests/*.csproj ./tests/Eventuras.Libs.DocComposer.Tests/
 COPY ./tests/Eventuras.Libs.Pdf.Tests/*.csproj ./tests/Eventuras.Libs.Pdf.Tests/
 COPY ./tests/Eventuras.Services.Converto.Tests/*.csproj ./tests/Eventuras.Services.Converto.Tests/
 COPY ./tests/Eventuras.Services.Tests/*.csproj ./tests/Eventuras.Services.Tests/

--- a/apps/api/Eventuras.slnx
+++ b/apps/api/Eventuras.slnx
@@ -8,6 +8,7 @@
     <File Path=".editorconfig" />
     <Project Path="src/Eventuras.Domain/Eventuras.Domain.csproj" />
     <Project Path="src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj" />
+    <Project Path="src/Eventuras.Libs.DocComposer/Eventuras.Libs.DocComposer.csproj" />
     <Project Path="src/Eventuras.Libs.Pdf/Eventuras.Libs.Pdf.csproj" />
     <Project Path="src/Eventuras.Services.Converto/Eventuras.Services.Converto.csproj" />
     <Project Path="src/Eventuras.Services.PowerOffice/Eventuras.Services.PowerOffice.csproj" />
@@ -23,6 +24,7 @@
     <Project Path="src/Losol.Communication.Sms/Losol.Communication.Sms.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Eventuras.Libs.DocComposer.Tests/Eventuras.Libs.DocComposer.Tests.csproj" />
     <Project Path="tests/Eventuras.Libs.Pdf.Tests/Eventuras.Libs.Pdf.Tests.csproj" />
     <Project Path="tests/Eventuras.Services.Converto.Tests/Eventuras.Services.Converto.Tests.csproj" />
     <Project Path="tests/Eventuras.Services.Tests/Eventuras.Services.Tests.csproj" />

--- a/apps/api/src/Eventuras.Libs.DocComposer/DocComposerOptions.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/DocComposerOptions.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.FileProviders;
+
+namespace Eventuras.Libs.DocComposer;
+
+public sealed class DocComposerOptions
+{
+    public IFileProvider? TemplateFileProvider { get; set; }
+
+    public string DefaultLocale { get; set; } = "en";
+}

--- a/apps/api/src/Eventuras.Libs.DocComposer/Eventuras.Libs.DocComposer.csproj
+++ b/apps/api/src/Eventuras.Libs.DocComposer/Eventuras.Libs.DocComposer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../common.props" />
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <RootNamespace>Eventuras.Libs.DocComposer</RootNamespace>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Fluid.Core" Version="2.31.0" />
+    <PackageReference Include="AngleSharp" Version="1.4.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+  </ItemGroup>
+</Project>

--- a/apps/api/src/Eventuras.Libs.DocComposer/FluidDocumentComposer.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/FluidDocumentComposer.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Fluid;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+namespace Eventuras.Libs.DocComposer;
+
+public sealed class FluidDocumentComposer : IDocumentComposer
+{
+    private const string TemplateExtension = ".liquid";
+
+    private readonly DocComposerOptions _options;
+    private readonly string _normalizedDefaultLocale;
+    private readonly FluidParser _parser;
+    private readonly TemplateOptions _templateOptions;
+    private readonly ConcurrentDictionary<Type, byte> _registeredModelTypes = new();
+
+    public FluidDocumentComposer(IOptions<DocComposerOptions> options)
+    {
+        _options = options.Value;
+        if (_options.TemplateFileProvider is null)
+        {
+            throw new InvalidOperationException(
+                $"{nameof(DocComposerOptions.TemplateFileProvider)} must be configured.");
+        }
+
+        if (string.IsNullOrWhiteSpace(_options.DefaultLocale))
+        {
+            throw new InvalidOperationException(
+                $"{nameof(DocComposerOptions.DefaultLocale)} must be a non-empty value.");
+        }
+
+        _normalizedDefaultLocale = NormalizeLocale(_options.DefaultLocale);
+        _parser = new FluidParser();
+        _templateOptions = new TemplateOptions();
+    }
+
+    public async Task<RenderedDocument> ComposeAsync<TModel>(
+        string templateName,
+        TModel model,
+        string locale,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(templateName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+
+        var templateSource = await LoadTemplateSourceAsync(templateName, locale, cancellationToken);
+        var template = _parser.Parse(templateSource);
+
+        RegisterModelType(typeof(TModel));
+        var context = new TemplateContext(model, _templateOptions);
+        var html = await template.RenderAsync(context);
+
+        return new RenderedDocument(html);
+    }
+
+    private void RegisterModelType(Type modelType)
+    {
+        if (_registeredModelTypes.TryAdd(modelType, 0))
+        {
+            _templateOptions.MemberAccessStrategy.Register(modelType);
+        }
+    }
+
+    private async Task<string> LoadTemplateSourceAsync(string templateName, string locale, CancellationToken cancellationToken)
+    {
+        var fileProvider = _options.TemplateFileProvider!;
+        var normalizedLocale = NormalizeLocale(locale);
+
+        var primaryPath = BuildPath(templateName, normalizedLocale);
+        var primary = fileProvider.GetFileInfo(primaryPath);
+        if (primary.Exists)
+        {
+            return await ReadAllTextAsync(primary, cancellationToken);
+        }
+
+        if (!string.Equals(normalizedLocale, _normalizedDefaultLocale, StringComparison.Ordinal))
+        {
+            var fallbackPath = BuildPath(templateName, _normalizedDefaultLocale);
+            var fallback = fileProvider.GetFileInfo(fallbackPath);
+            if (fallback.Exists)
+            {
+                return await ReadAllTextAsync(fallback, cancellationToken);
+            }
+        }
+
+        throw new FileNotFoundException(
+            $"Template '{templateName}' not found for locale '{locale}' or default locale '{_options.DefaultLocale}'.",
+            primaryPath);
+    }
+
+    private static string NormalizeLocale(string locale) =>
+        locale.Trim().ToLowerInvariant();
+
+    private static string BuildPath(string templateName, string locale) =>
+        string.Create(CultureInfo.InvariantCulture, $"{templateName}.{locale}{TemplateExtension}");
+
+    private static async Task<string> ReadAllTextAsync(IFileInfo fileInfo, CancellationToken cancellationToken)
+    {
+        await using var stream = fileInfo.CreateReadStream();
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync(cancellationToken);
+    }
+}

--- a/apps/api/src/Eventuras.Libs.DocComposer/FluidEmailComposer.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/FluidEmailComposer.cs
@@ -1,0 +1,33 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Eventuras.Libs.DocComposer;
+
+public sealed class FluidEmailComposer : IEmailComposer
+{
+    private readonly IDocumentComposer _documentComposer;
+
+    public FluidEmailComposer(IDocumentComposer documentComposer)
+    {
+        _documentComposer = documentComposer;
+    }
+
+    public async Task<RenderedEmail> ComposeAsync<TModel>(
+        string templateName,
+        TModel model,
+        string locale,
+        CancellationToken cancellationToken = default)
+    {
+        var rendered = await _documentComposer.ComposeAsync(templateName, model, locale, cancellationToken);
+
+        var document = await BrowsingContext.New(Configuration.Default)
+            .OpenAsync(req => req.Content(rendered.Html), cancellationToken);
+        var subject = document.Title?.Trim() ?? string.Empty;
+        var bodyNode = document.Body ?? (INode)document.DocumentElement;
+        var textBody = PlainTextExtractor.ExtractFromNode(bodyNode);
+
+        return new RenderedEmail(subject, rendered.Html, textBody);
+    }
+}

--- a/apps/api/src/Eventuras.Libs.DocComposer/IDocumentComposer.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/IDocumentComposer.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Eventuras.Libs.DocComposer;
+
+public interface IDocumentComposer
+{
+    Task<RenderedDocument> ComposeAsync<TModel>(
+        string templateName,
+        TModel model,
+        string locale,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Eventuras.Libs.DocComposer/IEmailComposer.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/IEmailComposer.cs
@@ -1,0 +1,13 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Eventuras.Libs.DocComposer;
+
+public interface IEmailComposer
+{
+    Task<RenderedEmail> ComposeAsync<TModel>(
+        string templateName,
+        TModel model,
+        string locale,
+        CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Eventuras.Libs.DocComposer/PlainTextExtractor.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/PlainTextExtractor.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using AngleSharp;
+using AngleSharp.Dom;
+
+namespace Eventuras.Libs.DocComposer;
+
+public static class PlainTextExtractor
+{
+    private static readonly HashSet<string> SkippedTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "script", "style", "head", "title", "meta", "link", "noscript"
+    };
+
+    private static readonly HashSet<string> BlockTags = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "p", "div", "section", "article", "header", "footer", "main",
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        "ul", "ol", "table", "tr", "blockquote", "pre"
+    };
+
+    public static async Task<string> ExtractAsync(string? html, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+        {
+            return string.Empty;
+        }
+
+        var context = BrowsingContext.New(Configuration.Default);
+        var document = await context.OpenAsync(req => req.Content(html), cancellationToken);
+
+        INode root = document.Body ?? (INode)document.DocumentElement;
+        return ExtractFromNode(root);
+    }
+
+    public static string ExtractFromNode(INode node)
+    {
+        ArgumentNullException.ThrowIfNull(node);
+
+        var builder = new StringBuilder();
+        WriteNode(node, builder);
+        return Normalize(builder.ToString());
+    }
+
+    private static void WriteNode(INode node, StringBuilder sb)
+    {
+        switch (node.NodeType)
+        {
+            case NodeType.Text:
+                sb.Append(node.TextContent);
+                return;
+
+            case NodeType.Element:
+                WriteElement((IElement)node, sb);
+                return;
+
+            case NodeType.Document:
+            case NodeType.DocumentFragment:
+                foreach (var child in node.ChildNodes)
+                {
+                    WriteNode(child, sb);
+                }
+                return;
+        }
+    }
+
+    private static void WriteElement(IElement element, StringBuilder sb)
+    {
+        var tag = element.LocalName;
+
+        if (SkippedTags.Contains(tag))
+        {
+            return;
+        }
+
+        switch (tag)
+        {
+            case "br":
+                sb.Append('\n');
+                return;
+
+            case "hr":
+                EnsureNewline(sb);
+                sb.Append("---\n");
+                return;
+
+            case "a":
+                var hrefStart = sb.Length;
+                WriteChildren(element, sb);
+                var href = element.GetAttribute("href");
+                if (!string.IsNullOrWhiteSpace(href))
+                {
+                    var linkText = sb.ToString(hrefStart, sb.Length - hrefStart).Trim();
+                    if (!string.Equals(linkText, href, StringComparison.Ordinal))
+                    {
+                        sb.Append(" (").Append(href).Append(')');
+                    }
+                }
+                return;
+
+            case "img":
+                var alt = element.GetAttribute("alt");
+                if (!string.IsNullOrWhiteSpace(alt))
+                {
+                    sb.Append('[').Append(alt).Append(']');
+                }
+                return;
+
+            case "li":
+                EnsureNewline(sb);
+                sb.Append("- ");
+                WriteChildren(element, sb);
+                EnsureNewline(sb);
+                return;
+
+            case "td":
+            case "th":
+                WriteChildren(element, sb);
+                sb.Append('\t');
+                return;
+        }
+
+        if (BlockTags.Contains(tag))
+        {
+            EnsureNewline(sb);
+            WriteChildren(element, sb);
+            EnsureNewline(sb);
+            return;
+        }
+
+        WriteChildren(element, sb);
+    }
+
+    private static void WriteChildren(IElement element, StringBuilder sb)
+    {
+        foreach (var child in element.ChildNodes)
+        {
+            WriteNode(child, sb);
+        }
+    }
+
+    private static void EnsureNewline(StringBuilder sb)
+    {
+        if (sb.Length > 0 && sb[^1] != '\n')
+        {
+            sb.Append('\n');
+        }
+    }
+
+    private static string Normalize(string text)
+    {
+        var lines = text.Split('\n');
+        var builder = new StringBuilder();
+        var blankLines = 0;
+
+        foreach (var raw in lines)
+        {
+            var line = CollapseInlineWhitespace(raw).TrimEnd();
+            if (line.Length == 0)
+            {
+                blankLines++;
+                if (blankLines <= 1)
+                {
+                    builder.Append('\n');
+                }
+            }
+            else
+            {
+                blankLines = 0;
+                builder.Append(line).Append('\n');
+            }
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static string CollapseInlineWhitespace(string input)
+    {
+        var sb = new StringBuilder(input.Length);
+        var inWhitespace = false;
+        foreach (var c in input)
+        {
+            if (c is ' ' or '\t' or '\r')
+            {
+                if (!inWhitespace)
+                {
+                    sb.Append(' ');
+                    inWhitespace = true;
+                }
+            }
+            else
+            {
+                sb.Append(c);
+                inWhitespace = false;
+            }
+        }
+        return sb.ToString();
+    }
+}

--- a/apps/api/src/Eventuras.Libs.DocComposer/RenderedDocument.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/RenderedDocument.cs
@@ -1,0 +1,3 @@
+namespace Eventuras.Libs.DocComposer;
+
+public sealed record RenderedDocument(string Html);

--- a/apps/api/src/Eventuras.Libs.DocComposer/RenderedEmail.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/RenderedEmail.cs
@@ -1,0 +1,3 @@
+namespace Eventuras.Libs.DocComposer;
+
+public sealed record RenderedEmail(string Subject, string HtmlBody, string TextBody);

--- a/apps/api/src/Eventuras.Libs.DocComposer/ServiceCollectionExtensions.cs
+++ b/apps/api/src/Eventuras.Libs.DocComposer/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Eventuras.Libs.DocComposer;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddFluidDocComposer(
+        this IServiceCollection services,
+        Action<DocComposerOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        services.AddOptions<DocComposerOptions>()
+            .Configure(configure)
+            .Validate(o => o.TemplateFileProvider is not null,
+                $"{nameof(DocComposerOptions.TemplateFileProvider)} must be configured.")
+            .Validate(o => !string.IsNullOrWhiteSpace(o.DefaultLocale),
+                $"{nameof(DocComposerOptions.DefaultLocale)} must be a non-empty value.")
+            .ValidateOnStart();
+
+        services.AddSingleton<IDocumentComposer, FluidDocumentComposer>();
+        services.AddSingleton<IEmailComposer, FluidEmailComposer>();
+        return services;
+    }
+}

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Eventuras.Libs.DocComposer.Tests.csproj
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Eventuras.Libs.DocComposer.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <Import Project="..\TestProject.props" />
+
+    <PropertyGroup>
+        <PreserveCompilationContext>true</PreserveCompilationContext>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="10.0.6" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../../src/Eventuras.Libs.DocComposer/Eventuras.Libs.DocComposer.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="Templates\**\*.liquid">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/FluidDocumentComposerTest.cs
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/FluidDocumentComposerTest.cs
@@ -1,0 +1,104 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Eventuras.Libs.DocComposer.Tests;
+
+public class FluidDocumentComposerTest : IDisposable
+{
+    public sealed record WelcomeModel(string Name, string EventTitle, string Url);
+
+    private PhysicalFileProvider? _provider;
+
+    private FluidDocumentComposer CreateComposer(string defaultLocale = "en")
+    {
+        var templatesDir = Path.Combine(AppContext.BaseDirectory, "Templates");
+        _provider = new PhysicalFileProvider(templatesDir);
+        var options = Options.Create(new DocComposerOptions
+        {
+            TemplateFileProvider = _provider,
+            DefaultLocale = defaultLocale
+        });
+        return new FluidDocumentComposer(options);
+    }
+
+    public void Dispose()
+    {
+        _provider?.Dispose();
+    }
+
+    [Fact]
+    public async Task ComposeAsync_RendersTemplate_ReturnsHtml()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo Losen", "Spring Workshop", "https://example.com/event/1");
+
+        var result = await composer.ComposeAsync("welcome", model, "en");
+
+        Assert.Contains("<h1>Hello Leo Losen</h1>", result.Html);
+        Assert.Contains("Spring Workshop", result.Html);
+    }
+
+    [Fact]
+    public async Task ComposeAsync_PicksRequestedLocale_WhenBothExist()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo Losen", "Vårens kurs", "https://example.no");
+
+        var result = await composer.ComposeAsync("welcome", model, "no");
+
+        Assert.Contains("Hei Leo Losen", result.Html);
+        Assert.Contains("Takk for at du meldte deg på Vårens kurs", result.Html);
+    }
+
+    [Fact]
+    public async Task ComposeAsync_FallsBackToDefaultLocale_WhenRequestedLocaleMissing()
+    {
+        var composer = CreateComposer(defaultLocale: "en");
+        var model = new WelcomeModel("Leo", string.Empty, string.Empty);
+
+        var result = await composer.ComposeAsync("english-only", model, "no");
+
+        Assert.Contains("This template exists only in English", result.Html);
+    }
+
+    [Fact]
+    public async Task ComposeAsync_Throws_WhenTemplateNotFound()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo", string.Empty, string.Empty);
+
+        await Assert.ThrowsAsync<FileNotFoundException>(
+            () => composer.ComposeAsync("nonexistent", model, "en"));
+    }
+
+    [Fact]
+    public async Task ComposeAsync_MatchesTemplate_WhenLocaleCaseDiffers()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo Losen", "Spring Workshop", "https://example.com");
+
+        var result = await composer.ComposeAsync("welcome", model, "EN");
+
+        Assert.Contains("Hello Leo Losen", result.Html);
+    }
+
+    [Fact]
+    public void Constructor_Throws_WhenDefaultLocaleIsWhitespace()
+    {
+        var templatesDir = Path.Combine(AppContext.BaseDirectory, "Templates");
+        using var provider = new PhysicalFileProvider(templatesDir);
+        var options = Options.Create(new DocComposerOptions
+        {
+            TemplateFileProvider = provider,
+            DefaultLocale = "  "
+        });
+
+        Assert.Throws<InvalidOperationException>(() => new FluidDocumentComposer(options));
+    }
+}

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/FluidEmailComposerTest.cs
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/FluidEmailComposerTest.cs
@@ -1,0 +1,71 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Eventuras.Libs.DocComposer.Tests;
+
+public class FluidEmailComposerTest : IDisposable
+{
+    public sealed record WelcomeModel(string Name, string EventTitle, string Url);
+
+    private PhysicalFileProvider? _provider;
+
+    private FluidEmailComposer CreateComposer()
+    {
+        var templatesDir = Path.Combine(AppContext.BaseDirectory, "Templates");
+        _provider = new PhysicalFileProvider(templatesDir);
+        var options = Options.Create(new DocComposerOptions
+        {
+            TemplateFileProvider = _provider,
+            DefaultLocale = "en"
+        });
+        var documentComposer = new FluidDocumentComposer(options);
+        return new FluidEmailComposer(documentComposer);
+    }
+
+    public void Dispose()
+    {
+        _provider?.Dispose();
+    }
+
+    [Fact]
+    public async Task ComposeAsync_ExtractsSubjectFromTitle()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo Losen", "Spring Workshop", "https://example.com/event/1");
+
+        var result = await composer.ComposeAsync("welcome", model, "en");
+
+        Assert.Equal("Welcome, Leo Losen!", result.Subject);
+    }
+
+    [Fact]
+    public async Task ComposeAsync_ReturnsHtmlBody_FromDocumentComposer()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo Losen", "Spring Workshop", "https://example.com/event/1");
+
+        var result = await composer.ComposeAsync("welcome", model, "en");
+
+        Assert.Contains("<h1>Hello Leo Losen</h1>", result.HtmlBody);
+    }
+
+    [Fact]
+    public async Task ComposeAsync_DerivesPlainTextBody_FromRenderedHtml()
+    {
+        var composer = CreateComposer();
+        var model = new WelcomeModel("Leo Losen", "Spring Workshop", "https://example.com/event/1");
+
+        var result = await composer.ComposeAsync("welcome", model, "en");
+
+        Assert.Contains("Hello Leo Losen", result.TextBody);
+        Assert.Contains("click here (https://example.com/event/1)", result.TextBody);
+        Assert.DoesNotContain("<h1>", result.TextBody);
+        Assert.DoesNotContain("<p>", result.TextBody);
+    }
+}

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/PlainTextExtractorTest.cs
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/PlainTextExtractorTest.cs
@@ -1,0 +1,76 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Eventuras.Libs.DocComposer.Tests;
+
+public class PlainTextExtractorTest
+{
+    [Fact]
+    public async Task ExtractAsync_PreservesLinkUrl_WhenDifferentFromText()
+    {
+        var html = """<p>Click <a href="https://example.com/page">here</a> to continue.</p>""";
+
+        var text = await PlainTextExtractor.ExtractAsync(html);
+
+        Assert.Contains("here (https://example.com/page)", text);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_OmitsLinkUrl_WhenSameAsText()
+    {
+        var html = """<a href="https://example.com">https://example.com</a>""";
+
+        var text = await PlainTextExtractor.ExtractAsync(html);
+
+        Assert.Equal("https://example.com", text);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_KeepsImageAltText_WhenPresent()
+    {
+        var html = """<img src="x.png" alt="Logo" />""";
+
+        var text = await PlainTextExtractor.ExtractAsync(html);
+
+        Assert.Equal("[Logo]", text);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_StripsScriptAndStyle()
+    {
+        var html = "<style>p { color: red; }</style><script>alert('x')</script><p>Visible</p>";
+
+        var text = await PlainTextExtractor.ExtractAsync(html);
+
+        Assert.Equal("Visible", text);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_FormatsListItems_WithDashPrefix()
+    {
+        var html = "<ul><li>One</li><li>Two</li></ul>";
+
+        var text = await PlainTextExtractor.ExtractAsync(html);
+
+        Assert.Contains("- One", text);
+        Assert.Contains("- Two", text);
+    }
+
+    [Fact]
+    public async Task ExtractAsync_ReturnsEmpty_WhenHtmlIsNullOrWhitespace()
+    {
+        Assert.Equal(string.Empty, await PlainTextExtractor.ExtractAsync(string.Empty));
+        Assert.Equal(string.Empty, await PlainTextExtractor.ExtractAsync(null));
+        Assert.Equal(string.Empty, await PlainTextExtractor.ExtractAsync("   "));
+    }
+
+    [Fact]
+    public async Task ExtractAsync_CollapsesRepeatedWhitespace()
+    {
+        var html = "<p>Hello     world</p>";
+
+        var text = await PlainTextExtractor.ExtractAsync(html);
+
+        Assert.Equal("Hello world", text);
+    }
+}

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Templates/english-only.en.liquid
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Templates/english-only.en.liquid
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>English only</title>
+</head>
+<body>
+  <p>This template exists only in English.</p>
+</body>
+</html>

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Templates/welcome.en.liquid
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Templates/welcome.en.liquid
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Welcome, {{ Name }}!</title>
+</head>
+<body>
+  <h1>Hello {{ Name }}</h1>
+  <p>Thanks for joining {{ EventTitle }}.</p>
+  <p>See details: <a href="{{ Url }}">click here</a></p>
+</body>
+</html>

--- a/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Templates/welcome.no.liquid
+++ b/apps/api/tests/Eventuras.Libs.DocComposer.Tests/Templates/welcome.no.liquid
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+  <title>Velkommen, {{ Name }}!</title>
+</head>
+<body>
+  <h1>Hei {{ Name }}</h1>
+  <p>Takk for at du meldte deg på {{ EventTitle }}.</p>
+  <p>Se detaljer: <a href="{{ Url }}">klikk her</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New standalone library `Eventuras.Libs.DocComposer` for rendering localized Liquid templates with Fluid.
- Core `IDocumentComposer` returns rendered HTML, suitable for emails, certificates, invoices, and other document outputs.
- Templates are loaded per locale via `IFileProvider` with convention `{name}.{locale}.liquid` and fall back to the configured default locale when the requested one is missing. Locale lookup is case-insensitive.
- Thin `IEmailComposer` wrapper layers email-specific concerns on top: subject extracted from rendered `<title>`, plain-text body derived via an AngleSharp-based extractor (handles links with hrefs, images with alt, lists, scripts/styles stripped, whitespace collapsed).
- Uses Fluid's default `MemberAccessStrategy` with per-model-type registration on first use, so templates can only read properties on the models they're rendered with.
- DI extension `AddFluidDocComposer(...)` registers both composers with options validation that fails fast on host startup. Test project covers rendering, locale fallback, locale casing, configuration validation, email subject/text extraction, and plain-text extractor edge cases.

## Scope of this PR
Infrastructure only — neither composer is wired into a sending flow yet.

## Test plan
- [x] `dotnet test` for the new test project — 16/16 passing locally
- [x] CI: full solution build with the new projects added to `Eventuras.slnx`
- [x] CI: Docker build with `Eventuras.Libs.DocComposer` csproj copied in restore layer