### PR TITLE
feat(api): make role claim type configurable via Auth:RoleClaimType

### DIFF
--- a/apps/api/src/Eventuras.WebApi/Auth/JwtBearerConfiguration.cs
+++ b/apps/api/src/Eventuras.WebApi/Auth/JwtBearerConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
@@ -12,7 +13,7 @@ namespace Eventuras.WebApi.Auth;
 public static class JwtBearerConfiguration
 {
     public static AuthenticationBuilder AddJwtBearerConfiguration(this AuthenticationBuilder builder, string issuer,
-        string audience, string jwtSecret) =>
+        string audience, string jwtSecret, string roleClaimType = null) =>
         builder.AddJwtBearer(options =>
         {
             options.Authority = issuer;
@@ -21,7 +22,9 @@ public static class JwtBearerConfiguration
             {
                 ValidateIssuer = true,
                 IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
-                ValidAudiences = new List<string> { audience, issuer.TrimEnd('/') + "/userinfo" }
+                ValidAudiences = new List<string> { audience, issuer.TrimEnd('/') + "/userinfo" },
+                // Default preserves current Auth0 behavior; Keycloak deployments set Auth:RoleClaimType=roles
+                RoleClaimType = string.IsNullOrWhiteSpace(roleClaimType) ? ClaimTypes.Role : roleClaimType.Trim()
             };
 
             options.Events = new JwtBearerEvents

--- a/apps/api/src/Eventuras.WebApi/Config/AuthSettings.cs
+++ b/apps/api/src/Eventuras.WebApi/Config/AuthSettings.cs
@@ -8,4 +8,5 @@ public class AuthSettings
     public string ClientSecret { get; set; }
     public string ApiIdentifier { get; set; }
     public bool EnablePiiLogging { get; set; }
+    public string RoleClaimType { get; set; }
 }

--- a/apps/api/src/Eventuras.WebApi/Program.cs
+++ b/apps/api/src/Eventuras.WebApi/Program.cs
@@ -152,15 +152,16 @@ builder.Services.AddSingleton<IBackgroundJobQueue, BackgroundJobQueue>();
 builder.Services.AddHostedService<NotificationBackgroundWorker>();
 builder.Services.AddHostedService<CertificateBackgroundWorker>();
 
+var authSettings = builder.Configuration.GetRequiredSection("Auth").Get<AuthSettings>()
+    ?? throw new InvalidOperationException("The \"Auth\" configuration section is empty.");
 builder.Services.AddAuthentication(options =>
     {
         options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
         options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
         options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
     })
-    .AddJwtBearerConfiguration(builder.Configuration["Auth:Issuer"],
-        builder.Configuration["Auth:Audience"],
-        builder.Configuration["Auth:ClientSecret"]);
+    .AddJwtBearerConfiguration(authSettings.Issuer, authSettings.Audience,
+        authSettings.ClientSecret, authSettings.RoleClaimType);
 
 builder.Services.AddSingleton<IAuthorizationHandler, RequireScopeHandler>();
 

--- a/apps/api/tests/Eventuras.WebApi.Tests/Auth/JwtBearerConfigurationTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Auth/JwtBearerConfigurationTests.cs
@@ -1,0 +1,53 @@
+using System.Security.Claims;
+using Eventuras.WebApi.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Eventuras.WebApi.Tests.Auth;
+
+public class JwtBearerConfigurationTests
+{
+    private const string Issuer = "https://auth.example.test/realms/test";
+    private const string Audience = "https://example.test/api";
+    private const string Secret = "test-signing-secret-which-is-long-enough";
+
+    private static JwtBearerOptions BuildOptions(string roleClaimType)
+    {
+        var services = new ServiceCollection();
+        services.AddOptions();
+        services.AddAuthentication()
+            .AddJwtBearerConfiguration(Issuer, Audience, Secret, roleClaimType);
+
+        using var provider = services.BuildServiceProvider();
+        return provider.GetRequiredService<IOptionsMonitor<JwtBearerOptions>>()
+            .Get(JwtBearerDefaults.AuthenticationScheme);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Defaults_To_Microsoft_Role_Claim_When_Blank(string roleClaimType)
+    {
+        // Auth0 deployments leave Auth:RoleClaimType unset and rely on the
+        // Microsoft role URI; whitespace-only values (e.g. env-var quoting)
+        // must also fall back rather than become an invalid claim type.
+        var options = BuildOptions(roleClaimType);
+
+        Assert.Equal(ClaimTypes.Role, options.TokenValidationParameters.RoleClaimType);
+    }
+
+    [Theory]
+    [InlineData("roles")]
+    [InlineData(" roles ")]
+    public void Applies_Configured_Role_Claim_Type_Trimmed(string roleClaimType)
+    {
+        // Keycloak deployments set Auth:RoleClaimType=roles.
+        var options = BuildOptions(roleClaimType);
+
+        Assert.Equal("roles", options.TokenValidationParameters.RoleClaimType);
+    }
+}


### PR DESCRIPTION
## Why

The API + Web are migrating from Auth0 to Keycloak (all envs except kursinord-prod), driven from `eventuras-infra`. The API relied on .NET's default role claim type (`ClaimTypes.Role` = the Microsoft role URI), which only worked because Auth0 emitted roles under that exact URI. Keycloak emits roles under the standard `roles` claim.

The Web app already reads roles from a configurable env var (`OIDC_ROLES_CLAIM`). This makes the API symmetric: the role claim name is now configuration instead of hardcoded. Infra already sets `Auth__RoleClaimType: "roles"`.

## What

- `Config/AuthSettings.cs` — add `RoleClaimType`.
- `Auth/JwtBearerConfiguration.cs` — accept an optional `roleClaimType` and apply it to `TokenValidationParameters.RoleClaimType`, defaulting to `ClaimTypes.Role` when unset.
- `Program.cs` — pass `Auth:RoleClaimType` through.

When `Auth:RoleClaimType` is unset, behavior is identical to today (Microsoft URI) — existing Auth0 deployments and tests are unaffected. Keycloak environments opt in with `Auth:RoleClaimType=roles`. The default inbound claim mapping renames `role` (singular) but leaves `roles` untouched, so `RoleClaimType = "roles"` resolves without touching `DefaultMapInboundClaims`.

## Verification

New `JwtBearerConfigurationTests` (2 tests, passing) drive the real `AddJwtBearerConfiguration` extension and assert the resulting `RoleClaimType`:
- unset → `ClaimTypes.Role` (Auth0 regression — unchanged)
- `"roles"` → `"roles"` (Keycloak opt-in)

Tested at the options level because the shared integration harness (`CustomWebApiApplicationFactory`) rebuilds `TokenValidationParameters` from scratch and would discard a production `RoleClaimType`. The end-to-end "Microsoft-URI role claim still authorizes" regression is already covered by the existing controller suite, which issues `ClaimTypes.Role` claims.

## Rollout coupling

The migration test bed is `kursinord-eventuras-api-staging` (Keycloak-backed, canary image). This must land in canary before infra can validate end-to-end. Will flag when merged + canary published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)