### PR TITLE
feat(api): add LiquidCertificateRenderer for course certificates

### DIFF
--- a/.changeset/api-cert-liquid-renderer.md
+++ b/.changeset/api-cert-liquid-renderer.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/api': patch
+---
+
+Add `LiquidCertificateRenderer` (standalone, not yet registered) along with `CourseCertificateModel` and `CourseCertificateModelMapper`. Renderer composes the embedded Liquid templates from PR #1502 with `CertificateViewModel` data and produces HTML + PDF via `IPdfRenderService`. Wiring into `ICertificateRenderer` follows in the next PR.

--- a/apps/api/src/Eventuras.Services/Certificates/CourseCertificateModel.cs
+++ b/apps/api/src/Eventuras.Services/Certificates/CourseCertificateModel.cs
@@ -1,0 +1,17 @@
+#nullable enable
+
+namespace Eventuras.Services.Certificates;
+
+public sealed record CourseCertificateModel(
+    string Title,
+    string RecipientName,
+    string? EvidenceDescription,
+    string? Comment,
+    string? Description,
+    string? IssuerOrganizationName,
+    string? IssuerOrganizationLogoDataUri,
+    string IssuedInCity,
+    string IssuedDate,
+    string? IssuerPersonSignatureDataUri,
+    string IssuerPersonName,
+    string Uuid);

