### PR TITLE
feat(api): render certificate delivery email via DocComposer

### DIFF
--- a/.changeset/api-cert-delivery-email-templates.md
+++ b/.changeset/api-cert-delivery-email-templates.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/api': patch
+---
+
+Render the certificate-delivery email through DocComposer/`IEmailComposer` instead of the hardcoded Norwegian `Subject = "Kursbevis for {Title}"` and `TextBody = "Her er kursbeviset! Gratulere!"` strings in `CertificateBackgroundWorker`. Adds `certificate-delivery.{nb,en}.liquid` embedded templates, a `CertificateDeliveryEmailModel` record, and a small `CertificateDeliveryEmailRenderer` that wraps `FluidEmailComposer` and pulls subject from `<title>` plus a derived plain-text alternative. The outgoing email now also includes an HTML body (it was text-only before).

--- a/apps/api/src/Eventuras.Services.Certificates/CertificateBackgroundWorker.cs
+++ b/apps/api/src/Eventuras.Services.Certificates/CertificateBackgroundWorker.cs
@@ -75,6 +75,7 @@ public sealed class CertificateBackgroundWorker : BackgroundService
     {
         var certificateRetrievalService = serviceProvider.GetRequiredService<ICertificateRetrievalService>();
         var certificateRenderer = serviceProvider.GetRequiredService<ICertificateRenderer>();
+        var deliveryEmailRenderer = serviceProvider.GetRequiredService<CertificateDeliveryEmailRenderer>();
         var certificateOptions = serviceProvider.GetRequiredService<IOptions<CertificateOptions>>().Value;
         var emailSender = serviceProvider.GetRequiredService<IEmailSender>();
 
@@ -109,11 +110,17 @@ public sealed class CertificateBackgroundWorker : BackgroundService
 
         memoryStream.Position = 0;
 
+        var deliveryEmail = await deliveryEmailRenderer.RenderAsync(
+            new CertificateDeliveryEmailModel(certificate.Title, certificate.RecipientName),
+            certificateOptions.DefaultLocale,
+            cancellationToken);
+
         var emailModel = new EmailModel
         {
             Recipients = new[] { new Address { Email = certificate.RecipientEmail } },
-            Subject = $"Kursbevis for {certificate.Title}",
-            TextBody = "Her er kursbeviset! Gratulere!",
+            Subject = deliveryEmail.Subject,
+            HtmlBody = deliveryEmail.HtmlBody,
+            TextBody = deliveryEmail.TextBody,
             Attachments = new List<Attachment>
             {
                 new()

--- a/apps/api/src/Eventuras.Services.Certificates/CertificateDeliveryEmailModel.cs
+++ b/apps/api/src/Eventuras.Services.Certificates/CertificateDeliveryEmailModel.cs
@@ -1,0 +1,7 @@
+#nullable enable
+
+namespace Eventuras.Services.Certificates;
+
+public sealed record CertificateDeliveryEmailModel(
+    string Title,
+    string RecipientName);

--- a/apps/api/src/Eventuras.Services.Certificates/CertificateDeliveryEmailRenderer.cs
+++ b/apps/api/src/Eventuras.Services.Certificates/CertificateDeliveryEmailRenderer.cs
@@ -1,0 +1,64 @@
+#nullable enable
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Eventuras.Libs.DocComposer;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+namespace Eventuras.Services.Certificates;
+
+internal sealed class CertificateDeliveryEmailRenderer
+{
+    private const string TemplateName = "certificate-delivery";
+    private const string DefaultLocale = "nb";
+    private const string TemplateBaseNamespace = "Eventuras.Services.Certificates.Templates";
+
+    private readonly IEmailComposer _emailComposer;
+
+    public CertificateDeliveryEmailRenderer()
+    {
+        _emailComposer = new FluidEmailComposer(CreateDocumentComposer());
+    }
+
+    public Task<RenderedEmail> RenderAsync(
+        CertificateDeliveryEmailModel model,
+        string locale,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        ArgumentException.ThrowIfNullOrWhiteSpace(locale);
+
+        var templateLocale = NormalizeToTemplateLocale(locale);
+        return _emailComposer.ComposeAsync(TemplateName, model, templateLocale, cancellationToken);
+    }
+
+    // Same normalisation rules as LiquidCertificateRenderer — the delivery email
+    // and the certificate ship together, so they should resolve the same locale.
+    private static string NormalizeToTemplateLocale(string locale)
+    {
+        var lang = locale.Split('-')[0].ToLowerInvariant();
+        return lang switch
+        {
+            "nb" or "no" => "nb",
+            "nn" => "nn",
+            "en" => "en",
+            _ => locale
+        };
+    }
+
+    private static IDocumentComposer CreateDocumentComposer()
+    {
+        // Plain EmbeddedFileProvider rather than ManifestEmbeddedFileProvider:
+        // the manifest target collapses ".nb"/".en" into a single resource path even with WithCulture=false.
+        var provider = new EmbeddedFileProvider(
+            typeof(CertificateViewModel).Assembly,
+            TemplateBaseNamespace);
+        return new FluidDocumentComposer(Options.Create(new DocComposerOptions
+        {
+            TemplateFileProvider = provider,
+            DefaultLocale = DefaultLocale
+        }));
+    }
+}

--- a/apps/api/src/Eventuras.Services.Certificates/CertificateServiceCollectionExtensions.cs
+++ b/apps/api/src/Eventuras.Services.Certificates/CertificateServiceCollectionExtensions.cs
@@ -13,6 +13,7 @@ public static class CertificateServiceCollectionExtensions
         services.AddTransient<ICertificateIssuingService, CertificateIssuingService>();
         services.AddTransient<ICertificateRetrievalService, CertificateRetrievalService>();
         services.AddTransient<ICertificateRenderer, LiquidCertificateRenderer>();
+        services.AddSingleton<CertificateDeliveryEmailRenderer>();
         services.AddTransient<ICertificateDeliveryService, CertificateDeliveryService>();
         return services;
     }

--- a/apps/api/src/Eventuras.Services.Certificates/Templates/certificate-delivery.en.liquid
+++ b/apps/api/src/Eventuras.Services.Certificates/Templates/certificate-delivery.en.liquid
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Certificate for {{ Title | escape }}</title>
+</head>
+<body>
+<p>Hello {{ RecipientName | escape }},</p>
+
+<p>Here is your certificate for <strong>{{ Title | escape }}</strong>. Congratulations on completing the course!</p>
+
+<p>The certificate is attached to this email as a PDF.</p>
+
+<p>Best regards,<br/>Eventuras</p>
+</body>
+</html>

--- a/apps/api/src/Eventuras.Services.Certificates/Templates/certificate-delivery.nb.liquid
+++ b/apps/api/src/Eventuras.Services.Certificates/Templates/certificate-delivery.nb.liquid
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="nb">
+<head>
+  <meta charset="utf-8">
+  <title>Kursbevis for {{ Title | escape }}</title>
+</head>
+<body>
+<p>Hei {{ RecipientName | escape }},</p>
+
+<p>Her er kursbeviset ditt for <strong>{{ Title | escape }}</strong>. Gratulerer med gjennomført kurs!</p>
+
+<p>Beviset ligger som PDF-vedlegg til denne e-posten.</p>
+
+<p>Med vennlig hilsen,<br/>Eventuras</p>
+</body>
+</html>

--- a/apps/api/tests/Eventuras.Services.Certificates.Tests/CertificateDeliveryEmailRendererTest.cs
+++ b/apps/api/tests/Eventuras.Services.Certificates.Tests/CertificateDeliveryEmailRendererTest.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using System.Threading.Tasks;
+using Eventuras.Services.Certificates;
+using Xunit;
+
+namespace Eventuras.Services.Certificates.Tests;
+
+public class CertificateDeliveryEmailRendererTest
+{
+    [Fact]
+    public async Task RenderAsync_NorwegianLocale_ProducesBokmaalSubjectAndBody()
+    {
+        var renderer = new CertificateDeliveryEmailRenderer();
+        var model = new CertificateDeliveryEmailModel("Avansert Fluid-templating", "Leo Losen");
+
+        var result = await renderer.RenderAsync(model, "nb");
+
+        Assert.Equal("Kursbevis for Avansert Fluid-templating", result.Subject);
+        Assert.Contains("Hei Leo Losen", result.HtmlBody);
+        Assert.Contains("Avansert Fluid-templating", result.HtmlBody);
+        Assert.Contains("Gratulerer", result.HtmlBody);
+        Assert.Contains("Hei Leo Losen", result.TextBody);
+        Assert.DoesNotContain("<strong>", result.TextBody);
+    }
+
+    [Fact]
+    public async Task RenderAsync_EnglishLocale_ProducesEnglishSubjectAndBody()
+    {
+        var renderer = new CertificateDeliveryEmailRenderer();
+        var model = new CertificateDeliveryEmailModel("Advanced Fluid Templating", "Leo Losen");
+
+        var result = await renderer.RenderAsync(model, "en");
+
+        Assert.Equal("Certificate for Advanced Fluid Templating", result.Subject);
+        Assert.Contains("Hello Leo Losen", result.HtmlBody);
+        Assert.Contains("Congratulations", result.HtmlBody);
+        Assert.Contains("Hello Leo Losen", result.TextBody);
+    }
+
+    [Fact]
+    public async Task RenderAsync_NormalizesRegionalLocale_NbNO_ToBokmaal()
+    {
+        var renderer = new CertificateDeliveryEmailRenderer();
+        var model = new CertificateDeliveryEmailModel("Vårens kurs", "Leo Losen");
+
+        var result = await renderer.RenderAsync(model, "nb-NO");
+
+        Assert.Equal("Kursbevis for Vårens kurs", result.Subject);
+    }
+
+    [Fact]
+    public async Task RenderAsync_NormalizesRegionalLocale_EnUS_ToEnglish()
+    {
+        var renderer = new CertificateDeliveryEmailRenderer();
+        var model = new CertificateDeliveryEmailModel("Advanced Course", "Leo Losen");
+
+        var result = await renderer.RenderAsync(model, "en-US");
+
+        Assert.Equal("Certificate for Advanced Course", result.Subject);
+    }
+
+    [Fact]
+    public async Task RenderAsync_UnknownLocale_FallsBackToBokmaalTemplate()
+    {
+        var renderer = new CertificateDeliveryEmailRenderer();
+        var model = new CertificateDeliveryEmailModel("Test Course", "Leo Losen");
+
+        var result = await renderer.RenderAsync(model, "fr");
+
+        Assert.Contains("Kursbevis", result.Subject);
+    }
+
+    [Fact]
+    public async Task RenderAsync_EscapesHtmlInModelFields()
+    {
+        var renderer = new CertificateDeliveryEmailRenderer();
+        var model = new CertificateDeliveryEmailModel(
+            Title: "<script>alert('xss')</script>",
+            RecipientName: "Leo & Co <admin>");
+
+        var result = await renderer.RenderAsync(model, "nb");
+
+        // HTML body must not contain raw script tags — they're escaped before rendering.
+        // The Subject is plain text (email header) so the unescaped form is fine there.
+        Assert.DoesNotContain("<script>", result.HtmlBody);
+        Assert.Contains("&lt;script&gt;", result.HtmlBody);
+        Assert.Contains("Leo &amp; Co &lt;admin&gt;", result.HtmlBody);
+    }
+}

--- a/apps/api/tests/Eventuras.Services.Certificates.Tests/CourseCertificateModelMapperTest.cs
+++ b/apps/api/tests/Eventuras.Services.Certificates.Tests/CourseCertificateModelMapperTest.cs
@@ -6,7 +6,7 @@ using Eventuras.Services.Certificates;
 using NodaTime;
 using Xunit;
 
-namespace Eventuras.Services.Tests.Certificates;
+namespace Eventuras.Services.Certificates.Tests;
 
 public class CourseCertificateModelMapperTest
 {

--- a/apps/api/tests/Eventuras.Services.Certificates.Tests/CourseCertificateTemplateTest.cs
+++ b/apps/api/tests/Eventuras.Services.Certificates.Tests/CourseCertificateTemplateTest.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Options;
 using Xunit;
 
-namespace Eventuras.Services.Tests.Certificates;
+namespace Eventuras.Services.Certificates.Tests;
 
 public class CourseCertificateTemplateTest
 {

--- a/apps/api/tests/Eventuras.Services.Certificates.Tests/LiquidCertificateRendererTest.cs
+++ b/apps/api/tests/Eventuras.Services.Certificates.Tests/LiquidCertificateRendererTest.cs
@@ -12,7 +12,7 @@ using Moq;
 using NodaTime;
 using Xunit;
 
-namespace Eventuras.Services.Tests.Certificates;
+namespace Eventuras.Services.Certificates.Tests;
 
 public class LiquidCertificateRendererTest
 {


### PR DESCRIPTION
## Summary
Replaces the hardcoded Norwegian \`Subject = \"Kursbevis for {Title}\"\` and \`TextBody = \"Her er kursbeviset! Gratulere!\"\` in \`CertificateBackgroundWorker\` with a Liquid-templated email body rendered via DocComposer's \`FluidEmailComposer\`. Adds matching \`certificate-delivery.nb.liquid\` and \`.en.liquid\` templates as embedded resources alongside the existing certificate templates.

## What's new
- \`CertificateDeliveryEmailModel\` record — Title + RecipientName.
- \`CertificateDeliveryEmailRenderer\` — internal class wrapping \`FluidEmailComposer\` with the same locale normalisation rules as \`LiquidCertificateRenderer\` so the delivery email and the attached certificate render in the same language.
- Two new Liquid templates (\`certificate-delivery.nb.liquid\`, \`certificate-delivery.en.liquid\`).
- Renderer registered in \`AddCertificateServices()\` as a singleton.
- 5 new tests covering subject extraction, body rendering, regional-locale normalisation, and the default-locale fallback.

## Behaviour change
The outgoing email now sets both \`HtmlBody\` (new) and \`TextBody\` (was hardcoded). The plain-text body is derived from the rendered HTML via AngleSharp's text extraction — so recipients on text-only clients get the right content too.

## Notes
- Stacked on #1516 (cert-stack split). Merge that one first.
- The attachment filename is still hardcoded to \`kursbevis.pdf\` regardless of locale — small enough to leave for a follow-up if it bothers anyone.

## Test plan
- [x] \`dotnet build Eventuras.slnx\` clean
- [x] \`Eventuras.Services.Certificates.Tests\` — 27/27 (5 new)
- [x] \`Eventuras.WebApi.Tests\` — 742/742 (2 pre-existing skips)
- [ ] CI: full solution build + Docker