### PR TITLE
feat(web): surface product sales account in SDK and admin form

### DIFF
--- a/.changeset/product-sales-account-ui.md
+++ b/.changeset/product-sales-account-ui.md
@@ -1,0 +1,6 @@
+---
+"@eventuras/event-sdk": minor
+"@eventuras/web": minor
+---
+
+Surface the product `salesAccount` field: regenerate the SDK types to include it, and add an optional "Sales account" input to the admin product create/edit form.

--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -244,6 +244,8 @@
       "minimumQuantity": "Min quantity",
       "name": "Name",
       "price": "Price",
+      "salesAccount": "Sales account",
+      "salesAccountDescription": "Optional. Empty uses the organization's default sales account on new products; on existing products it keeps the current value.",
       "vatPercent": "Vat",
       "visibility": "Visibility"
     }

--- a/apps/web/locales/nb-NO/common.json
+++ b/apps/web/locales/nb-NO/common.json
@@ -244,6 +244,8 @@
       "minimumQuantity": "Minste antall",
       "name": "Navn",
       "price": "Pris",
+      "salesAccount": "Salgskonto",
+      "salesAccountDescription": "Valgfritt. Tom bruker organisasjonens standard salgskonto på nye produkter; på eksisterende produkter beholdes gjeldende verdi.",
       "vatPercent": "Mva",
       "visibility": "Type"
     }

--- a/apps/web/src/app/(admin)/admin/events/[id]/products/ProductModal.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/products/ProductModal.tsx
@@ -118,6 +118,12 @@ const ProductModal: React.FC<ProductModalProps> = ({
               testId="product-minimum-quantity-input"
             />
           </div>
+          <NumberInput
+            name="salesAccount"
+            label={t('common.products.labels.salesAccount')}
+            description={t('common.products.labels.salesAccountDescription')}
+            testId="product-sales-account-input"
+          />
           <Dialog.Footer>
             <Button type="reset" variant="secondary" onClick={onClose}>
               {t('common.buttons.cancel')}

--- a/libs/event-sdk/src/client-next/types.gen.ts
+++ b/libs/event-sdk/src/client-next/types.gen.ts
@@ -310,6 +310,11 @@ export type NewProductDto = {
     price?: number;
     vatPercent?: number;
     visibility?: ProductVisibility;
+    /**
+     * Sales account code for the external accounting system.
+     * Null means the organization default is used.
+     */
+    salesAccount?: null | number;
 };
 
 export type NewProductVariantDto = {
@@ -587,6 +592,11 @@ export type ProductDto = {
     visibility?: ProductVisibility;
     inventory?: null | number;
     published?: null | boolean;
+    /**
+     * Sales account code for the external accounting system.
+     * Null means the organization default is used.
+     */
+    salesAccount?: null | number;
     variants?: Array<ProductVariantDto>;
     minimumQuantity?: number;
     isMandatory?: boolean;
@@ -603,6 +613,11 @@ export type ProductFormDto = {
     inventory?: null | number;
     published?: null | boolean;
     visibility?: null | ProductVisibility;
+    /**
+     * Sales account code for the external accounting system.
+     * Null means the organization default is used.
+     */
+    salesAccount?: null | number;
 };
 
 export type ProductOrderDto = {


### PR DESCRIPTION
## What

Follow-up to #1522 (now merged). Surfaces the product `salesAccount` field to the admin UI:

- **SDK** — regenerated `@eventuras/event-sdk` types (`NewProductDto`/`ProductDto`/`ProductFormDto` now carry `salesAccount`), using the hey-api 0.97.2 already on `main`.
- **Admin form** — optional "Sales account" `NumberInput` in the product create/edit modal, with help text that an empty value uses the organization default.
- **i18n** — `salesAccount` + `salesAccountDescription` labels for `nb-NO` and `en-US`.

Empty input serializes as omitted, so per the backend guard from #1522 the stored value is preserved on update (no accidental wipe).

No product-table column — sales account is an accounting/integration detail, kept to the edit form only.

## Test

`tsc --noEmit` clean on web + event-sdk; eslint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)