### PR TITLE
feat(api): pending-migrations health check + admin diagnostics panel

### DIFF
--- a/.changeset/admin-health-diagnostics-panel.md
+++ b/.changeset/admin-health-diagnostics-panel.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/web": patch
+---
+
+Surface backend health diagnostics in admin: the `/admin/system` page reads the API's admin-only `/health/diagnostics` and renders each check as a ratio Panel (red on problems), and the `/admin` dashboard shows a warning banner — linking on to the details — whenever a check is not Healthy. Starts with pending database migrations.

--- a/.changeset/pending-migrations-healthcheck.md
+++ b/.changeset/pending-migrations-healthcheck.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/api": minor
+---
+
+Add a pending-migrations health check. Reports Degraded (never Unhealthy) when EF Core migrations exist that haven't been applied, surfaced via the admin-only `GET /health/diagnostics` endpoint. Tagged "diagnostics" and excluded from the probe `/health`, so it can never flip the Kubernetes liveness/readiness probes.

--- a/apps/api/src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj
+++ b/apps/api/src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.6" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/apps/api/src/Eventuras.Infrastructure/HealthChecks/InfrastructureHealthChecksExtensions.cs
+++ b/apps/api/src/Eventuras.Infrastructure/HealthChecks/InfrastructureHealthChecksExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Eventuras.Infrastructure.HealthChecks;
+
+public static class InfrastructureHealthChecksExtensions
+{
+    /// <summary>
+    ///     Registers infrastructure (database) health checks. Tagged "diagnostics"
+    ///     so they are surfaced to admins via /health/diagnostics and kept off the
+    ///     Kubernetes probe /health endpoint. (Tag constant lives in ServiceDefaults
+    ///     for the host wiring; kept as a literal here to avoid a host dependency.)
+    /// </summary>
+    public static IServiceCollection AddInfrastructureHealthChecks(this IServiceCollection services)
+    {
+        services.Configure<HealthCheckServiceOptions>(options =>
+            options.Registrations.Add(new HealthCheckRegistration(
+                "database-migrations",
+                ActivatorUtilities.GetServiceOrCreateInstance<PendingMigrationsHealthCheck>,
+                // Defense in depth: if an exception ever escapes the check, the
+                // framework still treats it as Degraded, never Unhealthy.
+                failureStatus: HealthStatus.Degraded,
+                tags: new[] { "diagnostics" })));
+
+        return services;
+    }
+}

--- a/apps/api/src/Eventuras.Infrastructure/HealthChecks/PendingMigrationsHealthCheck.cs
+++ b/apps/api/src/Eventuras.Infrastructure/HealthChecks/PendingMigrationsHealthCheck.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Eventuras.Infrastructure.HealthChecks;
+
+/// <summary>
+///     Reports <see cref="HealthStatus.Degraded" /> when the database schema is
+///     behind the deployed code — i.e. EF Core migrations exist in the assembly
+///     that have not been applied to the database (migrations are applied
+///     out-of-band here, not at startup).
+///
+///     Deliberately Degraded, never Unhealthy: a pending migration must NOT flip
+///     the Kubernetes probes and trigger a reboot. It is tagged "diagnostics" and
+///     excluded from the probe /health endpoint, then surfaced to admins via
+///     /health/diagnostics.
+/// </summary>
+public sealed class PendingMigrationsHealthCheck : IHealthCheck
+{
+    private readonly ApplicationDbContext _db;
+
+    public PendingMigrationsHealthCheck(ApplicationDbContext db) => _db = db;
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var pending = (await _db.Database.GetPendingMigrationsAsync(cancellationToken)).ToArray();
+
+            if (pending.Length == 0)
+            {
+                return HealthCheckResult.Healthy("Database schema is up to date.");
+            }
+
+            return HealthCheckResult.Degraded(
+                $"{pending.Length} pending migration(s) not applied.",
+                data: new Dictionary<string, object> { ["pending"] = pending });
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Never Unhealthy: a transient DB hiccup while *checking* must not
+            // turn this into a 503 (the contract is Degraded-only).
+            return HealthCheckResult.Degraded("Could not determine pending migrations.", ex);
+        }
+    }
+}

