### PR TITLE
fix(api): make course certificate PDF fill A4 with readable text

### DIFF
--- a/.changeset/api-cert-pdf-rendering.md
+++ b/.changeset/api-cert-pdf-rendering.md
@@ -1,0 +1,9 @@
+---
+'@eventuras/api': patch
+---
+
+Make the course certificate PDF fill the A4 page with readable text. Three changes:
+
+- `LiquidCertificateRenderer` now renders at `Scale = 1.0` (was `0.8f`), so content is no longer shrunk to ~80% of the paper with a gray band below it.
+- Both Liquid templates drop the `@media print` block and apply its rules as defaults — Converto's headless-Chrome render does not always trigger print media, which left the screen-only gray background and the small `font-size: 10px` showing through.
+- Base font is `14px` (was `16px`) so body text reads cleanly at the new scale on A4 without crowding the page.

--- a/apps/api/src/Eventuras.Services/Certificates/LiquidCertificateRenderer.cs
+++ b/apps/api/src/Eventuras.Services/Certificates/LiquidCertificateRenderer.cs
@@ -65,7 +65,7 @@ internal sealed class LiquidCertificateRenderer : ICertificateRenderer
     {
         var html = await RenderToHtmlAsStringAsync(viewModel, locale, cancellationToken);
         return await _pdfRenderService.GeneratePdfFromHtml(html,
-            new PdfOptions { PaperSize = PaperSize.A4, Scale = 0.8f });
+            new PdfOptions { PaperSize = PaperSize.A4, Scale = 1.0f });
     }
 
     private static FluidDocumentComposer CreateDocumentComposer()

--- a/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.en.liquid
+++ b/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.en.liquid
@@ -12,39 +12,22 @@
       padding: 0;
       font-family: 'Carrois Gothic SC';
       font-weight: 500;
-      font-size: 16px;
-      background: rgb(241, 241, 241);
+      font-size: 14px;
+      background: #fff;
       -webkit-print-color-adjust: exact;
       box-sizing: border-box;
     }
 
     .page {
       position: relative;
-      height: 297mm;
-      width: 210mm;
+      height: 100%;
+      width: 100%;
       text-align: center;
       display: block;
       background: #fff;
       color: black;
       page-break-after: auto;
-      margin: 50px;
       overflow: hidden;
-    }
-
-    @media print {
-      html, body {
-        font-size: 10px;
-      }
-
-      body {
-        background: #fff;
-      }
-
-      .page {
-        margin: 0;
-        height: 100%;
-        width: 100%;
-      }
     }
 
     .page.first {

--- a/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.nb.liquid
+++ b/apps/api/src/Eventuras.Services/Certificates/Templates/course-certificate.nb.liquid
@@ -12,39 +12,22 @@
       padding: 0;
       font-family: 'Carrois Gothic SC';
       font-weight: 500;
-      font-size: 16px;
-      background: rgb(241, 241, 241);
+      font-size: 14px;
+      background: #fff;
       -webkit-print-color-adjust: exact;
       box-sizing: border-box;
     }
 
     .page {
       position: relative;
-      height: 297mm;
-      width: 210mm;
+      height: 100%;
+      width: 100%;
       text-align: center;
       display: block;
       background: #fff;
       color: black;
       page-break-after: auto;
-      margin: 50px;
       overflow: hidden;
-    }
-
-    @media print {
-      html, body {
-        font-size: 10px;
-      }
-
-      body {
-        background: #fff;
-      }
-
-      .page {
-        margin: 0;
-        height: 100%;
-        width: 100%;
-      }
     }
 
     .page.first {


### PR DESCRIPTION
## Summary
Fixes two visual regressions on the generated course certificate PDF: the body text was too small to read at a normal A4 zoom, and the bottom ~20% of the paper was a gray strip below the certificate content.

## Changes
- `LiquidCertificateRenderer` now passes `Scale = 1.0` (was `0.8f`) to `IPdfRenderService`, so the rendered content fills the paper instead of being shrunk to ~80% with a blank band at the bottom.
- Both Liquid templates drop the `@media print` block and apply its rules as defaults. Converto's headless-Chrome render does not reliably trigger print media, so the screen-only gray body background (`rgb(241,241,241)`) and the tiny print `font-size: 10px` were not being overridden as intended. Folding those rules into the defaults makes the template render identically regardless of media-query handling.
- Base font is `14px` (was `16px`) — a touch smaller than browser-default so body lines read cleanly at the new full scale on A4 without crowding the page.

The blue header still spans the paper edge to edge by design; body-text horizontal margins continue to come from the existing `.group { padding: 3mm 25mm }`.

## Test plan
- [x] `dotnet test` for `Eventuras.Services.Tests` — 81/81 passing
- [ ] CI: full solution build
- [ ] Smoke check: issue a certificate via the production preview endpoint and confirm the PDF fills the page and reads cleanly at default zoom