### PR TITLE
fix(api): enhance claim handling and add tests for raw OIDC claims

### DIFF
--- a/apps/api/docs/auth-claims.md
+++ b/apps/api/docs/auth-claims.md
@@ -8,15 +8,18 @@ what the identity provider (Auth0 or Keycloak) must emit for it to work.
 | Concern | Claim read | Mechanism |
 | --- | --- | --- |
 | Roles (authorization) | `Auth:RoleClaimType` (e.g. `roles` for Keycloak; defaults to the .NET `ClaimTypes.Role` URI) | Configured on the JWT bearer in [`JwtBearerConfiguration`](../src/Eventuras.WebApi/Auth/JwtBearerConfiguration.cs); drives `IsInRole`, `[Authorize(Roles=…)]`, `IsSystemAdmin()`, `IsAdmin()` |
-| Email | `email` → `ClaimTypes.Email` | .NET **default inbound claim mapping** (`MapInboundClaims` is left at its default `true` — not set in code) |
-| Name | `name` → `ClaimTypes.Name` | Same default inbound mapping |
+| Email | `ClaimTypes.Email` or raw `email` | [`ClaimsPrincipalExtensions.GetEmail()`](../src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs) supports both mapped and raw JWT claims |
+| Name | `ClaimTypes.Name` or raw `name` | [`ClaimsPrincipalExtensions.GetName()`](../src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs) supports both mapped and raw JWT claims |
 | Scopes | `scope` (space-delimited) | [`RequireScopeHandler`](../src/Eventuras.WebApi/Auth/RequireScopeHandler.cs); the claim's `Issuer` must equal `Auth:Issuer` |
 | DB user id | `ClaimTypes.NameIdentifier` on the `Eventuras.Database` identity | Added by [`DbUserClaimTransformation`](../src/Eventuras.WebApi/DbUserClaimTransformation.cs) after resolving the DB user |
 | Org-member roles | `ClaimTypes.Role` on the `Eventuras.Database` identity | Added by `DbUserClaimTransformation` for the **current** organization only |
 
-Only **roles** and **scope** are handled explicitly; email and name ride on the
-framework default inbound mapping. `GetRoles()` reads roles per identity using
-each identity's `RoleClaimType`, so it stays correct regardless of `Auth:RoleClaimType`.
+When `Auth:RoleClaimType` is blank, JWT bearer keeps the framework default
+inbound claim mapping for compatibility with existing Auth0 tokens. When
+`Auth:RoleClaimType` is set (for example to `roles`), inbound mapping is disabled
+so the raw JWT claim name remains available to `IsInRole` and
+`[Authorize(Roles=…)]`. `GetRoles()` reads roles per identity using each
+identity's `RoleClaimType`, so it stays correct regardless of `Auth:RoleClaimType`.
 
 ## What the IdP must emit
 