--- a/apps/api/src/Eventuras.ServiceDefaults/Extensions.cs
+++ b/apps/api/src/Eventuras.ServiceDefaults/Extensions.cs
@@ -55,7 +55,7 @@ public static class Extensions
     public static IHostApplicationBuilder AddDefaultHealthChecks(this IHostApplicationBuilder builder)
     {
         builder.Services.AddHealthChecks()
-            .AddCheck("self", () => HealthCheckResult.Healthy(), tags: ["live"]);
+            .AddCheck("self", () => HealthCheckResult.Healthy(), tags: [HealthTags.Live]);
 
         return builder;
     }
@@ -68,7 +68,7 @@ public static class Extensions
     {
         app.MapHealthChecks("/alive", new HealthCheckOptions
         {
-            Predicate = r => r.Tags.Contains("live"),
+            Predicate = r => r.Tags.Contains(HealthTags.Live),
         });
 
         return app;

--- a/apps/api/src/Eventuras.ServiceDefaults/Health/HealthReportWriter.cs
+++ b/apps/api/src/Eventuras.ServiceDefaults/Health/HealthReportWriter.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Eventuras.ServiceDefaults;
+
+/// <summary>
+///     Writes a health report as JSON with per-check detail, so an admin UI can
+///     render each check's status and data (e.g. the list of pending migrations).
+/// </summary>
+public static class HealthReportWriter
+{
+    public static Task WriteJson(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "application/json";
+
+        var payload = new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(e => new
+            {
+                name = e.Key,
+                status = e.Value.Status.ToString(),
+                description = e.Value.Description,
+                data = e.Value.Data,
+            }),
+        };
+
+        return context.Response.WriteAsync(JsonSerializer.Serialize(payload));
+    }
+}

--- a/apps/api/src/Eventuras.ServiceDefaults/Health/HealthTags.cs
+++ b/apps/api/src/Eventuras.ServiceDefaults/Health/HealthTags.cs
@@ -1,0 +1,19 @@
+namespace Eventuras.ServiceDefaults;
+
+/// <summary>
+///     Conventional health-check tags shared across the solution.
+/// </summary>
+public static class HealthTags
+{
+    /// <summary>Liveness — minimal "is the process up" checks (/alive probe).</summary>
+    public const string Live = "live";
+
+    /// <summary>Readiness — "can serve traffic" checks.</summary>
+    public const string Ready = "ready";
+
+    /// <summary>
+    ///     Admin-facing diagnostics (e.g. pending migrations). Excluded from the
+    ///     Kubernetes probe /health endpoint; surfaced via /health/diagnostics.
+    /// </summary>
+    public const string Diagnostics = "diagnostics";
+}

--- a/apps/api/src/Eventuras.WebApi/Program.cs
+++ b/apps/api/src/Eventuras.WebApi/Program.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
+using Eventuras.Infrastructure.HealthChecks;
 using Eventuras.ServiceDefaults;
 using Eventuras.Services;
 using Eventuras.Services.BackgroundJobs;
@@ -165,6 +166,11 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddSingleton<IAuthorizationHandler, RequireScopeHandler>();
 
