### PR TITLE
feat(web): show user id on the account page

### DIFF
--- a/.changeset/account-user-id.md
+++ b/.changeset/account-user-id.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/web": patch
+---
+
+Show the user's own ID in a discreet "User details" accordion at the bottom of the account page (useful for support).

--- a/apps/web/locales/en-US/user.json
+++ b/apps/web/locales/en-US/user.json
@@ -1,5 +1,9 @@
 {
   "account": {
+    "details": {
+      "title": "User details",
+      "userId": "User ID"
+    },
     "create": {
       "label": "Create user"
     },

--- a/apps/web/locales/nb-NO/user.json
+++ b/apps/web/locales/nb-NO/user.json
@@ -1,5 +1,9 @@
 {
   "account": {
+    "details": {
+      "title": "Brukerdetaljer",
+      "userId": "Bruker-ID"
+    },
     "create": {
       "label": "Lag bruker"
     },

--- a/apps/web/src/app/(user)/user/account/page.tsx
+++ b/apps/web/src/app/(user)/user/account/page.tsx
@@ -1,5 +1,7 @@
 import { getTranslations } from 'next-intl/server';
 
+import { Accordion } from '@eventuras/ratio-ui/core/Accordion';
+import { DescriptionList } from '@eventuras/ratio-ui/core/DescriptionList';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 
@@ -13,10 +15,29 @@ const UserAccountPage = async () => {
   if (!response.data) {
     return <div>{t('user.page.profileNotFound')}</div>;
   }
+  const userId = response.data.id;
+
   return (
     <Container>
       <Heading>{t('user.profile.page.heading')}</Heading>
       <UserEditor user={response.data} />
+      {userId && (
+        <Accordion>
+          <Accordion.Item className="mt-8">
+            <Accordion.Summary>{t('user.account.details.title')}</Accordion.Summary>
+            <Accordion.Content>
+              <DescriptionList>
+                <DescriptionList.Item>
+                  <DescriptionList.Term>{t('user.account.details.userId')}</DescriptionList.Term>
+                  <DescriptionList.Definition>
+                    <span className="font-mono select-all">{userId}</span>
+                  </DescriptionList.Definition>
+                </DescriptionList.Item>
+              </DescriptionList>
+            </Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
Adds a discreet **"User details"** accordion (ratio-ui `Accordion`) at the bottom of [/user/account](apps/web/src/app/(user)/user/account/page.tsx), showing the user's own ID in a ratio-ui `DescriptionList` — copy-friendly (`select-all`, monospace). Useful for support.

The ID comes from the existing `getV3Userprofile()` call (`UserDto.id`), so no extra request. en-US / nb-NO strings added.

> Note: a `sub` (login ID) row was considered but dropped — the web session doesn't currently persist `sub` (`buildSessionFromTokens` omits it), and the user ID alone is enough for support. Persisting `sub` in the session is tracked with the identity work (ADR-0007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)