### PR TITLE
feat(api): send per-product sales account to PowerOffice

### DIFF
--- a/.changeset/product-sales-account-poweroffice.md
+++ b/.changeset/product-sales-account-poweroffice.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/api": minor
+---
+
+Send a product's own sales account to PowerOffice when the product is first created there. The per-product `salesAccount` now flows through the invoice line; when a product has none, the integration keeps falling back to the organization default (`POWER_OFFICE_DEFAULT_SALES_ACCOUNT`). Existing PowerOffice products are still never modified.

--- a/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeConstants.cs
+++ b/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeConstants.cs
@@ -9,6 +9,6 @@ internal static class PowerOfficeConstants
     internal const string ClientKeyDescription = "PowerOffice Client key";
     internal const string DefaultSalesAccountKey = "POWER_OFFICE_DEFAULT_SALES_ACCOUNT";
     internal const string DefaultSalesAccountDescription =
-        "Default sales account (kontokode) used when a product is first created in PowerOffice. Falls back to 3100 if unset.";
+        "Fallback sales account (kontokode) used when a product is first created in PowerOffice and the product itself has no sales account set. Falls back to 3100 if unset or invalid.";
     internal const int FallbackSalesAccount = 3100;
 }

--- a/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeService.cs
+++ b/apps/api/src/Eventuras.Services.PowerOffice/PowerOfficeService.cs
@@ -222,7 +222,7 @@ public class PowerOfficeService : IInvoicingProvider
                 Name = line.Description,
                 Description = line.ProductDescription,
                 SalesPrice = line.Price,
-                SalesAccount = await ResolveDefaultSalesAccountAsync()
+                SalesAccount = line.SalesAccount ?? await ResolveDefaultSalesAccountAsync()
             };
             await api.Product.SaveAsync(product);
         }

--- a/apps/api/src/Eventuras.Services.PowerOffice/README.md
+++ b/apps/api/src/Eventuras.Services.PowerOffice/README.md
@@ -31,7 +31,7 @@ PowerOffice settings are configured per organization through the organization se
 | ------------------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------------- |
 | `POWER_OFFICE_APP_KEY`               | String | PowerOffice Application Key                                                                                            |
 | `POWER_OFFICE_CLIENT_KEY`            | String | PowerOffice Client Key                                                                                                 |
-| `POWER_OFFICE_DEFAULT_SALES_ACCOUNT` | Number | Default sales account (kontokode) assigned when a product is first created in PowerOffice. Defaults to `3100` if unset. |
+| `POWER_OFFICE_DEFAULT_SALES_ACCOUNT` | Number | Fallback sales account (kontokode) assigned when a product is first created in PowerOffice and the product has no sales account of its own. Defaults to `3100` if unset or invalid. |
 
 **Note**: These settings are stored securely in the database per organization, not in configuration files.
 
@@ -53,8 +53,8 @@ The service handles invoices for the following payment methods:
 
 2. **Product Creation**
    - Creates products in PowerOffice if they don't exist (matched by product code)
-   - New products are assigned the sales account from `POWER_OFFICE_DEFAULT_SALES_ACCOUNT`, falling back to `3100` if the setting is missing or invalid
-   - Products that already exist in PowerOffice are left unchanged — the sales account on existing PowerOffice products is never overwritten
+   - New products are assigned the product's own sales account when set; otherwise the `POWER_OFFICE_DEFAULT_SALES_ACCOUNT` setting, falling back to `3100` if it is missing or invalid
+   - Products that already exist in PowerOffice are left unchanged — the sales account on existing PowerOffice products is never overwritten, so changing a product's sales account in Eventuras does not propagate to a product already created in PowerOffice
 
 3. **Invoice Generation**
    - Creates draft invoice in PowerOffice

--- a/apps/api/src/Eventuras.Services/Invoicing/InvoiceInfo.cs
+++ b/apps/api/src/Eventuras.Services/Invoicing/InvoiceInfo.cs
@@ -52,6 +52,7 @@ public class InvoiceInfo
                             : l.ProductName,
                         ProductCode = l.ItemCode,
                         ProductDescription = l.ProductVariantDescription ?? l.ProductDescription,
+                        SalesAccount = l.Product?.SalesAccount,
                         Quantity = l.Quantity,
                         Price = l.Price,
                         Total = l.LineTotal

