### PR TITLE
fix(fides-auth): preserve callback path in OIDC redirect_uri

### DIFF
--- a/.changeset/fides-callback-path.md
+++ b/.changeset/fides-callback-path.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/fides-auth-next": patch
+---
+
+Preserve the request path when reconstructing the OIDC callback URL. Behind a TLS-terminating proxy the token-exchange `redirect_uri` collapsed to `/`, causing Keycloak to reject login with `invalid_redirect_uri`.

--- a/apps/web/src/app/(auth)/api/auth/callback/oidc/route.ts
+++ b/apps/web/src/app/(auth)/api/auth/callback/oidc/route.ts
@@ -1,9 +1,13 @@
 import { handleOidcCallback } from '@eventuras/fides-auth-next/oidc-callback';
+import { Logger } from '@eventuras/logger';
 
 import { appConfig } from '@/config.server';
 import { oauthConfig } from '@/utils/oauthConfig';
 
+const logger = Logger.create({ namespace: 'web:auth:callback' });
+
 export async function GET(request: Request): Promise<Response> {
+  logger.debug({ path: new URL(request.url).pathname }, 'Handling OIDC callback');
   return handleOidcCallback(request, {
     oauthConfig,
     applicationUrl: appConfig.env.APPLICATION_URL as string,

--- a/libs/fides-auth-next/src/oidc-callback.test.ts
+++ b/libs/fides-auth-next/src/oidc-callback.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for the proxy callback-path bug.
+ *
+ * Behind a TLS-terminating proxy `applicationUrl` is just the origin, so the
+ * reconstructed callback URL must take its path from the incoming request.
+ * If it doesn't, the token-exchange redirect_uri collapses to "/" and Keycloak
+ * rejects it with invalid_redirect_uri (Auth0 tolerated the mismatch).
+ *
+ * We mock the OAuth machinery (tested in @eventuras/fides-auth) and assert on
+ * the URL handed to exchangeAuthorizationCode.
+ */
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('@eventuras/fides-auth/oauth', () => ({
+  exchangeAuthorizationCode: vi.fn(),
+  buildSessionFromTokens: vi.fn(),
+  validateReturnUrl: vi.fn(),
+}));
+vi.mock('./cookies', () => ({
+  getAuthCookie: vi.fn(),
+  setSessionCookie: vi.fn(),
+  deleteAuthCookies: vi.fn(),
+}));
+vi.mock('./request', () => ({
+  globalGETRateLimit: vi.fn(),
+}));
+vi.mock('./session', () => ({
+  createSession: vi.fn(),
+}));
+
+import { handleOidcCallback } from './oidc-callback';
+import {
+  exchangeAuthorizationCode,
+  buildSessionFromTokens,
+  validateReturnUrl,
+} from '@eventuras/fides-auth/oauth';
+import { getAuthCookie } from './cookies';
+import { globalGETRateLimit } from './request';
+import { createSession } from './session';
+
+const mockedExchange = vi.mocked(exchangeAuthorizationCode);
+const mockedBuildSession = vi.mocked(buildSessionFromTokens);
+const mockedValidateReturnUrl = vi.mocked(validateReturnUrl);
+const mockedGetAuthCookie = vi.mocked(getAuthCookie);
+const mockedRateLimit = vi.mocked(globalGETRateLimit);
+const mockedCreateSession = vi.mocked(createSession);
+
+const config = {
+  oauthConfig: {
+    issuer: 'https://id.example.test/realms/test',
+    clientId: 'web',
+    clientSecret: 'shh',
+    redirect_uri: 'https://host.example.test/api/auth/callback/oidc',
+    scope: 'openid',
+  },
+  // Public origin only — no path — as seen behind a TLS-terminating proxy.
+  applicationUrl: 'https://host.example.test',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedRateLimit.mockResolvedValue(true);
+  mockedGetAuthCookie.mockImplementation(async (name: string) =>
+    name === 'oauth_state' ? 'xyz' : name === 'oauth_code_verifier' ? 'verifier' : null,
+  );
+  mockedExchange.mockResolvedValue({ accessToken: 'a' } as any);
+  mockedBuildSession.mockReturnValue({} as any);
+  mockedCreateSession.mockResolvedValue('jwt');
+  mockedValidateReturnUrl.mockReturnValue(new URL('https://host.example.test/'));
+});
+
+describe('handleOidcCallback — proxy callback path', () => {
+  it('passes the full callback path and https scheme to the token exchange', async () => {
+    // Internal hop arrives over http at the callback path with the auth code.
+    const request = new Request(
+      'http://internal/api/auth/callback/oidc?code=abc&state=xyz',
+    );
+
+    const response = await handleOidcCallback(request, config);
+
+    expect(response.status).toBe(302);
+    expect(mockedExchange).toHaveBeenCalledTimes(1);
+
+    const passedUrl = mockedExchange.mock.calls[0]![1] as URL;
+    expect(passedUrl.pathname).toBe('/api/auth/callback/oidc');
+    expect(passedUrl.protocol).toBe('https:');
+    expect(passedUrl.host).toBe('host.example.test');
+    expect(passedUrl.searchParams.get('code')).toBe('abc');
+  });
+});

--- a/libs/fides-auth-next/src/oidc-callback.ts
+++ b/libs/fides-auth-next/src/oidc-callback.ts
@@ -92,9 +92,12 @@ export async function handleOidcCallback(
   }
 
   try {
-    // 2) Reconstruct the public callback URL
+    // 2) Reconstruct the public callback URL. Keep the request path: behind a
+    // TLS-terminating proxy applicationUrl is just the origin ("/"), and the
+    // token-exchange redirect_uri must match the callback path used at authorize.
     const currentUrl = new URL(request.url);
     const publicUrl = new URL(applicationUrl);
+    publicUrl.pathname = currentUrl.pathname;
     publicUrl.search = currentUrl.search;
 
     // 3) Read PKCE cookies


### PR DESCRIPTION
## Why

Web is migrating from Auth0 to Keycloak. Login fails at the token-exchange step with *"An unexpected error occurred. Please restart the login process."* The server log shows `invalid_grant "Incorrect redirect_uri"` (400); Keycloak's event log shows `CODE_TO_TOKEN_ERROR → invalid_redirect_uri`:

- `LOGIN (authorize)` → `redirect_uri = https://host/api/auth/callback/oidc` ✅
- `CODE_TO_TOKEN` → `redirect_uri = https://host/` ❌

Auth0 tolerated the mismatch; Keycloak validates strictly, so the migration surfaced it. Client, issuer, audience and registered redirect URIs are all correct — this is purely client-side URL construction.

## Root cause

`oidc-callback.ts` reconstructed the public callback URL from `applicationUrl` but copied only the query string, never the path:

```ts
const publicUrl = new URL(applicationUrl);  // origin only behind a proxy → pathname "/"
publicUrl.search = currentUrl.search;       // copies ?code&state — but NOT pathname
```

`oauth.ts` (`exchangeAuthorizationCode`) then anchors the origin to `oauthConfig.redirect_uri` (the earlier proxy-scheme fix) but copies the path from this URL — `pathname = "/"` clobbers the correct path. openid-client derives the token request's `redirect_uri` from it → `https://host/`, which no longer matches the authorize value → Keycloak rejects.

The earlier `oauth.ts` fix corrected the scheme (http→https); the path was still lost upstream. Both must be correct.

## Fix

One line in `oidc-callback.ts` — preserve the request path:

```ts
publicUrl.pathname = currentUrl.pathname;
publicUrl.search = currentUrl.search;
```

## Verification

- New `oidc-callback.test.ts`: given `applicationUrl = https://host` and `request.url = http://internal/api/auth/callback/oidc?code=…`, asserts the URL passed to `exchangeAuthorizationCode` has pathname `/api/auth/callback/oidc` and scheme `https`. The assertion targets the changed line directly (without the fix, pathname is `/`).
- Full package suite: 18/18 green; `pnpm build` clean.
- **End-to-end (pending, infra)**: log in on web-staging against Keycloak (`id.losol.no/realms/losol`) and confirm a session is established; Keycloak event log should show `CODE_TO_TOKEN` with no error.

## Rollout coupling

`apps/web` depends on `@eventuras/fides-auth-next` via `workspace:*`, so a new eventuras-web image (canary / next `main-<sha>`) picks up the fix. Other consumers behind a TLS-terminating proxy (Ignis, idem-admin) benefit too. Will flag when merged + a web canary is published — infra is ready to validate immediately on kursinord-staging and losol staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)