### PR TITLE
feat(ratio-ui): forward native HTML attrs on Table; add Foot and Caption

### DIFF
--- a/.changeset/ratio-ui-table-native-attrs-and-foot-caption.md
+++ b/.changeset/ratio-ui-table-native-attrs-and-foot-caption.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/ratio-ui': minor
+---
+
+`Table` and its subcomponents now extend their native HTML attribute types — `Table`, `Table.Header`, `Table.Body`, `Table.Foot`, `Table.Row`, `Table.HeadCell`, `Table.Cell`, `Table.Caption` all forward the rest of their props (`colSpan`/`rowSpan`, `scope`, `onClick`, `aria-*`, `data-*`, …) to the underlying element. Adds two new subcomponents: `Table.Foot` (`<tfoot>`) and `Table.Caption` (`<caption>`).

--- a/libs/ratio-ui/src/core/Table/Table.stories.tsx
+++ b/libs/ratio-ui/src/core/Table/Table.stories.tsx
@@ -71,6 +71,101 @@ export const WithManyColumns: TableStory = () => (
   </Table>
 );
 
+// Demonstrates colSpan/rowSpan support
+export const WithSpannedCells: TableStory = () => (
+  <Table>
+    <Table.Header>
+      <Table.Row>
+        <Table.HeadCell rowSpan={2}>Name</Table.HeadCell>
+        <Table.HeadCell colSpan={2} className="text-center">
+          Contact
+        </Table.HeadCell>
+        <Table.HeadCell rowSpan={2}>Role</Table.HeadCell>
+      </Table.Row>
+      <Table.Row>
+        <Table.HeadCell>Email</Table.HeadCell>
+        <Table.HeadCell>Phone</Table.HeadCell>
+      </Table.Row>
+    </Table.Header>
+    <Table.Body>
+      <Table.Row>
+        <Table.Cell>John Doe</Table.Cell>
+        <Table.Cell>john@example.com</Table.Cell>
+        <Table.Cell>+47 900 00 000</Table.Cell>
+        <Table.Cell>Admin</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <Table.Cell>Jane Smith</Table.Cell>
+        <Table.Cell colSpan={2}>jane@example.com (no phone on file)</Table.Cell>
+        <Table.Cell>User</Table.Cell>
+      </Table.Row>
+    </Table.Body>
+  </Table>
+);
+
+// Demonstrates Foot + Caption + native row events. The Caption labels the
+// table for assistive tech; the Foot holds a totals row; row-level onClick
+// works because TableRow now forwards native <tr> attributes. Clickable
+// rows pair onClick with role="button", tabIndex={0}, and an Enter/Space
+// key handler so keyboard users can trigger the same action.
+const triggerOnEnterOrSpace =
+  (action: () => void) => (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      action();
+    }
+  };
+
+export const WithCaptionAndFoot: TableStory = () => {
+  const logRow = (label: string) => () => console.log(`row: ${label}`);
+  const clickableRowClasses =
+    'cursor-pointer hover:bg-card-hover focus:outline-2 focus:outline-(--text-link)';
+
+  return (
+    <Table>
+      <Table.Caption>Quarterly product sales — click a row for details</Table.Caption>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeadCell scope="col">Product</Table.HeadCell>
+          <Table.HeadCell scope="col">Units</Table.HeadCell>
+          <Table.HeadCell scope="col">Revenue</Table.HeadCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row
+          role="button"
+          tabIndex={0}
+          onClick={logRow('Widget A')}
+          onKeyDown={triggerOnEnterOrSpace(logRow('Widget A'))}
+          className={clickableRowClasses}
+        >
+          <Table.Cell>Widget A</Table.Cell>
+          <Table.Cell>120</Table.Cell>
+          <Table.Cell>$2,398.80</Table.Cell>
+        </Table.Row>
+        <Table.Row
+          role="button"
+          tabIndex={0}
+          onClick={logRow('Widget B')}
+          onKeyDown={triggerOnEnterOrSpace(logRow('Widget B'))}
+          className={clickableRowClasses}
+        >
+          <Table.Cell>Widget B</Table.Cell>
+          <Table.Cell>80</Table.Cell>
+          <Table.Cell>$2,399.20</Table.Cell>
+        </Table.Row>
+      </Table.Body>
+      <Table.Foot>
+        <Table.Row>
+          <Table.Cell className="font-semibold">Total</Table.Cell>
+          <Table.Cell className="font-semibold">200</Table.Cell>
+          <Table.Cell className="font-semibold">$4,798.00</Table.Cell>
+        </Table.Row>
+      </Table.Foot>
+    </Table>
+  );
+};
+
 export const WithCustomStyling: TableStory = () => (
   <Table className="bg-gray-50">
     <Table.Header>

--- a/libs/ratio-ui/src/core/Table/Table.tsx
+++ b/libs/ratio-ui/src/core/Table/Table.tsx
@@ -1,33 +1,35 @@
 import React from 'react';
 
-type TableProps = {
+type TableProps = React.TableHTMLAttributes<HTMLTableElement> & {
   children: React.ReactNode;
-  className?: string;
 };
 
-type TableHeaderProps = {
+type TableHeaderProps = React.HTMLAttributes<HTMLTableSectionElement> & {
   children: React.ReactNode;
-  className?: string;
 };
 
-type TableBodyProps = {
+type TableBodyProps = React.HTMLAttributes<HTMLTableSectionElement> & {
   children: React.ReactNode;
-  className?: string;
 };
 
-type TableRowProps = {
+type TableFootProps = React.HTMLAttributes<HTMLTableSectionElement> & {
   children: React.ReactNode;
-  className?: string;
 };
 
-type TableHeadCellProps = {
+type TableRowProps = React.HTMLAttributes<HTMLTableRowElement> & {
   children: React.ReactNode;
-  className?: string;
 };
 
-type TableCellProps = {
+type TableHeadCellProps = React.ThHTMLAttributes<HTMLTableCellElement> & {
   children: React.ReactNode;
-  className?: string;
+};
+
+type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement> & {
+  children: React.ReactNode;
+};
+
+type TableCaptionProps = React.HTMLAttributes<HTMLTableCaptionElement> & {
+  children: React.ReactNode;
 };
 
 /**
@@ -36,45 +38,88 @@ type TableCellProps = {
 export const Table: React.FC<TableProps> & {
   Header: React.FC<TableHeaderProps>;
   Body: React.FC<TableBodyProps>;
+  Foot: React.FC<TableFootProps>;
   Row: React.FC<TableRowProps>;
   HeadCell: React.FC<TableHeadCellProps>;
   Cell: React.FC<TableCellProps>;
-} = ({ children, className = '' }) => {
+  Caption: React.FC<TableCaptionProps>;
+} = ({ children, className = '', ...rest }) => {
   return (
     <div className="overflow-x-auto">
-      <table className={`min-w-full border-collapse ${className}`}>{children}</table>
+      <table className={`min-w-full border-collapse ${className}`} {...rest}>
+        {children}
+      </table>
     </div>
   );
 };
 
-const TableHeader: React.FC<TableHeaderProps> = ({ children, className = '' }) => {
-  return <thead className={className}>{children}</thead>;
+const TableHeader: React.FC<TableHeaderProps> = ({ children, className = '', ...rest }) => {
+  return (
+    <thead className={className} {...rest}>
+      {children}
+    </thead>
+  );
 };
 
-const TableBody: React.FC<TableBodyProps> = ({ children, className = '' }) => {
-  return <tbody className={className}>{children}</tbody>;
+const TableBody: React.FC<TableBodyProps> = ({ children, className = '', ...rest }) => {
+  return (
+    <tbody className={className} {...rest}>
+      {children}
+    </tbody>
+  );
 };
 
-const TableRow: React.FC<TableRowProps> = ({ children, className = '' }) => {
-  return <tr className={`border-b border-border-1 ${className}`}>{children}</tr>;
+const TableFoot: React.FC<TableFootProps> = ({ children, className = '', ...rest }) => {
+  return (
+    <tfoot className={className} {...rest}>
+      {children}
+    </tfoot>
+  );
 };
 
-const TableHeadCell: React.FC<TableHeadCellProps> = ({ children, className = '' }) => {
+const TableRow: React.FC<TableRowProps> = ({ children, className = '', ...rest }) => {
+  return (
+    <tr className={`border-b border-border-1 ${className}`} {...rest}>
+      {children}
+    </tr>
+  );
+};
+
+const TableHeadCell: React.FC<TableHeadCellProps> = ({ children, className = '', ...rest }) => {
   return (
     <th
       className={`px-4 py-3 text-left text-sm font-semibold text-(--text) bg-card-hover ${className}`}
+      {...rest}
     >
       {children}
     </th>
   );
 };
 
-const TableCell: React.FC<TableCellProps> = ({ children, className = '' }) => {
-  return <td className={`px-4 py-3 text-sm text-(--text-muted) ${className}`}>{children}</td>;
+const TableCell: React.FC<TableCellProps> = ({ children, className = '', ...rest }) => {
+  return (
+    <td className={`px-4 py-3 text-sm text-(--text-muted) ${className}`} {...rest}>
+      {children}
+    </td>
+  );
+};
+
+// `<caption>` is a child of `<table>`, not the wrapper `<div>` — but the
+// styled root mounts a wrapper div, so consumers compose `<Table.Caption>`
+// as the first child inside `<Table>` and the browser anchors it to the
+// containing table element via DOM ordering.
+const TableCaption: React.FC<TableCaptionProps> = ({ children, className = '', ...rest }) => {
+  return (
+    <caption className={`px-4 py-2 text-sm text-(--text-muted) text-left ${className}`} {...rest}>
+      {children}
+    </caption>
+  );
 };
 
 Table.Header = TableHeader;
 Table.Body = TableBody;
+Table.Foot = TableFoot;
 Table.Row = TableRow;
 Table.HeadCell = TableHeadCell;
 Table.Cell = TableCell;
+Table.Caption = TableCaption;


### PR DESCRIPTION
All seven Table subcomponents now extend their native attribute types and spread the rest of their props onto the underlying element, so colSpan/rowSpan on cells, scope on header cells, onClick / data-* / aria-* on rows, and the equivalents on `<table>`/`<thead>`/`<tbody>` all work without further changes. Unblocks TanStack-style grouped multi-level headers, which currently fall back to flat-column-only rendering because group header cells can't set colspan.

Also adds two missing subcomponents that round out the public API: Table.Foot (`<tfoot>`) and Table.Caption (`<caption>`). New Storybook story `WithCaptionAndFoot` demonstrates them together with a clickable body row.

Existing usages keep rendering identically when no extra attributes are passed — styling and className composition are unchanged.