### PR TITLE
feat(api): bind certificate default locale to appsettings

### DIFF
--- a/.changeset/api-cert-locale-config.md
+++ b/.changeset/api-cert-locale-config.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/api': patch
+---
+
+Add a `Certificates:DefaultLocale` setting (defaults to `nb-NO`) bound to `CertificateOptions` so the certificate renderer's default locale can be configured from `appsettings.json` without code changes. The two certificate controllers and the background worker now read it via `IOptions<CertificateOptions>` instead of a hardcoded value.

--- a/apps/api/src/Eventuras.Services/BackgroundJobs/CertificateBackgroundWorker.cs
+++ b/apps/api/src/Eventuras.Services/BackgroundJobs/CertificateBackgroundWorker.cs
@@ -8,6 +8,7 @@ using Losol.Communication.Email;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Eventuras.Services.BackgroundJobs;
 
@@ -74,6 +75,7 @@ public sealed class CertificateBackgroundWorker : BackgroundService
     {
         var certificateRetrievalService = serviceProvider.GetRequiredService<ICertificateRetrievalService>();
         var certificateRenderer = serviceProvider.GetRequiredService<ICertificateRenderer>();
+        var certificateOptions = serviceProvider.GetRequiredService<IOptions<CertificateOptions>>().Value;
         var emailSender = serviceProvider.GetRequiredService<IEmailSender>();
 
         var certificate = await certificateRetrievalService.GetCertificateByIdAsync(
@@ -87,9 +89,8 @@ public sealed class CertificateBackgroundWorker : BackgroundService
             return;
         }
 
-        // TODO: derive locale from registration user preference / org default instead of hardcoded "nb"
         await using var pdfStream = await certificateRenderer
-            .RenderToPdfAsStreamAsync(new CertificateViewModel(certificate), "nb", cancellationToken);
+            .RenderToPdfAsStreamAsync(new CertificateViewModel(certificate), certificateOptions.DefaultLocale, cancellationToken);
 
         if (pdfStream == null)
         {

--- a/apps/api/src/Eventuras.Services/Certificates/CertificateOptions.cs
+++ b/apps/api/src/Eventuras.Services/Certificates/CertificateOptions.cs
@@ -1,0 +1,10 @@
+#nullable enable
+
+namespace Eventuras.Services.Certificates;
+
+public sealed class CertificateOptions
+{
+    public const string SectionName = "Certificates";
+
+    public string DefaultLocale { get; set; } = "nb-NO";
+}

--- a/apps/api/src/Eventuras.Services/Certificates/CertificateServiceCollectionExtensions.cs
+++ b/apps/api/src/Eventuras.Services/Certificates/CertificateServiceCollectionExtensions.cs
@@ -6,6 +6,9 @@ public static class CertificateServiceCollectionExtensions
 {
     public static IServiceCollection AddCertificateServices(this IServiceCollection services)
     {
+        services.AddOptions<CertificateOptions>()
+            .BindConfiguration(CertificateOptions.SectionName);
+
         services.AddTransient<ICertificateAccessControlService, CertificateAccessControlService>();
         services.AddTransient<ICertificateIssuingService, CertificateIssuingService>();
         services.AddTransient<ICertificateRetrievalService, CertificateRetrievalService>();

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Certificates/CertificatesController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Certificates/CertificatesController.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
 
 namespace Eventuras.WebApi.Controllers.v3.Certificates;
@@ -22,16 +23,19 @@ public class CertificatesController : ControllerBase
 {
     private readonly ICertificateRenderer _certificateRenderer;
     private readonly ICertificateRetrievalService _certificateRetrievalService;
+    private readonly IOptions<CertificateOptions> _certificateOptions;
     private readonly ILogger<CertificatesController> _logger;
 
     public CertificatesController(
         ICertificateRetrievalService certificateRetrievalService,
         ICertificateRenderer certificateRenderer,
+        IOptions<CertificateOptions> certificateOptions,
         ILogger<CertificatesController> logger)
     {
         _certificateRetrievalService = certificateRetrievalService ??
                                        throw new ArgumentNullException(nameof(certificateRetrievalService));
         _certificateRenderer = certificateRenderer ?? throw new ArgumentNullException(nameof(certificateRenderer));
+        _certificateOptions = certificateOptions ?? throw new ArgumentNullException(nameof(certificateOptions));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -51,16 +55,14 @@ public class CertificatesController : ControllerBase
                 return Ok(new CertificateDto(cert));
 
             case CertificateFormat.Html:
-                // TODO: derive locale from Accept-Language / user preference / org default instead of hardcoded "nb"
                 var html = await _certificateRenderer
-                    .RenderToHtmlAsStringAsync(new CertificateViewModel(cert), "nb");
+                    .RenderToHtmlAsStringAsync(new CertificateViewModel(cert), _certificateOptions.Value.DefaultLocale);
                 return Content(html, MediaTypeNames.Text.Html);
 
             case CertificateFormat.Pdf:
                 try
                 {
-                    // TODO: derive locale from Accept-Language / user preference / org default instead of hardcoded "nb"
-                    var stream = await _certificateRenderer.RenderToPdfAsStreamAsync(new CertificateViewModel(cert), "nb");
+                    var stream = await _certificateRenderer.RenderToPdfAsStreamAsync(new CertificateViewModel(cert), _certificateOptions.Value.DefaultLocale);
                     var memoryStream = new MemoryStream();
                     await stream.CopyToAsync(memoryStream);
                     return File(memoryStream.ToArray(), MediaTypeNames.Application.Pdf);

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/Certificates/EventCertificatesController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/Certificates/EventCertificatesController.cs
@@ -12,6 +12,7 @@ using Eventuras.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Eventuras.WebApi.Controllers.v3.Events.Certificates;
 
@@ -25,6 +26,7 @@ public class EventCertificatesController : ControllerBase
     private readonly ICertificateIssuingService _certificateIssuingService;
     private readonly ICertificateRenderer _certificateRenderer;
     private readonly ICertificateRetrievalService _certificateRetrievalService;
+    private readonly IOptions<CertificateOptions> _certificateOptions;
     private readonly IEventInfoAccessControlService _eventInfoAccessControlService;
     private readonly IEventInfoRetrievalService _eventInfoRetrievalService;
     private readonly ILogger<EventCertificatesController> _logger;
@@ -32,6 +34,7 @@ public class EventCertificatesController : ControllerBase
     public EventCertificatesController(
         IEventInfoRetrievalService eventInfoRetrievalService,
         ICertificateRenderer certificateRenderer,
+        IOptions<CertificateOptions> certificateOptions,
         ICertificateIssuingService certificateIssuingService,
         ICertificateDeliveryService certificateDeliveryService,
         IEventInfoAccessControlService eventInfoAccessControlService,
@@ -43,6 +46,9 @@ public class EventCertificatesController : ControllerBase
 
         _certificateRenderer = certificateRenderer ?? throw
             new ArgumentNullException(nameof(certificateRenderer));
+
+        _certificateOptions = certificateOptions ?? throw
+            new ArgumentNullException(nameof(certificateOptions));
 
         _certificateIssuingService = certificateIssuingService ?? throw
             new ArgumentNullException(nameof(certificateIssuingService));
@@ -100,9 +106,8 @@ public class EventCertificatesController : ControllerBase
                 EventInfoRetrievalOptions.ForCertificateRendering,
                 cancellationToken);
 
-        // TODO: derive locale from Accept-Language / user preference / org default instead of hardcoded "nb"
         var html = await _certificateRenderer
-            .RenderToHtmlAsStringAsync(new CertificateViewModel(eventInfo), "nb", cancellationToken);
+            .RenderToHtmlAsStringAsync(new CertificateViewModel(eventInfo), _certificateOptions.Value.DefaultLocale, cancellationToken);
 
         return Content(html, MediaTypeNames.Text.Html);
     }

--- a/apps/api/src/Eventuras.WebApi/appsettings.json
+++ b/apps/api/src/Eventuras.WebApi/appsettings.json
@@ -7,6 +7,9 @@
     "AllowedOrigins": "",
     "TimeZone": "Europe/Oslo"
   },
+  "Certificates": {
+    "DefaultLocale": "nb-NO"
+  },
   "FeatureManagement": {
     "UsePowerOffice": true,
     "UseStripeInvoice": false,


### PR DESCRIPTION
## Summary
- New `CertificateOptions` (in `Eventuras.Services.Certificates`) bound to the `Certificates` section in `appsettings.json` via `BindConfiguration`, defaulting to `DefaultLocale = "nb-NO"`.
- `CertificateBackgroundWorker`, `CertificatesController` (HTML + PDF branches), and `EventCertificatesController.Preview` now read the locale through `IOptions<CertificateOptions>` instead of a hardcoded `"nb"`.
- `appsettings.json` gets a `Certificates: { DefaultLocale: "nb-NO" }` section so ops can change the default without a code change.

## Notes
- `nb-NO` is the BCP 47-precise tag for Bokmål-in-Norway. The renderer's `NormalizeToTemplateLocale` strips the region (`nb-NO` → `nb`) when looking up the template, while the mapper's `CultureInfo.GetCultureInfo("nb-NO")` keeps the regional culture for date formatting — so we get more precise locale handling without renaming any templates.
- Per-request locale (Accept-Language / user preference / org default) is the next step. This PR just moves the default out of code.

## Test plan
- [x] `dotnet build Eventuras.slnx` clean
- [x] `Eventuras.Services.Tests` — 81/81
- [x] `Eventuras.WebApi.Tests` — 742/742 (2 pre-existing skips)
- [ ] CI: full solution build + Docker