### PR TITLE
chore(api): harden and document auth claim mapping

### DIFF
--- a/.changeset/auth-claim-mapping-review.md
+++ b/.changeset/auth-claim-mapping-review.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/api": patch
+---
+
+Harden auth claim mapping: `GetRoles()` now reads roles per identity using each identity's `RoleClaimType` (so it respects `Auth:RoleClaimType` instead of a hardcoded claim type), add `RequireScopeHandler` tests covering the issuer-coupled scope claim, and document the claim → usage mapping and Keycloak requirements in `docs/auth-claims.md`.

--- a/apps/api/docs/auth-claims.md
+++ b/apps/api/docs/auth-claims.md
@@ -1,0 +1,41 @@
+# Authentication claim mapping
+
+How the API turns an incoming OIDC token into an authenticated principal, and
+what the identity provider (Auth0 or Keycloak) must emit for it to work.
+
+## Claim → usage
+
+| Concern | Claim read | Mechanism |
+| --- | --- | --- |
+| Roles (authorization) | `Auth:RoleClaimType` (e.g. `roles` for Keycloak; defaults to the .NET `ClaimTypes.Role` URI) | Configured on the JWT bearer in [`JwtBearerConfiguration`](../src/Eventuras.WebApi/Auth/JwtBearerConfiguration.cs); drives `IsInRole`, `[Authorize(Roles=…)]`, `IsSystemAdmin()`, `IsAdmin()` |
+| Email | `email` → `ClaimTypes.Email` | .NET **default inbound claim mapping** (`MapInboundClaims` is left at its default `true` — not set in code) |
+| Name | `name` → `ClaimTypes.Name` | Same default inbound mapping |
+| Scopes | `scope` (space-delimited) | [`RequireScopeHandler`](../src/Eventuras.WebApi/Auth/RequireScopeHandler.cs); the claim's `Issuer` must equal `Auth:Issuer` |
+| DB user id | `ClaimTypes.NameIdentifier` on the `Eventuras.Database` identity | Added by [`DbUserClaimTransformation`](../src/Eventuras.WebApi/DbUserClaimTransformation.cs) after resolving the DB user |
+| Org-member roles | `ClaimTypes.Role` on the `Eventuras.Database` identity | Added by `DbUserClaimTransformation` for the **current** organization only |
+
+Only **roles** and **scope** are handled explicitly; email and name ride on the
+framework default inbound mapping. `GetRoles()` reads roles per identity using
+each identity's `RoleClaimType`, so it stays correct regardless of `Auth:RoleClaimType`.
+
+## What the IdP must emit
+
+- **Roles**: a top-level `roles` claim. Keycloak places client roles under
+  `resource_access.{client}.roles` by default — neither the API nor the web app
+  reads that shape, so a "User Client Role" protocol mapper must flatten roles
+  into a flat `roles` claim. It must be added to **both** tokens:
+  - the **access token** (consumed by this API), and
+  - the **ID token** (consumed by the web session — `fides-auth` decodes the
+    `id_token`).
+- **Email**: the `email` scope/mapper (Keycloak emits this by default). Email is
+  currently the join key between the IdP identity and the DB user
+  (`GetUserByEmailAsync`).
+- **Issuer**: the token `iss` must exactly equal `Auth:Issuer` (used for both
+  issuer validation and the scope-claim filter).
+
+## Known fragility / future work
+
+The DB user is resolved by **email**, which is mutable — changing a user's email
+in the IdP breaks the link. The robust fix is to key on the stable `sub` (store
+it on `ApplicationUser` as an external-login mapping and resolve by `sub`,
+backfilling by email on first login). Tracked separately; not required to run.

--- a/apps/api/src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs
+++ b/apps/api/src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs
@@ -22,8 +22,15 @@ public static class ClaimsPrincipalExtensions
 
     public static string? GetMobilePhone(this ClaimsPrincipal user) => user.FindFirstValue(ClaimTypes.MobilePhone);
 
+    // Read roles per identity using that identity's RoleClaimType (same basis as
+    // IsInRole): the JWT identity uses the configured Auth:RoleClaimType (e.g.
+    // "roles" for Keycloak), the DB identity uses ClaimTypes.Role. A hardcoded
+    // ClaimTypes.Role here would miss IdP roles when RoleClaimType is "roles".
     public static IEnumerable<string> GetRoles(this ClaimsPrincipal user) =>
-        user.FindAll(ClaimTypes.Role).Select(c => c.Value);
+        user.Identities
+            .SelectMany(identity => identity.FindAll(identity.RoleClaimType))
+            .Select(c => c.Value)
+            .Distinct();
 
     public static bool IsAdmin(this ClaimsPrincipal user) =>
         new[] { Roles.Admin, Roles.SystemAdmin }.Any(user.IsInRole);

