### PR TITLE
fix(core): default formatDate to Europe/Oslo timezone

### DIFF
--- a/.changeset/core-format-date-default-timezone.md
+++ b/.changeset/core-format-date-default-timezone.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/core': patch
+---
+
+Default `formatDate`/`formatDateSpan`/`formatCompactDateRange` to `Europe/Oslo` time zone so SSR (server clock, typically UTC) and client hydration (user device) produce identical date strings. Fixes React hydration error #418 on event pages for users whose device time zone differs from the server's. Override via the new `timeZone` option (or `timeZone` argument on `formatCompactDateRange`) when a different zone is needed.

--- a/libs/core/src/datetime/formatDate.ts
+++ b/libs/core/src/datetime/formatDate.ts
@@ -1,11 +1,18 @@
 interface FormatDateOptions {
   locale?: string;
   showTime?: boolean;
+  timeZone?: string;
 }
+
+// Default IANA time zone for formatted dates. Hardcoded to the project's
+// operational time zone so SSR (server clock, typically UTC) and client
+// hydration (user device) produce identical strings. Override via
+// FormatDateOptions.timeZone where needed.
+const DEFAULT_TIME_ZONE = 'Europe/Oslo';
 
 const formatDate = (
   date: string | Date,
-  { locale = 'en-US', showTime = false }: FormatDateOptions = {}
+  { locale = 'en-US', showTime = false, timeZone = DEFAULT_TIME_ZONE }: FormatDateOptions = {}
 ): string => {
   if (!date) {
     return '';
@@ -15,11 +22,13 @@ const formatDate = (
     year: 'numeric',
     month: 'numeric',
     day: 'numeric',
+    timeZone,
   };
 
   const timeOptions: Intl.DateTimeFormatOptions = {
     hour: '2-digit',
     minute: '2-digit',
+    timeZone,
   };
 
   const parsedDate = new Date(date);
@@ -64,16 +73,17 @@ const formatDateSpan = (
 const formatCompactDateRange = (
   startDate: string | Date | null | undefined,
   endDate: string | Date | null | undefined,
-  locale = 'en-US'
+  locale = 'en-US',
+  timeZone: string = DEFAULT_TIME_ZONE
 ): string => {
   if (!startDate) return '';
 
   const start = new Date(startDate);
   const end = endDate ? new Date(endDate) : null;
 
-  const dayMonthFmt = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short' });
-  const dayFmt = new Intl.DateTimeFormat(locale, { day: 'numeric' });
-  const yearFmt = new Intl.DateTimeFormat(locale, { year: 'numeric' });
+  const dayMonthFmt = new Intl.DateTimeFormat(locale, { day: 'numeric', month: 'short', timeZone });
+  const dayFmt = new Intl.DateTimeFormat(locale, { day: 'numeric', timeZone });
+  const yearFmt = new Intl.DateTimeFormat(locale, { year: 'numeric', timeZone });
 
   // Pull the locale-formatted day number without any trailing punctuation
   // (some locales — e.g. nb-NO — append "." after the day; we add our own
@@ -87,9 +97,29 @@ const formatCompactDateRange = (
     return startLabel;
   }
 
-  const sameMonth =
-    start.getFullYear() === end.getFullYear() && start.getMonth() === end.getMonth();
-  const sameYear = start.getFullYear() === end.getFullYear();
+  // Compare year/month/day in the configured time zone, not the runtime's
+  // local zone — otherwise an event that starts late on day N in Europe/Oslo
+  // can be classified as same-month/same-year against day N+1 in UTC.
+  const ymdInZoneFmt = new Intl.DateTimeFormat('en-US', {
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    timeZone,
+  });
+  const partsInZone = (date: Date) => {
+    const lookup = Object.fromEntries(
+      ymdInZoneFmt.formatToParts(date).map(p => [p.type, p.value])
+    );
+    return {
+      year: Number(lookup.year),
+      month: Number(lookup.month),
+    };
+  };
+
+  const startParts = partsInZone(start);
+  const endParts = partsInZone(end);
+  const sameMonth = startParts.year === endParts.year && startParts.month === endParts.month;
+  const sameYear = startParts.year === endParts.year;
 
   if (sameMonth) {
     return `${dayPart(start)}.–${dayMonthFmt.format(end)}`.toUpperCase();


### PR DESCRIPTION
## Summary
Fixes a production React hydration error #418 on event pages by making `formatDate`, `formatDateSpan`, and `formatCompactDateRange` time-zone-aware.

## Root cause
The `Intl.DateTimeFormat` calls inside these three formatters ran with the runtime's local time zone — UTC inside the container during SSR, the user's device zone during client hydration. For event dates that straddle the day boundary (e.g. `2026-03-25T22:00:00Z` is March 25 in UTC but March 26 in Europe/Oslo), the server and the client produced different strings, and React 19's stricter hydration surfaced the divergence as #418. iOS dominates the reported events only because that's the most common device on the affected URLs — the bug applies to any client whose zone differs from the server's.

## Change
- Add a `timeZone` option to `FormatDateOptions` and a `timeZone` argument to `formatCompactDateRange`, both defaulting to `Europe/Oslo`.
- Apply the zone to all `Intl.DateTimeFormatOptions` so date and time formatting are deterministic across SSR/CSR.
- Fix the `sameMonth`/`sameYear` comparison in `formatCompactDateRange` to read the year/month parts in the configured zone instead of via `Date.prototype.getMonth`/`getFullYear` (which still read from the runtime's local zone).

## Notes
- 15 call sites across `apps/web`, `apps/historia`, and `libs/notitia-templates` inherit the new default automatically.
- Override `timeZone` per call when a different zone is needed.

## Test plan
- [x] `pnpm --filter @eventuras/core build` clean
- [ ] CI: full lint + build
- [ ] Smoke check: open an event page on iOS Safari, confirm the date renders without console-side hydration errors