+// Diagnostics health checks (e.g. pending migrations) live near their subsystem
+// and are registered here. Tagged "diagnostics" → surfaced to admins, kept off
+// the probe /health so they can never flip the Kubernetes probes.
+builder.Services.AddInfrastructureHealthChecks();
+
 builder.Services.AddOpenApi("v3", options =>
 {
     options.AddDocumentTransformer<AddSecuritySchemeTransformer>();
@@ -225,8 +231,17 @@ app.MapDefaultEndpoints();
 // Kubernetes liveness/readiness probe – excludes external dependency checks.
 app.MapHealthChecks("/health", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
 {
-    Predicate = check => !check.Tags.Contains("converto"),
+    Predicate = check => !check.Tags.Contains("converto") && !check.Tags.Contains(HealthTags.Diagnostics),
 });
+
+// Admin diagnostics: runs the "diagnostics"-tagged checks (e.g. pending
+// migrations) and returns per-check JSON for the admin UI. Not used by probes.
+app.MapHealthChecks("/health/diagnostics",
+    new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+    {
+        Predicate = check => check.Tags.Contains(HealthTags.Diagnostics),
+        ResponseWriter = HealthReportWriter.WriteJson,
+    }).RequireAuthorization(Auth.AdministratorRole);
 
 // Manual diagnostics endpoint – call this to verify Converto is reachable.
 // Not used by Kubernetes probes. Requires AdministratorRole to prevent abuse.

--- a/apps/api/tests/Eventuras.WebApi.Tests/Health/HealthDiagnosticsEndpointTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Health/HealthDiagnosticsEndpointTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Xunit;
+
+namespace Eventuras.WebApi.Tests.Health;
+
+public class HealthDiagnosticsEndpointTests : IClassFixture<CustomWebApiApplicationFactory<Program>>
+{
+    private readonly CustomWebApiApplicationFactory<Program> _factory;
+
+    public HealthDiagnosticsEndpointTests(CustomWebApiApplicationFactory<Program> factory) =>
+        _factory = factory;
+
+    [Fact]
+    public async Task Probe_Health_Excludes_Diagnostics_Checks()
+    {
+        // Register a "diagnostics"-tagged check that is Unhealthy. If diagnostics
+        // checks were on the probe /health, it would return 503. It staying 200
+        // proves the predicate excludes them — and so a pending migration (also
+        // "diagnostics") can never flip the Kubernetes probes.
+        var client = _factory
+            .WithWebHostBuilder(b => b.ConfigureTestServices(services =>
+                services.AddHealthChecks()
+                    .AddCheck("forced-unhealthy", () => HealthCheckResult.Unhealthy(),
+                        tags: ["diagnostics"])))
+            .CreateClient();
+
+        var response = await client.GetAsync("/health");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Diagnostics_Requires_Authentication()
+    {
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/health/diagnostics");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Diagnostics_Forbids_Non_Admin()
+    {
+        var client = _factory.CreateClient().Authenticated();
+
+        var response = await client.GetAsync("/health/diagnostics");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+}

--- a/apps/web/src/app/(admin)/admin/HealthAlert.tsx
+++ b/apps/web/src/app/(admin)/admin/HealthAlert.tsx
@@ -1,0 +1,26 @@
+import { Panel } from '@eventuras/ratio-ui/core/Panel';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+import { getHealthDiagnostics, unhealthyChecks } from './system/getHealthDiagnostics';
+
+/**
+ * Admin dashboard banner: shown only when the backend reports health problems
+ * (e.g. pending migrations), linking on to the full diagnostics on /admin/system.
+ * Renders nothing when everything is healthy (or diagnostics couldn't be loaded).
+ */
+export const HealthAlert = async () => {
+  const { checks } = await getHealthDiagnostics();
+  const problems = unhealthyChecks(checks);
+
+  if (problems.length === 0) {
+    return null;
+  }
+
+  return (
+    <Panel status="warning" marginY="sm">
+      {problems.length} health issue{problems.length === 1 ? '' : 's'} detected (
+      {problems.map(check => check.name).join(', ')}).{' '}
+      <Link href="/admin/system">View health checks</Link>
+    </Panel>
+  );
+};

--- a/apps/web/src/app/(admin)/admin/page.tsx
+++ b/apps/web/src/app/(admin)/admin/page.tsx
@@ -10,6 +10,7 @@ import { Link } from '@eventuras/ratio-ui-next/Link';
 import { getOrganizationId } from '@/utils/organization';
 
 import AdminEventList from './events/AdminEventList';
+import { HealthAlert } from './HealthAlert';
 
 interface AdminPageProps {
   searchParams?: Promise<{ page?: string }>;
@@ -21,6 +22,7 @@ const AdminPage = async (props: AdminPageProps) => {
   return (
     <Container>
       <Heading as="h1">{t('admin.title')}</Heading>
+      <HealthAlert />
       <Section className="py-10">
         <ButtonGroup wrap gap="xs">
           <Link href={`/admin/events/create`} variant="button-primary" testId="add-event-button">

--- a/apps/web/src/app/(admin)/admin/system/HealthDiagnostics.tsx
+++ b/apps/web/src/app/(admin)/admin/system/HealthDiagnostics.tsx
@@ -1,0 +1,53 @@
+import { Panel } from '@eventuras/ratio-ui/core/Panel';
+
+import { getHealthDiagnostics } from './getHealthDiagnostics';
+
+/** Maps an ASP.NET health status to a ratio Panel status (red for problems). */
+const panelStatus = (status: string) => {
+  switch (status) {
+    case 'Healthy':
+      return 'success' as const;
+    case 'Degraded':
+      return 'warning' as const;
+    case 'Unhealthy':
+      return 'error' as const;
+    default:
+      return 'neutral' as const;
+  }
+};
+
+/**
+ * Renders the API's admin-only `/health/diagnostics` report as ratio Panels —
+ * one per check, coloured by status (e.g. pending migrations show as a warning).
+ */
+export const HealthDiagnostics = async () => {
+  const { checks, error } = await getHealthDiagnostics();
+
+  if (error) {
+    return <Panel status="error">{error}</Panel>;
+  }
+  if (checks.length === 0) {
+    return <Panel status="success">No diagnostics checks reported.</Panel>;
+  }
+
+  return (
+    <div className="space-y-2">
+      {checks.map(check => {
+        const pending = (check.data?.pending as string[] | undefined) ?? [];
+        return (
+          <Panel key={check.name} status={panelStatus(check.status)}>
+            <strong>{check.name}</strong> — {check.status}
+            {check.description && <div>{check.description}</div>}
+            {pending.length > 0 && (
+              <ul className="mt-1 list-inside list-disc font-mono text-xs">
+                {pending.map(migration => (
+                  <li key={migration}>{migration}</li>
+                ))}
+              </ul>
+            )}
+          </Panel>
+        );
+      })}
+    </div>
+  );
+};

--- a/apps/web/src/app/(admin)/admin/system/getHealthDiagnostics.ts
+++ b/apps/web/src/app/(admin)/admin/system/getHealthDiagnostics.ts
@@ -1,0 +1,48 @@
+import { Logger } from '@eventuras/logger';
+
+import { appConfig } from '@/config.server';
+import { getAccessToken } from '@/utils/getAccesstoken';
+
+const logger = Logger.create({ namespace: 'web:admin:health' });
+
+export interface HealthCheck {
+  name: string;
+  status: string;
+  description?: string | null;
+  data?: Record<string, unknown> | null;
+}
+
+export interface HealthDiagnosticsResult {
+  checks: HealthCheck[];
+  error: string | null;
+}
+
+/** Fetches the API's admin-only `/health/diagnostics` report (server-side). */
+export async function getHealthDiagnostics(): Promise<HealthDiagnosticsResult> {
+  const token = await getAccessToken();
+  const baseUrl = String(appConfig.env.BACKEND_URL ?? '').replace(/\/+$/, '');
+
+  if (!token || !baseUrl) {
+    return { checks: [], error: 'Diagnostics unavailable (no token or backend URL).' };
+  }
+
+  try {
+    const response = await fetch(`${baseUrl}/health/diagnostics`, {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: 'no-store',
+    });
+    if (!response.ok) {
+      logger.warn({ status: response.status }, 'Failed to load health diagnostics');
+      return { checks: [], error: `Could not load diagnostics (HTTP ${response.status}).` };
+    }
+    const report = (await response.json()) as { checks?: HealthCheck[] };
+    return { checks: report.checks ?? [], error: null };
+  } catch (error) {
+    logger.error({ error }, 'Error fetching health diagnostics');
+    return { checks: [], error: 'Error loading diagnostics.' };
+  }
+}
+
+/** Checks that are not Healthy — the problems worth surfacing to an admin. */
+export const unhealthyChecks = (checks: HealthCheck[]) =>
+  checks.filter(check => check.status !== 'Healthy');

--- a/apps/web/src/app/(admin)/admin/system/page.tsx
+++ b/apps/web/src/app/(admin)/admin/system/page.tsx
@@ -7,6 +7,7 @@ import { Section } from '@eventuras/ratio-ui/layout/Section';
 import { getV3OrganizationsByOrganizationIdSettings } from '@/lib/eventuras-sdk';
 
 import { ErrorTestButton } from './ErrorTestButton';
+import { HealthDiagnostics } from './HealthDiagnostics';
 import { SentryDiagnostics } from './SentryDiagnostics';
 
 const AdminSystemPage = async () => {
@@ -32,6 +33,8 @@ const AdminSystemPage = async () => {
       <Section>
         <Container>
           <Heading as="h2">Diagnostics</Heading>
+          <Heading as="h3">Health checks</Heading>
+          <HealthDiagnostics />
           <Heading as="h3">Backend API</Heading>
           <ErrorTestButton />
           <Heading as="h3">Web app Sentry</Heading>


### PR DESCRIPTION
Detects EF Core migrations that exist in the deployed code but haven't been applied to the database (migrations run **out-of-band** here — `DbInitializer.SeedAsync()` only migrates when `runMigrations=true`, and startup calls it without that flag).

## Key safety: never reboots the pod

- The check reports **Degraded**, never Unhealthy (Degraded → HTTP 200).
- It is tagged **`diagnostics`** and **excluded from the probe `/health`** (`Predicate = !converto && !diagnostics`). The k8s startup/liveness/readiness probes all hit `/health`, so a pending migration can never flip them.
- Surfaced instead via the admin-only **`GET /health/diagnostics`** (mirrors the existing `/health/converto` pattern), returning per-check JSON for an admin UI.

## Structure (checks colocated with their subsystem)

Mirrors the existing `ConvertoHealthCheck` (which lives in `Eventuras.Services.Converto`):

- **`Eventuras.Infrastructure/HealthChecks/`** — `PendingMigrationsHealthCheck` + `AddInfrastructureHealthChecks()` (the check is a DB concern, lives next to `ApplicationDbContext`).
- **`Eventuras.ServiceDefaults/Health/`** — shared conventions: `HealthTags` (live/ready/diagnostics) + the JSON `HealthReportWriter`.
- **`Program.cs`** — just composes: `AddInfrastructureHealthChecks()`, excludes `diagnostics` from `/health`, maps the admin `/health/diagnostics`.

This sets the convention for future checks (each subsystem contributes its own; the host composes). A dedicated `Eventuras.Health` project is intentionally **not** introduced yet — promote to one only when a shared, web-facing contract emerges.

## Verification

`dotnet build` clean. 3 tests: `/health` → 200 (proves diagnostics excluded from the probe path), `/health/diagnostics` → 401 anonymous / 403 non-admin.

Next (separate PR): an admin UI panel (ratio `Panel`) reading `/health/diagnostics`, showing red statuses, starting with migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Commit 2 — admin UI panel (ratio Panel)

Adds a **Health checks** section to `/admin/system` ([HealthDiagnostics.tsx](apps/web/src/app/(admin)/admin/system/HealthDiagnostics.tsx)) that fetches the API's admin-only `/health/diagnostics` (with the caller's bearer token, server-side) and renders each check as a ratio `Panel` — green/amber/red by status. Pending migrations list their migration names. Separate `@eventuras/web` changeset. Banner is still deferred.