--- a/apps/api/src/Eventuras.Services/Certificates/CourseCertificateModelMapper.cs
+++ b/apps/api/src/Eventuras.Services/Certificates/CourseCertificateModelMapper.cs
@@ -1,0 +1,45 @@
+#nullable enable
+
+using System;
+using System.Globalization;
+using NodaTime.Text;
+
+namespace Eventuras.Services.Certificates;
+
+public static class CourseCertificateModelMapper
+{
+    public static CourseCertificateModel FromViewModel(CertificateViewModel viewModel, string locale)
+    {
+        ArgumentNullException.ThrowIfNull(viewModel);
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+
+        var culture = MapLocaleToCulture(locale);
+        var datePattern = LocalDatePattern.Create("dd.MM.yyyy", culture);
+
+        return new CourseCertificateModel(
+            Title: viewModel.Title ?? string.Empty,
+            RecipientName: viewModel.RecipientName ?? string.Empty,
+            EvidenceDescription: viewModel.EvidenceDescription,
+            Comment: viewModel.Comment,
+            Description: viewModel.Description,
+            IssuerOrganizationName: viewModel.IssuerOrganizationName,
+            IssuerOrganizationLogoDataUri: viewModel.IssuerOrganizationLogoBase64,
+            IssuedInCity: viewModel.IssuedInCity ?? string.Empty,
+            IssuedDate: datePattern.Format(viewModel.IssuingDate),
+            IssuerPersonSignatureDataUri: viewModel.IssuerPersonSignatureImageBase64,
+            IssuerPersonName: viewModel.IssuerPersonName ?? string.Empty,
+            Uuid: viewModel.Uuid.ToString());
+    }
+
+    private static CultureInfo MapLocaleToCulture(string locale)
+    {
+        try
+        {
+            return CultureInfo.GetCultureInfo(locale);
+        }
+        catch (CultureNotFoundException)
+        {
+            return CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/apps/api/src/Eventuras.Services/Certificates/LiquidCertificateRenderer.cs
+++ b/apps/api/src/Eventuras.Services/Certificates/LiquidCertificateRenderer.cs
@@ -1,0 +1,81 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Eventuras.Libs.DocComposer;
+using Eventuras.Libs.Pdf;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+namespace Eventuras.Services.Certificates;
+
+internal sealed class LiquidCertificateRenderer
+{
+    private const string TemplateName = "course-certificate";
+    private const string DefaultLocale = "no";
+    private const string TemplateBaseNamespace = "Eventuras.Services.Certificates.Templates";
+
+    private readonly IDocumentComposer _documentComposer;
+    private readonly IPdfRenderService _pdfRenderService;
+
+    public LiquidCertificateRenderer(IPdfRenderService pdfRenderService)
+    {
+        ArgumentNullException.ThrowIfNull(pdfRenderService);
+        _pdfRenderService = pdfRenderService;
+        _documentComposer = CreateDocumentComposer();
+    }
+
+    public async Task<string> RenderToHtmlAsStringAsync(
+        CertificateViewModel viewModel,
+        string locale,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(viewModel);
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+
+        var templateLocale = NormalizeToTemplateLocale(locale);
+        var model = CourseCertificateModelMapper.FromViewModel(viewModel, locale);
+        var rendered = await _documentComposer.ComposeAsync(TemplateName, model, templateLocale, cancellationToken);
+        return rendered.Html;
+    }
+
+    // Collapse regional tags (en-US, nb-NO, ...) to the language root and pick the closest
+    // available template locale. Unknown languages pass through so DocComposer can fall back
+    // to its configured default.
+    private static string NormalizeToTemplateLocale(string locale)
+    {
+        var lang = locale.Split('-')[0].ToLowerInvariant();
+        return lang switch
+        {
+            "no" or "nb" or "nn" => "no",
+            "en" => "en",
+            _ => locale
+        };
+    }
+
+    public async Task<Stream> RenderToPdfAsStreamAsync(
+        CertificateViewModel viewModel,
+        string locale,
+        CancellationToken cancellationToken = default)
+    {
+        var html = await RenderToHtmlAsStringAsync(viewModel, locale, cancellationToken);
+        return await _pdfRenderService.GeneratePdfFromHtml(html,
+            new PdfOptions { PaperSize = PaperSize.A4, Scale = 0.8f });
+    }
+
+    private static FluidDocumentComposer CreateDocumentComposer()
+    {
+        // Plain EmbeddedFileProvider rather than ManifestEmbeddedFileProvider:
+        // the manifest target collapses ".no"/".en" into a single resource path even with WithCulture=false.
+        var provider = new EmbeddedFileProvider(
+            typeof(CertificateViewModel).Assembly,
+            TemplateBaseNamespace);
+        return new FluidDocumentComposer(Options.Create(new DocComposerOptions
+        {
+            TemplateFileProvider = provider,
+            DefaultLocale = DefaultLocale
+        }));
+    }
+}

--- a/apps/api/tests/Eventuras.Services.Tests/Certificates/CourseCertificateModelMapperTest.cs
+++ b/apps/api/tests/Eventuras.Services.Tests/Certificates/CourseCertificateModelMapperTest.cs
@@ -1,0 +1,125 @@
+#nullable enable
+
+using System;
+using Eventuras.Domain;
+using Eventuras.Services.Certificates;
+using NodaTime;
+using Xunit;
+
+namespace Eventuras.Services.Tests.Certificates;
+
+public class CourseCertificateModelMapperTest
+{
+    private static CertificateViewModel CreateViewModel(Action<Certificate>? customize = null)
+    {
+        var certificate = new Certificate
+        {
+            Uuid = Guid.Parse("01234567-89ab-7cde-9012-3456789abcde"),
+            Title = "Avansert Fluid-templating",
+            Description = "Et omfattende kurs",
+            Comment = "Gjennomført med stort engasjement",
+            RecipientName = "Leo Losen",
+            EvidenceDescription = "Workshop på Eventuras 2026",
+            IssuingOrganizationName = "Eventuras AS",
+            IssuedByName = "Kursansvarlig Hansen",
+            IssuedInCity = "Oslo",
+            IssuedDate = new LocalDate(2026, 5, 15)
+        };
+        customize?.Invoke(certificate);
+        return new CertificateViewModel(certificate);
+    }
+
+    [Fact]
+    public void FromViewModel_CopiesAllPlainStringFields()
+    {
+        var viewModel = CreateViewModel();
+
+        var model = CourseCertificateModelMapper.FromViewModel(viewModel, "no");
+
+        Assert.Equal("Avansert Fluid-templating", model.Title);
+        Assert.Equal("Leo Losen", model.RecipientName);
+        Assert.Equal("Workshop på Eventuras 2026", model.EvidenceDescription);
+        Assert.Equal("Gjennomført med stort engasjement", model.Comment);
+        Assert.Equal("Et omfattende kurs", model.Description);
+        Assert.Equal("Eventuras AS", model.IssuerOrganizationName);
+        Assert.Equal("Oslo", model.IssuedInCity);
+        Assert.Equal("Kursansvarlig Hansen", model.IssuerPersonName);
+        Assert.Equal("01234567-89ab-7cde-9012-3456789abcde", model.Uuid);
+    }
+
+    [Fact]
+    public void FromViewModel_FormatsDate_UsingNorwegianCulture_ForNo()
+    {
+        var viewModel = CreateViewModel();
+
+        var model = CourseCertificateModelMapper.FromViewModel(viewModel, "no");
+
+        Assert.Equal("15.05.2026", model.IssuedDate);
+    }
+
+    [Fact]
+    public void FromViewModel_FormatsDate_UsingEnglishCulture_ForEn()
+    {
+        var viewModel = CreateViewModel();
+
+        var model = CourseCertificateModelMapper.FromViewModel(viewModel, "en");
+
+        Assert.Equal("15.05.2026", model.IssuedDate);
+    }
+
+    [Fact]
+    public void FromViewModel_ReturnsEmptyStrings_ForNullRequiredFields()
+    {
+        var viewModel = CreateViewModel(c =>
+        {
+            c.Title = null!;
+            c.RecipientName = null!;
+            c.IssuedInCity = null!;
+            c.IssuedByName = null!;
+        });
+
+        var model = CourseCertificateModelMapper.FromViewModel(viewModel, "no");
+
+        Assert.Equal(string.Empty, model.Title);
+        Assert.Equal(string.Empty, model.RecipientName);
+        Assert.Equal(string.Empty, model.IssuedInCity);
+        Assert.Equal(string.Empty, model.IssuerPersonName);
+    }
+
+    [Fact]
+    public void FromViewModel_PassesThroughNulls_ForOptionalFields()
+    {
+        var viewModel = CreateViewModel(c =>
+        {
+            c.EvidenceDescription = null;
+            c.Comment = null;
+            c.Description = null;
+            c.IssuingOrganizationName = null;
+        });
+
+        var model = CourseCertificateModelMapper.FromViewModel(viewModel, "no");
+
+        Assert.Null(model.EvidenceDescription);
+        Assert.Null(model.Comment);
+        Assert.Null(model.Description);
+        Assert.Null(model.IssuerOrganizationName);
+        Assert.Null(model.IssuerOrganizationLogoDataUri);
+        Assert.Null(model.IssuerPersonSignatureDataUri);
+    }
+
+    [Fact]
+    public void FromViewModel_Throws_WhenViewModelIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            CourseCertificateModelMapper.FromViewModel(null!, "no"));
+    }
+
+    [Fact]
+    public void FromViewModel_Throws_WhenLocaleIsWhitespace()
+    {
+        var viewModel = CreateViewModel();
+
+        Assert.Throws<ArgumentException>(() =>
+            CourseCertificateModelMapper.FromViewModel(viewModel, "  "));
+    }
+}

--- a/apps/api/tests/Eventuras.Services.Tests/Certificates/LiquidCertificateRendererTest.cs
+++ b/apps/api/tests/Eventuras.Services.Tests/Certificates/LiquidCertificateRendererTest.cs
@@ -1,0 +1,163 @@
+#nullable enable
+
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Eventuras.Domain;
+using Eventuras.Libs.Pdf;
+using Eventuras.Services.Certificates;
+using Moq;
+using NodaTime;
+using Xunit;
+
+namespace Eventuras.Services.Tests.Certificates;
+
+public class LiquidCertificateRendererTest
+{
+    private static CertificateViewModel CreateViewModel() =>
+        new(new Certificate
+        {
+            Uuid = Guid.Parse("01234567-89ab-7cde-9012-3456789abcde"),
+            Title = "Avansert Fluid-templating",
+            RecipientName = "Leo Losen",
+            EvidenceDescription = "Workshop på Eventuras 2026",
+            IssuingOrganizationName = "Eventuras AS",
+            IssuedByName = "Kursansvarlig Hansen",
+            IssuedInCity = "Oslo",
+            IssuedDate = new LocalDate(2026, 5, 15)
+        });
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_NorwegianLocale_RendersWithExpectedFields()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+
+        var html = await renderer.RenderToHtmlAsStringAsync(viewModel, "no");
+
+        Assert.Contains("Kursbevis", html);
+        Assert.Contains("Avansert Fluid-templating", html);
+        Assert.Contains("Leo Losen", html);
+        Assert.Contains("For deltakelse på Workshop på Eventuras 2026", html);
+        Assert.Contains("Arrangert av Eventuras AS", html);
+        Assert.Contains("Oslo", html);
+        Assert.Contains("15.05.2026", html);
+        Assert.Contains("Kursansvarlig Hansen", html);
+        Assert.Contains("01234567-89ab-7cde-9012-3456789abcde", html);
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_EnglishLocale_RendersEnglishCopy()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+
+        var html = await renderer.RenderToHtmlAsStringAsync(viewModel, "en");
+
+        Assert.Contains("Certificate of Completion", html);
+        Assert.Contains("Awarded to", html);
+        Assert.Contains("For participation in Workshop på Eventuras 2026", html);
+        Assert.Contains("Organized by Eventuras AS", html);
+        Assert.Contains("Course leader", html);
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_UnknownLocale_FallsBackToDefaultNorwegianTemplate()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+
+        var html = await renderer.RenderToHtmlAsStringAsync(viewModel, "fr");
+
+        Assert.Contains("Kursbevis", html);
+    }
+
+    [Fact]
+    public async Task RenderToPdfAsStreamAsync_PassesRenderedHtml_ToPdfRenderService()
+    {
+        var pdfBytes = Encoding.UTF8.GetBytes("%PDF-1.4");
+        string? capturedHtml = null;
+        var pdfRenderService = new Mock<IPdfRenderService>();
+        pdfRenderService
+            .Setup(x => x.GeneratePdfFromHtml(It.IsAny<string>(), It.IsAny<PdfOptions>()))
+            .Callback<string, PdfOptions>((html, _) => capturedHtml = html)
+            .ReturnsAsync(new MemoryStream(pdfBytes));
+
+        var renderer = new LiquidCertificateRenderer(pdfRenderService.Object);
+        var viewModel = CreateViewModel();
+
+        await using var pdfStream = await renderer.RenderToPdfAsStreamAsync(viewModel, "no");
+
+        Assert.NotNull(capturedHtml);
+        Assert.Contains("Kursbevis", capturedHtml);
+        Assert.Contains("Leo Losen", capturedHtml);
+
+        using var reader = new BinaryReader(pdfStream);
+        var actualBytes = reader.ReadBytes(pdfBytes.Length);
+        Assert.Equal(pdfBytes, actualBytes);
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_NormalizesRegionalLocale_EnUS_ToEnglishTemplate()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+
+        var html = await renderer.RenderToHtmlAsStringAsync(viewModel, "en-US");
+
+        Assert.Contains("Certificate of Completion", html);
+        Assert.DoesNotContain("Kursbevis", html);
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_NormalizesRegionalLocale_NbNO_ToNorwegianTemplate()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+
+        var html = await renderer.RenderToHtmlAsStringAsync(viewModel, "nb-NO");
+
+        Assert.Contains("Kursbevis", html);
+        Assert.DoesNotContain("Certificate of Completion", html);
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_Throws_WhenViewModelIsNull()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            renderer.RenderToHtmlAsStringAsync(null!, "no"));
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_Throws_WhenLocaleIsWhitespace()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            renderer.RenderToHtmlAsStringAsync(viewModel, "  "));
+    }
+
+    [Fact]
+    public void Constructor_Throws_WhenPdfRenderServiceIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new LiquidCertificateRenderer(null!));
+    }
+
+    [Fact]
+    public async Task RenderToHtmlAsStringAsync_AcceptsCancellationToken()
+    {
+        var renderer = new LiquidCertificateRenderer(Mock.Of<IPdfRenderService>());
+        var viewModel = CreateViewModel();
+        using var cts = new CancellationTokenSource();
+
+        var html = await renderer.RenderToHtmlAsStringAsync(viewModel, "no", cts.Token);
+
+        Assert.Contains("Kursbevis", html);
+    }
+}