--- a/apps/api/src/Eventuras.Services/Invoicing/InvoiceLine.cs
+++ b/apps/api/src/Eventuras.Services/Invoicing/InvoiceLine.cs
@@ -7,6 +7,13 @@ public class InvoiceLine
 
     public string ProductCode { get; set; }
     public string ProductDescription { get; set; }
+
+    /// <summary>
+    ///     Per-product sales account code. When null, the invoicing provider falls
+    ///     back to the organization default.
+    /// </summary>
+    public int? SalesAccount { get; set; }
+
     public int? Quantity { get; set; }
 
     public decimal? Price { get; set; }

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Invoices/InvoiceInfoTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Invoices/InvoiceInfoTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Eventuras.Services.Invoicing;
+using Eventuras.TestAbstractions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Eventuras.WebApi.Tests.Controllers.Invoices;
+
+public class InvoiceInfoTests : IClassFixture<CustomWebApiApplicationFactory<Program>>
+{
+    private readonly CustomWebApiApplicationFactory<Program> _factory;
+
+    public InvoiceInfoTests(CustomWebApiApplicationFactory<Program> factory) =>
+        _factory = factory ?? throw new ArgumentNullException(nameof(factory));
+
+    [Theory]
+    [InlineData(3010, 3010)] // product has its own account -> carried through
+    [InlineData(null, null)] // no account -> null, provider falls back to the org default
+    public async Task CreateFromOrderList_Should_Carry_Product_SalesAccount(int? productSalesAccount, int? expected)
+    {
+        using var scope = _factory.Services.NewTestScope();
+        using var evt = await scope.CreateEventAsync();
+        using var user = await scope.CreateUserAsync();
+        using var registration = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+        using var product = await scope.CreateProductAsync(evt.Entity);
+
+        product.Entity.SalesAccount = productSalesAccount;
+        await scope.Db.SaveChangesAsync();
+
+        using var order = await scope.CreateOrderAsync(registration.Entity, product.Entity);
+
+        // Load the same way the invoicing flow does (see OrdersQueryableExtensions):
+        // order lines must include the live Product so its sales account is available.
+        var orders = await scope.Db.Orders
+            .Where(o => o.OrderId == order.Entity.OrderId)
+            .Include(o => o.Registration).ThenInclude(r => r.User)
+            .Include(o => o.Registration).ThenInclude(r => r.EventInfo)
+            .Include(o => o.OrderLines).ThenInclude(l => l.Product)
+            .AsNoTracking()
+            .ToListAsync();
+
+        var info = InvoiceInfo.CreateFromOrderList(orders);
+
+        var productLine = info.Lines.Single(l => l.Type == InvoiceLineType.Product);
+        Assert.Equal(expected, productLine.SalesAccount);
+    }
+}


### PR DESCRIPTION
## What

Completes the per-product sales account feature (after #1522 and #1524). When PowerOffice lazily creates a product, it now uses the **product's own** `salesAccount` if set, falling back to the organization default (`POWER_OFFICE_DEFAULT_SALES_ACCOUNT`, then `3100`) when the product has none.

- `InvoiceLine` carries an optional `SalesAccount` (alongside the existing product-master fields like `ProductDescription` it already carries for product creation).
- `InvoiceInfo.CreateFromOrderList` sets it from `OrderLine.Product?.SalesAccount` — a live read; the order query already `Include`s `OrderLines.ThenInclude(l => l.Product)` (`OrdersQueryableExtensions`), so no query change was needed.
- `PowerOfficeService.CreateProductIfNotExistsAsync` uses `line.SalesAccount ?? ResolveDefaultSalesAccountAsync()`.
- Updated the setting description + README.

## Behavior notes

- **Existing PowerOffice products are still never modified** — changing a product's sales account in Eventuras does not propagate to a product already created in PowerOffice (documented in the README).
- Variants inherit their product's sales account (each variant is a separate PowerOffice product).

## Follow-up (not in this PR)

Ole raised giving the integration a persistent product↔external mapping (an `ExternalAccountingProduct` relation + sync service) instead of the current lazy string-match + full remote fetch. That would let the sync read `Product.SalesAccount` directly (removing it from the invoice line), avoid the per-invoice full product fetch, and enable update propagation. Tracked as a separate, larger initiative.

## Test

`InvoiceInfoTests` verifies the account flows from the product through the loaded order graph (including the `Include(Product)` path), for both a set account and the null/fallback case. Full test project builds; PowerOffice provider itself is not unit-tested (SDK), consistent with the existing tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)