### PR TITLE
fix(web): skip Sentry client init for known crawler user agents

### DIFF
--- a/.changeset/web-skip-sentry-for-bots.md
+++ b/.changeset/web-skip-sentry-for-bots.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Skip Sentry client-side initialisation when `navigator.userAgent` matches a known crawler (detected via the new `isBot` helper from `@eventuras/core/useragents`). Crawlers produce ChunkLoadError and hydration noise that's not actionable; suppressing the SDK at init time keeps those events out of the error tracker without affecting real users.

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -1,5 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
+import { isBot } from '@eventuras/core/useragents';
+
 import type { SentryClientConfig } from '@/providers/sentry';
 
 declare global {
@@ -9,8 +11,11 @@ declare global {
 }
 
 const config = typeof window === 'undefined' ? undefined : window.__SENTRY_CONFIG__;
+const userAgent = typeof navigator === 'undefined' ? undefined : navigator.userAgent;
 
-if (config?.dsn) {
+if (isBot(userAgent)) {
+  console.log('[Sentry] Client-side disabled (bot user agent detected)');
+} else if (config?.dsn) {
   Sentry.init({
     dsn: config.dsn,
     enableLogs: true,


### PR DESCRIPTION
## Summary
Skip `Sentry.init` when `navigator.userAgent` matches a known crawler so bots never get a Sentry session and never report client-side errors. Detection delegates to the new `isBot` helper from `@eventuras/core/useragents` (introduced in #1513), which uses the vendored isbot pattern list.

## Why
A crawler triggered a `ChunkLoadError` that landed in the error tracker — not actionable, since bots request stale or partial assets and do not execute JavaScript the way Sentry expects. Filtering at SDK init time (rather than via dashboard inbound filters or `ignoreErrors: ['ChunkLoadError']`) means we drop the noise at source while keeping all real-user signal — including any genuine chunk-load issue from a real client.

## Notes
- Stacked on top of #1513. Merge that one first.
- Server-side and edge Sentry configs are unchanged.

## Test plan
- [x] `pnpm install` + `tsc --noEmit` clean
- [ ] CI: full lint + build
- [ ] Smoke check: open the production site, confirm \`[Sentry] Client-side initialized successfully\` still logs for a normal browser