### PR DESCRIPTION
## Summary
- New `CourseCertificateModel` record tailored for Liquid templates (pre-formatted date string, data-URI images).
- New `CourseCertificateModelMapper.FromViewModel(CertificateViewModel, locale)` that handles locale → culture mapping (`no`/`nb` → `nb-NO`, `nn` → `nn-NO`, `en` → `en-US`, fallback to invariant) and formats the issuing date with `NodaTime.Text.LocalDatePattern`.
- New `LiquidCertificateRenderer` (internal) with `RenderToHtmlAsStringAsync(viewModel, locale, ct)` and `RenderToPdfAsStreamAsync(viewModel, locale, ct)` — composes the embedded Liquid templates from #1502 via `IDocumentComposer` and routes HTML through the existing `IPdfRenderService` for PDF output.
- Tests cover all-field mapping, locale-driven date formatting, null handling, end-to-end HTML rendering for both `no` and `en`, default-locale fallback for unknown locales, and the PDF path with a mocked `IPdfRenderService`.

## Scope of this PR
Standalone class only — `LiquidCertificateRenderer` does NOT implement `ICertificateRenderer` and is not registered in DI. Existing Razor `CertificateRenderer` is untouched.

## Follow-ups
- PR 3: swap `ICertificateRenderer` implementation to the Liquid renderer, add `locale` param to the interface, update callers, delete `CourseCertificate.cshtml` + decouple from `ViewRenderService`.

## Test plan
- [x] `dotnet test` for `Eventuras.Services.Tests` — 77/77 passing locally (15 new)
- [ ] CI: full solution build