### PR TITLE
feat(web): add create-organization drawer to admin

### DIFF
--- a/.changeset/admin-create-organization.md
+++ b/.changeset/admin-create-organization.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/web": minor
+---
+
+Add a "Create new organization" drawer to the admin organizations page. Submits to the existing `POST /v3/organizations` endpoint (SystemAdmin only) and redirects to the new organization so an admin can immediately add members.

--- a/apps/web/locales/en-US/admin.json
+++ b/apps/web/locales/en-US/admin.json
@@ -130,6 +130,21 @@
     }
   },
   "organizations": {
+    "create": {
+      "button": "Create new organization",
+      "title": "Create new organization",
+      "name": "Name",
+      "description": "Description",
+      "url": "Website",
+      "email": "Email",
+      "phone": "Phone",
+      "nameRequired": "Name is required",
+      "submit": "Create",
+      "submitting": "Creating…",
+      "cancel": "Cancel",
+      "success": "Organization created",
+      "error": "Could not create organization"
+    },
     "page": {
       "title": "Organizations"
     }

--- a/apps/web/locales/nb-NO/admin.json
+++ b/apps/web/locales/nb-NO/admin.json
@@ -130,6 +130,21 @@
     }
   },
   "organizations": {
+    "create": {
+      "button": "Opprett ny organisasjon",
+      "title": "Opprett ny organisasjon",
+      "name": "Navn",
+      "description": "Beskrivelse",
+      "url": "Nettside",
+      "email": "E-post",
+      "phone": "Telefon",
+      "nameRequired": "Navn er påkrevd",
+      "submit": "Opprett",
+      "submitting": "Oppretter…",
+      "cancel": "Avbryt",
+      "success": "Organisasjon opprettet",
+      "error": "Kunne ikke opprette organisasjon"
+    },
     "page": {
       "title": "Organisasjoner"
     }

--- a/apps/web/src/app/(admin)/admin/organizations/CreateOrganization.tsx
+++ b/apps/web/src/app/(admin)/admin/organizations/CreateOrganization.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import { Logger } from '@eventuras/logger';
+import { Button } from '@eventuras/ratio-ui/core/Button';
+import { TextField } from '@eventuras/ratio-ui/forms';
+import { Drawer } from '@eventuras/ratio-ui/layout/Drawer';
+import { useToast } from '@eventuras/ratio-ui/toast';
+
+import { createOrganization } from './actions';
+
+const logger = Logger.create({
+  namespace: 'web:admin:organizations',
+  context: { component: 'CreateOrganization' },
+});
+
+const emptyForm = { name: '', description: '', url: '', email: '', phone: '' };
+
+/** Button + drawer to create a new organization (SystemAdmin only). */
+export const CreateOrganization: React.FC = () => {
+  const t = useTranslations();
+  const router = useRouter();
+  const toast = useToast();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [form, setForm] = useState(emptyForm);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Force-close: resets and closes regardless of in-flight state (success path).
+  const closeDrawer = () => {
+    setForm(emptyForm);
+    setError(null);
+    setIsSaving(false);
+    setIsOpen(false);
+  };
+
+  // User-initiated close (drawer backdrop / Cancel): blocked while saving so an
+  // in-flight request can't redirect or set an error after the user dismissed it.
+  const requestClose = () => {
+    if (isSaving) return;
+    closeDrawer();
+  };
+
+  const update =
+    (field: keyof typeof emptyForm) =>
+    (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setForm(prev => ({ ...prev, [field]: e.target.value }));
+      if (error) setError(null);
+    };
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      setError(t('admin.organizations.create.nameRequired'));
+      return;
+    }
+    setIsSaving(true);
+    setError(null);
+    try {
+      const result = await createOrganization(form);
+      if (!result.success) {
+        setError(result.error.message || t('admin.organizations.create.error'));
+        return;
+      }
+      toast.success(t('admin.organizations.create.success'));
+      const id = result.data.organizationId;
+      closeDrawer();
+      // Land on the new org so the admin can add themselves as a member.
+      router.push(`/admin/organizations/${id}`);
+      router.refresh();
+    } catch (err) {
+      logger.error({ error: err, name: form.name }, 'Failed to create organization');
+      setError(t('admin.organizations.create.error'));
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={() => setIsOpen(true)}>{t('admin.organizations.create.button')}</Button>
+
+      <Drawer isOpen={isOpen} onClose={requestClose}>
+        <Drawer.Header as="h2">{t('admin.organizations.create.title')}</Drawer.Header>
+        <Drawer.Body>
+          <div className="space-y-4">
+            <TextField
+              name="name"
+              label={t('admin.organizations.create.name')}
+              value={form.name}
+              onChange={update('name')}
+              disabled={isSaving}
+              autoFocus
+              required
+            />
+            <TextField
+              name="description"
+              label={t('admin.organizations.create.description')}
+              value={form.description}
+              onChange={update('description')}
+              disabled={isSaving}
+              multiline
+              rows={3}
+            />
+            <TextField
+              name="url"
+              type="url"
+              label={t('admin.organizations.create.url')}
+              value={form.url}
+              onChange={update('url')}
+              disabled={isSaving}
+            />
+            <TextField
+              name="email"
+              type="email"
+              label={t('admin.organizations.create.email')}
+              value={form.email}
+              onChange={update('email')}
+              disabled={isSaving}
+            />
+            <TextField
+              name="phone"
+              type="tel"
+              label={t('admin.organizations.create.phone')}
+              value={form.phone}
+              onChange={update('phone')}
+              disabled={isSaving}
+            />
+            {error && (
+              <p className="text-red-600 text-sm" role="alert">
+                {error}
+              </p>
+            )}
+          </div>
+        </Drawer.Body>
+        <Drawer.Footer>
+          <div className="flex gap-2 justify-end">
+            <Button variant="secondary" onClick={requestClose} disabled={isSaving}>
+              {t('admin.organizations.create.cancel')}
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving || !form.name.trim()}>
+              {isSaving
+                ? t('admin.organizations.create.submitting')
+                : t('admin.organizations.create.submit')}
+            </Button>
+          </div>
+        </Drawer.Footer>
+      </Drawer>
+    </>
+  );
+};