--- a/apps/api/src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs
+++ b/apps/api/src/Eventuras.Services/Auth/ClaimsPrincipalExtensions.cs
@@ -9,6 +9,10 @@ namespace Eventuras.Services.Auth;
 
 public static class ClaimsPrincipalExtensions
 {
+    private const string EmailClaimType = "email";
+    private const string NameClaimType = "name";
+    private const string PhoneNumberClaimType = "phone_number";
+
     public static Guid? GetUserId(this ClaimsPrincipal user)
     {
         var dbIdentity = user.Identities.FirstOrDefault(i => i.AuthenticationType == "Eventuras.Database");
@@ -16,11 +20,14 @@ public static class ClaimsPrincipalExtensions
         return value != null && Guid.TryParse(value, out var id) ? id : null;
     }
 
-    public static string? GetEmail(this ClaimsPrincipal user) => user.FindFirstValue(ClaimTypes.Email);
+    public static string? GetEmail(this ClaimsPrincipal user) =>
+        user.FindFirstValue(ClaimTypes.Email) ?? user.FindFirstValue(EmailClaimType);
 
-    public static string? GetName(this ClaimsPrincipal user) => user.FindFirstValue(ClaimTypes.Name);
+    public static string? GetName(this ClaimsPrincipal user) =>
+        user.FindFirstValue(ClaimTypes.Name) ?? user.FindFirstValue(NameClaimType);
 
-    public static string? GetMobilePhone(this ClaimsPrincipal user) => user.FindFirstValue(ClaimTypes.MobilePhone);
+    public static string? GetMobilePhone(this ClaimsPrincipal user) =>
+        user.FindFirstValue(ClaimTypes.MobilePhone) ?? user.FindFirstValue(PhoneNumberClaimType);
 
     // Read roles per identity using that identity's RoleClaimType (same basis as
     // IsInRole): the JWT identity uses the configured Auth:RoleClaimType (e.g.

--- a/apps/api/src/Eventuras.WebApi/Auth/JwtBearerConfiguration.cs
+++ b/apps/api/src/Eventuras.WebApi/Auth/JwtBearerConfiguration.cs
@@ -16,15 +16,20 @@ public static class JwtBearerConfiguration
         string audience, string jwtSecret, string roleClaimType = null) =>
         builder.AddJwtBearer(options =>
         {
+            var useDefaultInboundClaimMapping = string.IsNullOrWhiteSpace(roleClaimType);
+
             options.Authority = issuer;
+            options.MapInboundClaims = useDefaultInboundClaimMapping;
             options.SaveToken = true;
             options.TokenValidationParameters = new TokenValidationParameters
             {
                 ValidateIssuer = true,
                 IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
                 ValidAudiences = new List<string> { audience, issuer.TrimEnd('/') + "/userinfo" },
-                // Default preserves current Auth0 behavior; Keycloak deployments set Auth:RoleClaimType=roles
-                RoleClaimType = string.IsNullOrWhiteSpace(roleClaimType) ? ClaimTypes.Role : roleClaimType.Trim()
+                // Default preserves current Auth0 behavior. When a custom role claim
+                // is configured, keep raw JWT claim names so "roles" remains "roles".
+                RoleClaimType = useDefaultInboundClaimMapping ? ClaimTypes.Role : roleClaimType.Trim(),
+                NameClaimType = useDefaultInboundClaimMapping ? ClaimTypes.Name : "name"
             };
 
             options.Events = new JwtBearerEvents

--- a/apps/api/src/Eventuras.WebApi/DbUserClaimTransformation.cs
+++ b/apps/api/src/Eventuras.WebApi/DbUserClaimTransformation.cs
@@ -51,8 +51,7 @@ public class DbUserClaimTransformation : IClaimsTransformation
         try
         {
             // Email is the join key between the IdP identity and the DB user.
-            // It relies on the token carrying `email` (mapped to ClaimTypes.Email
-            // via default inbound mapping). See docs/auth-claims.md.
+            // It relies on the token carrying `email`. See docs/auth-claims.md.
             var dbUser = await _userRetrievalService.GetUserByEmailAsync(userEmail);
 
             var identity = new ClaimsIdentity(EventurasDbAuthType);

--- a/apps/api/tests/Eventuras.WebApi.Tests/Auth/ClaimsPrincipalExtensionsTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Auth/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using System.Security.Claims;
+using Eventuras.Services;
+using Eventuras.Services.Auth;
+using Xunit;
+
+namespace Eventuras.WebApi.Tests.Auth;
+
+public class ClaimsPrincipalExtensionsTests
+{
+    [Fact]
+    public void Reads_Raw_Oidc_Claims_When_Inbound_Mapping_Is_Disabled()
+    {
+        var identity = new ClaimsIdentity(
+            new[]
+            {
+                new Claim("email", "person@example.test"),
+                new Claim("name", "Test Person"),
+                new Claim("phone_number", "+4712345678"),
+                new Claim("roles", Roles.Admin)
+            },
+            "Test",
+            "name",
+            "roles");
+
+        var principal = new ClaimsPrincipal(identity);
+
+        Assert.Equal("person@example.test", principal.GetEmail());
+        Assert.Equal("Test Person", principal.GetName());
+        Assert.Equal("+4712345678", principal.GetMobilePhone());
+        Assert.True(principal.IsAdmin());
+        Assert.Equal(new[] { Roles.Admin }, principal.GetRoles().ToArray());
+    }
+}

--- a/apps/api/tests/Eventuras.WebApi.Tests/Auth/JwtBearerConfigurationTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Auth/JwtBearerConfigurationTests.cs
@@ -37,7 +37,9 @@ public class JwtBearerConfigurationTests
         // must also fall back rather than become an invalid claim type.
         var options = BuildOptions(roleClaimType);
 
+        Assert.True(options.MapInboundClaims);
         Assert.Equal(ClaimTypes.Role, options.TokenValidationParameters.RoleClaimType);
+        Assert.Equal(ClaimTypes.Name, options.TokenValidationParameters.NameClaimType);
     }
 
     [Theory]
@@ -48,6 +50,8 @@ public class JwtBearerConfigurationTests
         // Keycloak deployments set Auth:RoleClaimType=roles.
         var options = BuildOptions(roleClaimType);
 
+        Assert.False(options.MapInboundClaims);
         Assert.Equal("roles", options.TokenValidationParameters.RoleClaimType);
+        Assert.Equal("name", options.TokenValidationParameters.NameClaimType);
     }
 }


### PR DESCRIPTION
Disable inbound JWT claim mapping when Auth:RoleClaimType is configured, so raw role claims like "roles" are preserved for authorization checks.

Add fallback lookup for raw OIDC profile claims and cover the behavior with auth regression tests.