--- a/apps/api/src/Eventuras.WebApi/Auth/RequireScopeHandler.cs
+++ b/apps/api/src/Eventuras.WebApi/Auth/RequireScopeHandler.cs
@@ -21,6 +21,10 @@ public class RequireScopeHandler : AuthorizationHandler<ScopeRequirement>
 {
     protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, ScopeRequirement requirement)
     {
+        // The scope claim's Issuer must equal Auth:Issuer (the token "iss"). A
+        // mismatch (e.g. a trailing-slash difference after an IdP change) silently
+        // fails the requirement rather than erroring — keep Auth:Issuer exact.
+        // Both Auth0 and Keycloak emit a single space-delimited "scope" claim.
         var scopeClaim = context.User.FindFirst(c => c.Type == "scope" && c.Issuer == requirement.Issuer);
         if (scopeClaim == null || string.IsNullOrEmpty(scopeClaim.Value))
         {

--- a/apps/api/src/Eventuras.WebApi/DbUserClaimTransformation.cs
+++ b/apps/api/src/Eventuras.WebApi/DbUserClaimTransformation.cs
@@ -50,6 +50,9 @@ public class DbUserClaimTransformation : IClaimsTransformation
 
         try
         {
+            // Email is the join key between the IdP identity and the DB user.
+            // It relies on the token carrying `email` (mapped to ClaimTypes.Email
+            // via default inbound mapping). See docs/auth-claims.md.
             var dbUser = await _userRetrievalService.GetUserByEmailAsync(userEmail);
 
             var identity = new ClaimsIdentity(EventurasDbAuthType);

--- a/apps/api/tests/Eventuras.WebApi.Tests/Auth/RequireScopeHandlerTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Auth/RequireScopeHandlerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Eventuras.WebApi.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Eventuras.WebApi.Tests.Auth;
+
+public class RequireScopeHandlerTests
+{
+    private const string Issuer = "https://auth.example.test/realms/test";
+
+    private static async Task<bool> HandleAsync(string scopeValue, string claimIssuer, string requiredScope)
+    {
+        var requirement = new ScopeRequirement(Issuer, requiredScope);
+        var claims = scopeValue is null
+            ? Array.Empty<Claim>()
+            : new[] { new Claim("scope", scopeValue, ClaimValueTypes.String, claimIssuer) };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestAuth"));
+        var context = new AuthorizationHandlerContext(new[] { requirement }, principal, resource: null);
+
+        await new RequireScopeHandler().HandleAsync(context);
+        return context.HasSucceeded;
+    }
+
+    [Fact]
+    public async Task Grants_When_Required_Scope_Present() =>
+        Assert.True(await HandleAsync("eventuras:admin", Issuer, "eventuras:admin"));
+
+    // Both Auth0 and Keycloak emit a single space-delimited "scope" claim.
+    [Fact]
+    public async Task Grants_When_Scope_Among_Space_Delimited() =>
+        Assert.True(await HandleAsync("openid profile eventuras:admin", Issuer, "eventuras:admin"));
+
+    // The Issuer filter is exact: a trailing-slash difference denies silently.
+    [Fact]
+    public async Task Denies_When_Issuer_Mismatches() =>
+        Assert.False(await HandleAsync("eventuras:admin", Issuer + "/", "eventuras:admin"));
+
+    [Fact]
+    public async Task Denies_When_Scope_Claim_Absent() =>
+        Assert.False(await HandleAsync(null, Issuer, "eventuras:admin"));
+}


### PR DESCRIPTION
Review of the role/claim mappings surfaced by the Auth0→Keycloak migration. **No behavior change to the unblock** — getting login working is config/infra (`Auth:RoleClaimType=roles` + a Keycloak protocol mapper). This PR is the hardening + documentation so it doesn't bite again.

## Changes

- **`GetRoles()` cleanup** ([ClaimsPrincipalExtensions.cs](apps/api/src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs)) — was hardcoded to `FindAll(ClaimTypes.Role)`, which would miss Keycloak's `roles` when `Auth:RoleClaimType=roles`. Now reads roles per identity using each identity's `RoleClaimType` (the same basis as `IsInRole`). The method was previously unused, so this is a latent-trap fix, not a live bug.
- **Scope handler tests** ([RequireScopeHandlerTests.cs](apps/api/tests/Eventuras.WebApi.Tests/Auth/RequireScopeHandlerTests.cs)) — cover the single space-delimited `scope` claim (both Auth0 and Keycloak emit this shape) and the **exact issuer coupling**: the scope claim's `Issuer` must equal `Auth:Issuer`, and a mismatch (e.g. a trailing-slash difference after an IdP change) denies silently. Added a comment in [RequireScopeHandler](apps/api/src/Eventuras.WebApi/Auth/RequireScopeHandler.cs) to that effect.
- **Documentation** ([docs/auth-claims.md](apps/api/docs/auth-claims.md)) — claim → usage table, that email/name ride on .NET default inbound mapping while only roles/scope are explicit, and what the IdP must emit (a flat `roles` claim via a protocol mapper on **both** the access token (API) and the ID token (web session); `email`; exact `iss`). Plus a pointer comment in `DbUserClaimTransformation` noting email is the join key.

## What this is NOT

Identity is still resolved by **email** (mutable). Switching the join key to the stable `sub` is noted as future work in the doc and intentionally left out of this PR.

## Verification

`dotnet build` clean; `Eventuras.WebApi.Tests.Auth` namespace 9/9 green (4 new scope tests + the existing 5 JWT-config cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)