### PR TITLE
feat(api): add embedded Liquid templates for course certificates

### DIFF
--- a/.changeset/api-cert-liquid-foundation.md
+++ b/.changeset/api-cert-liquid-foundation.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/api': patch
+---
+
+Add embedded Liquid templates for course certificates (`course-certificate.no.liquid`, `course-certificate.en.liquid`) and wire `Eventuras.Libs.DocComposer` into `Eventuras.Services`. Foundation for the upcoming DocComposer-based certificate renderer; no production code uses it yet.

--- a/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.en.liquid
+++ b/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.en.liquid
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Certificate of Completion</title>
+  <link
+    href="https://fonts.googleapis.com/css?family=Material+Icons|Reenie+Beanie|Carrois+Gothic+SC|Libre+Baskerville"
+    rel="stylesheet"/>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Carrois Gothic SC';
+      font-weight: 500;
+      font-size: 16px;
+      background: rgb(241, 241, 241);
+      -webkit-print-color-adjust: exact;
+      box-sizing: border-box;
+    }
+
+    .page {
+      position: relative;
+      height: 297mm;
+      width: 210mm;
+      text-align: center;
+      display: block;
+      background: #fff;
+      color: black;
+      page-break-after: auto;
+      margin: 50px;
+      overflow: hidden;
+    }
+
+    @media print {
+      html, body {
+        font-size: 10px;
+      }
+
+      body {
+        background: #fff;
+      }
+
+      .page {
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    }
+
+    .page.first {
+      border-left: 5px solid green;
+    }
+
+    .bottom {
+      position: absolute;
+      left: 5mm;
+      right: 5mm;
+      bottom: 5mm;
+    }
+
+    .group {
+      padding: 3mm 25mm;
+      margin: 5mm;
+    }
+
+    .line {
+      position: relative;
+    }
+
+    .keep-lines {
+      white-space: pre-line;
+    }
+
+    .center {
+      text-align: center;
+    }
+
+    .logo {
+      padding: 3mm;
+    }
+
+    .w-100 { width: 100%; }
+    .w-75 { width: 75%; }
+    .w-66 { width: 66%; }
+    .w-50 { width: 50%; }
+    .w-33 { width: 33%; }
+    .w-25 { width: 25%; }
+
+    .handwriting {
+      font-size: 24px;
+      font-family: 'Reenie Beanie';
+      padding-bottom: 0;
+      text-decoration: underline;
+    }
+
+    .featured {
+      padding: 15mm 0 10mm 0;
+      background-color: #336699;
+      color: white;
+    }
+
+    .title { font-size: 32px }
+    .subtitle { font-size: 28px }
+
+    .text {
+      font-family: 'Libre Baskerville', serif;
+      font-size: 14px
+    }
+
+    .light { color: #555 }
+  </style>
+</head>
+<body>
+<div class="page">
+  <div class="featured">
+    <div class="line title">Certificate of Completion</div>
+    <div class="line subtitle">{{ Title }}</div>
+  </div>
+
+  <div class="group">
+    <div class="line">Awarded to</div>
+    <div class="subtitle">{{ RecipientName }}</div>
+  </div>
+
+  <div class="group">
+    {% if EvidenceDescription %}
+      <p class="line">For participation in {{ EvidenceDescription }}</p>
+    {% endif %}
+    <br/>
+    {% if Comment %}
+      <p class="line">{{ Comment }}</p>
+      <br/>
+    {% endif %}
+  </div>
+
+  {% if Description %}
+    <div class="group">
+      <p class="line keep-lines">{{ Description }}</p>
+    </div>
+  {% endif %}
+
+  {% if IssuerOrganizationName %}
+    <div class="group">
+      <div class="logo">
+        {% if IssuerOrganizationLogoDataUri %}
+          <img src="{{ IssuerOrganizationLogoDataUri }}" alt="Logo" class="center w-50"/>
+        {% endif %}
+      </div>
+      <div class="line">
+        Organized by {{ IssuerOrganizationName }}
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="group">
+    <div class="line">{{ IssuedInCity }} {{ IssuedDate }}</div>
+
+    {% if IssuerPersonSignatureDataUri %}
+      <div class="center">
+        <img src="{{ IssuerPersonSignatureDataUri }}" class="w-33" alt="Signature"/>
+      </div>
+    {% else %}
+      <div class="line handwriting">{{ IssuerPersonName }}</div>
+    {% endif %}
+    <div class="line">{{ IssuerPersonName }}</div>
+    <div class="line">
+      Course leader<br/>
+      <br/>
+      <br/>
+      <small>Digitally signed with code <br/>
+        <code>{{ Uuid }}</code></small>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.no.liquid
+++ b/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.no.liquid
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+  <meta charset="utf-8">
+  <title>Kursbevis</title>
+  <link
+    href="https://fonts.googleapis.com/css?family=Material+Icons|Reenie+Beanie|Carrois+Gothic+SC|Libre+Baskerville"
+    rel="stylesheet"/>
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      font-family: 'Carrois Gothic SC';
+      font-weight: 500;
+      font-size: 16px;
+      background: rgb(241, 241, 241);
+      -webkit-print-color-adjust: exact;
+      box-sizing: border-box;
+    }
+
+    .page {
+      position: relative;
+      height: 297mm;
+      width: 210mm;
+      text-align: center;
+      display: block;
+      background: #fff;
+      color: black;
+      page-break-after: auto;
+      margin: 50px;
+      overflow: hidden;
+    }
+
+    @media print {
+      html, body {
+        font-size: 10px;
+      }
+
+      body {
+        background: #fff;
+      }
+
+      .page {
+        margin: 0;
+        height: 100%;
+        width: 100%;
+      }
+    }
+
+    .page.first {
+      border-left: 5px solid green;
+    }
+
+    .bottom {
+      position: absolute;
+      left: 5mm;
+      right: 5mm;
+      bottom: 5mm;
+    }
+
+    .group {
+      padding: 3mm 25mm;
+      margin: 5mm;
+    }
+
+    .line {
+      position: relative;
+    }
+
+    .keep-lines {
+      white-space: pre-line;
+    }
+
+    .center {
+      text-align: center;
+    }
+
+    .logo {
+      padding: 3mm;
+    }
+
+    .w-100 { width: 100%; }
+    .w-75 { width: 75%; }
+    .w-66 { width: 66%; }
+    .w-50 { width: 50%; }
+    .w-33 { width: 33%; }
+    .w-25 { width: 25%; }
+
+    .handwriting {
+      font-size: 24px;
+      font-family: 'Reenie Beanie';
+      padding-bottom: 0;
+      text-decoration: underline;
+    }
+
+    .featured {
+      padding: 15mm 0 10mm 0;
+      background-color: #336699;
+      color: white;
+    }
+
+    .title { font-size: 32px }
+    .subtitle { font-size: 28px }
+
+    .text {
+      font-family: 'Libre Baskerville', serif;
+      font-size: 14px
+    }
+
+    .light { color: #555 }
+  </style>
+</head>
+<body>
+<div class="page">
+  <div class="featured">
+    <div class="line title">Kursbevis</div>
+    <div class="line subtitle">{{ Title }}</div>
+  </div>
+
+  <div class="group">
+    <div class="line">Tildelt</div>
+    <div class="subtitle">{{ RecipientName }}</div>
+  </div>
+
+  <div class="group">
+    {% if EvidenceDescription %}
+      <p class="line">For deltakelse på {{ EvidenceDescription }}</p>
+    {% endif %}
+    <br/>
+    {% if Comment %}
+      <p class="line">{{ Comment }}</p>
+      <br/>
+    {% endif %}
+  </div>
+
+  {% if Description %}
+    <div class="group">
+      <p class="line keep-lines">{{ Description }}</p>
+    </div>
+  {% endif %}
+
+  {% if IssuerOrganizationName %}
+    <div class="group">
+      <div class="logo">
+        {% if IssuerOrganizationLogoDataUri %}
+          <img src="{{ IssuerOrganizationLogoDataUri }}" alt="Logo" class="center w-50"/>
+        {% endif %}
+      </div>
+      <div class="line">
+        Arrangert av {{ IssuerOrganizationName }}
+      </div>
+    </div>
+  {% endif %}
+
+  <div class="group">
+    <div class="line">{{ IssuedInCity }} {{ IssuedDate }}</div>
+
+    {% if IssuerPersonSignatureDataUri %}
+      <div class="center">
+        <img src="{{ IssuerPersonSignatureDataUri }}" class="w-33" alt="Signatur"/>
+      </div>
+    {% else %}
+      <div class="line handwriting">{{ IssuerPersonName }}</div>
+    {% endif %}
+    <div class="line">{{ IssuerPersonName }}</div>
+    <div class="line">
+      Kursansvarlig<br/>
+      <br/>
+      <br/>
+      <small>Digitalt signert med kode <br/>
+        <code>{{ Uuid }}</code></small>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/apps/api/src/Eventuras.Services/Eventuras.Services.csproj
+++ b/apps/api/src/Eventuras.Services/Eventuras.Services.csproj
@@ -13,14 +13,22 @@
   <ItemGroup>
     <ProjectReference Include="..\Eventuras.Domain\Eventuras.Domain.csproj" />
     <ProjectReference Include="..\Eventuras.Infrastructure\Eventuras.Infrastructure.csproj" />
+    <ProjectReference Include="..\Eventuras.Libs.DocComposer\Eventuras.Libs.DocComposer.csproj" />
     <ProjectReference Include="..\Eventuras.Libs.Pdf\Eventuras.Libs.Pdf.csproj" />
     <ProjectReference Include="..\..\src\Losol.Communication.Email\Losol.Communication.Email.csproj" />
     <ProjectReference Include="..\..\src\Losol.Communication.Sms\Losol.Communication.Sms.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="10.0.6" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
     <PackageReference Include="Markdig" Version="1.1.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- WithCulture=false: prevent MSBuild from treating ".no"/".en" as satellite-assembly culture suffixes -->
+    <EmbeddedResource Include="Certificates\Templates\*.liquid">
+      <WithCulture>false</WithCulture>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Views\Shared\Templates\Certificates\">

--- a/apps/api/tests/Eventuras.Services.Tests/Certificates/CourseCertificateTemplateTest.cs
+++ b/apps/api/tests/Eventuras.Services.Tests/Certificates/CourseCertificateTemplateTest.cs
@@ -1,0 +1,118 @@
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Eventuras.Libs.DocComposer;
+using Eventuras.Services.Certificates;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Eventuras.Services.Tests.Certificates;
+
+public class CourseCertificateTemplateTest
+{
+    private const string TemplateName = "course-certificate";
+
+    private sealed record SampleModel(
+        string Title,
+        string RecipientName,
+        string? EvidenceDescription,
+        string? Comment,
+        string? Description,
+        string? IssuerOrganizationName,
+        string? IssuerOrganizationLogoDataUri,
+        string IssuedInCity,
+        string IssuedDate,
+        string? IssuerPersonSignatureDataUri,
+        string IssuerPersonName,
+        string Uuid);
+
+    private static FluidDocumentComposer CreateComposer()
+    {
+        // Plain EmbeddedFileProvider rather than ManifestEmbeddedFileProvider:
+        // the manifest target collapses ".no"/".en" into a single resource path even with WithCulture=false.
+        var provider = new EmbeddedFileProvider(
+            typeof(CertificateViewModel).Assembly,
+            "Eventuras.Services.Certificates.Templates");
+        var options = Options.Create(new DocComposerOptions
+        {
+            TemplateFileProvider = provider,
+            DefaultLocale = "no"
+        });
+        return new FluidDocumentComposer(options);
+    }
+
+    private static SampleModel CreateSampleModel() => new(
+        Title: "Avansert Fluid-templating",
+        RecipientName: "Leo Losen",
+        EvidenceDescription: "Workshop på Eventuras 2026",
+        Comment: null,
+        Description: null,
+        IssuerOrganizationName: "Eventuras AS",
+        IssuerOrganizationLogoDataUri: null,
+        IssuedInCity: "Oslo",
+        IssuedDate: "15.05.2026",
+        IssuerPersonSignatureDataUri: null,
+        IssuerPersonName: "Kursansvarlig Hansen",
+        Uuid: Guid.NewGuid().ToString());
+
+    [Fact]
+    public async Task NorwegianTemplate_RendersWithExpectedFields()
+    {
+        var composer = CreateComposer();
+        var model = CreateSampleModel();
+
+        var rendered = await composer.ComposeAsync(TemplateName, model, "no");
+
+        Assert.Contains("<title>Kursbevis</title>", rendered.Html);
+        Assert.Contains("Kursbevis", rendered.Html);
+        Assert.Contains(model.Title, rendered.Html);
+        Assert.Contains(model.RecipientName, rendered.Html);
+        Assert.Contains("For deltakelse på " + model.EvidenceDescription, rendered.Html);
+        Assert.Contains("Arrangert av " + model.IssuerOrganizationName, rendered.Html);
+        Assert.Contains(model.IssuedInCity, rendered.Html);
+        Assert.Contains(model.IssuedDate, rendered.Html);
+        Assert.Contains(model.IssuerPersonName, rendered.Html);
+        Assert.Contains(model.Uuid, rendered.Html);
+    }
+
+    [Fact]
+    public async Task EnglishTemplate_RendersWithExpectedFields()
+    {
+        var composer = CreateComposer();
+        var model = CreateSampleModel();
+
+        var rendered = await composer.ComposeAsync(TemplateName, model, "en");
+
+        Assert.Contains("<title>Certificate of Completion</title>", rendered.Html);
+        Assert.Contains("Certificate of Completion", rendered.Html);
+        Assert.Contains("Awarded to", rendered.Html);
+        Assert.Contains("For participation in " + model.EvidenceDescription, rendered.Html);
+        Assert.Contains("Organized by " + model.IssuerOrganizationName, rendered.Html);
+        Assert.Contains("Course leader", rendered.Html);
+        Assert.Contains(model.RecipientName, rendered.Html);
+    }
+
+    [Fact]
+    public async Task OptionalSections_AreHidden_WhenFieldsAreNull()
+    {
+        var composer = CreateComposer();
+        var model = CreateSampleModel() with
+        {
+            EvidenceDescription = null,
+            Comment = null,
+            Description = null,
+            IssuerOrganizationName = null,
+            IssuerOrganizationLogoDataUri = null,
+            IssuerPersonSignatureDataUri = null
+        };
+
+        var rendered = await composer.ComposeAsync(TemplateName, model, "no");
+
+        Assert.DoesNotContain("For deltakelse på", rendered.Html);
+        Assert.DoesNotContain("Arrangert av", rendered.Html);
+        Assert.DoesNotContain("<img", rendered.Html);
+        Assert.Contains("handwriting", rendered.Html);
+    }
+}


### PR DESCRIPTION
## Summary
- New `Eventuras.Libs.DocComposer` ProjectReference in `Eventuras.Services`, with `Microsoft.Extensions.FileProviders.Embedded` package added.
- Embedded Liquid templates `course-certificate.no.liquid` and `course-certificate.en.liquid` under `apps/api/src/Eventuras.Services/Certificates/Templates/`, included via `<EmbeddedResource WithCulture=false>` to keep the locale suffix intact (without `WithCulture=false` MSBuild treats `.no`/`.en` as satellite-assembly culture suffixes and collapses both files into a single resource).
- Verify test (`CourseCertificateTemplateTest`) loads the templates via `EmbeddedFileProvider` and renders them with `FluidDocumentComposer` + a sample record, asserting that both locale variants emit the expected fields and that optional sections are hidden when null.

## Scope of this PR
Foundation only — neither the Liquid renderer nor any DI wiring is added. Existing Razor flow (`CertificateRenderer` + `Templates/Certificates/CourseCertificate.cshtml`) is untouched.

## Follow-ups
- PR 2: `CourseCertificateModel` + `LiquidCertificateRenderer` (standalone class, not registered)
- PR 3: swap `ICertificateRenderer` implementation, add `locale` param, delete the Razor template

## Test plan
- [x] `dotnet test` for `Eventuras.Services.Tests` — 62/62 passing locally (3 new)
- [ ] CI: full solution build with the new embedded resources in `Eventuras.Services`