--- a/apps/web/src/app/(admin)/admin/organizations/actions.ts
+++ b/apps/web/src/app/(admin)/admin/organizations/actions.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { formatApiError } from '@eventuras/core/errors';
+import {
+  actionError,
+  actionSuccess,
+  type ServerActionResult,
+} from '@eventuras/core-nextjs/actions';
+import { Logger } from '@eventuras/logger';
+
+import { readCorrelationIdFromResponse } from '@/lib/correlation-id';
+import { postV3Organizations } from '@/lib/eventuras-sdk';
+
+const logger = Logger.create({
+  namespace: 'web:admin:organizations',
+  context: { action: 'createOrganization' },
+});
+
+export interface CreateOrganizationInput {
+  name: string;
+  description?: string;
+  url?: string;
+  email?: string;
+  phone?: string;
+}
+
+/** Create a new organization. Requires SystemAdmin on the API. */
+export async function createOrganization(
+  input: CreateOrganizationInput
+): Promise<ServerActionResult<{ organizationId: number }>> {
+  if (!input.name?.trim()) {
+    return actionError('Organization name is required');
+  }
+
+  try {
+    const response = await postV3Organizations({
+      body: {
+        name: input.name.trim(),
+        description: input.description?.trim() || undefined,
+        url: input.url?.trim() || undefined,
+        email: input.email?.trim() || undefined,
+        phone: input.phone?.trim() || undefined,
+      },
+    });
+
+    if (!response.data?.organizationId) {
+      logger.error({ error: response.error }, 'Failed to create organization');
+      return actionError(
+        formatApiError(
+          response.error,
+          'Failed to create organization',
+          response.response?.status,
+          response.response ? readCorrelationIdFromResponse(response.response) : undefined
+        )
+      );
+    }
+
+    logger.info({ organizationId: response.data.organizationId }, 'Organization created');
+    revalidatePath('/admin/organizations');
+
+    return actionSuccess({ organizationId: response.data.organizationId });
+  } catch (error) {
+    logger.error({ error }, 'Error creating organization');
+    return actionError('An unexpected error occurred while creating the organization');
+  }
+}

--- a/apps/web/src/app/(admin)/admin/organizations/page.tsx
+++ b/apps/web/src/app/(admin)/admin/organizations/page.tsx
@@ -8,6 +8,8 @@ import { Link } from '@eventuras/ratio-ui-next/Link';
 
 import { getV3Organizations } from '@/lib/eventuras-sdk';
 
+import { CreateOrganization } from './CreateOrganization';
+
 const AdminOrganizationsPage = async () => {
   const t = await getTranslations();
   const organizations = await getV3Organizations();
@@ -15,17 +17,20 @@ const AdminOrganizationsPage = async () => {
     <>
       <Section className="py-8">
         <Container>
-          <Heading as="h1">{t('admin.organizations.page.title')}</Heading>
+          <div className="flex items-center justify-between gap-4">
+            <Heading as="h1">{t('admin.organizations.page.title')}</Heading>
+            <CreateOrganization />
+          </div>
         </Container>
       </Section>
       <Section>
         <Container>
           <List>
             {organizations?.data?.map(org => (
-                <List.Item key={org.organizationId}>
-                  <Link href={`/admin/organizations/${org.organizationId}`}>{org.name}</Link>
-                </List.Item>
-              ))}
+              <List.Item key={org.organizationId}>
+                <Link href={`/admin/organizations/${org.organizationId}`}>{org.name}</Link>
+              </List.Item>
+            ))}
           </List>
         </Container>
       </Section>


### PR DESCRIPTION
## What

Adds a **Create new organization** button + drawer to the admin organizations list ([organizations/page.tsx](apps/web/src/app/(admin)/admin/organizations/page.tsx)). The drawer collects name (required), description, website, email and phone, posts to the existing `POST /v3/organizations` endpoint, and on success redirects to the new org's detail page so an admin can immediately add members.

- New client island `CreateOrganization.tsx` (button + drawer, mirrors the `AddMemberDrawer` pattern).
- New server action `createOrganization` in `organizations/actions.ts` (`postV3Organizations`, `revalidatePath`, typed `ServerActionResult`).
- en-US / nb-NO strings.

## Why now

Bootstrapping a fresh (Keycloak-backed) environment: there were no organizations, so a SystemAdmin had no way to create the first org from the UI in order to add themselves as a member. The backend (`POST /v3/organizations`) and SDK (`postV3Organizations`) already existed — only the UI affordance was missing.

## Authorization

`POST /v3/organizations` is gated to **SystemAdmin** (the whole `OrganizationsController` is `[Authorize(Roles = SystemAdmin)]`). A non-SystemAdmin who opens the drawer will get a 403, surfaced as an inline error. The button is not yet role-hidden in the UI — see follow-up.

## Verification

- `tsc --noEmit`: 0 errors. `eslint`: clean.
- Manual e2e pending (needs a SystemAdmin session against an env where the role claim is recognized — see note below).

## Follow-up

- Hide the button for non-SystemAdmin sessions (API already enforces it).
- The empty-list-vs-403 ambiguity on the list page is a separate UX gap (a 403 from the API currently renders as "no organizations").

🤖 Generated with [Claude Code](https://claude.com/claude-code)