### PR TITLE
feat(ratio-ui): add FileUpload form component (beta)

### DIFF
--- a/.changeset/file-upload-component.md
+++ b/.changeset/file-upload-component.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/ratio-ui": minor
+---
+
+Add `FileUpload` form component (beta): drag-and-drop, image previews, upload progress and optional folder picking, built on react-aria-components `DropZone` + `FileTrigger`.

--- a/libs/ratio-ui/src/forms/FileUpload/FileUpload.stories.tsx
+++ b/libs/ratio-ui/src/forms/FileUpload/FileUpload.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React, { useEffect, useRef, useState } from 'react';
+import { FileUpload, FileUploadItem } from './FileUpload';
+
+const meta: Meta<typeof FileUpload> = {
+  title: 'Forms/FileUpload',
+  component: FileUpload,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Accessible file picker with drag-and-drop, image previews and upload progress, built on react-aria-components DropZone + FileTrigger. Presentational: emits validated File[] via onSelect; the app owns the upload and feeds progress/status back through the controlled `items` list.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-96">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+let idSeq = 0;
+const nextId = () => `file-${(idSeq += 1)}`;
+
+/**
+ * Controlled example that mimics how the consuming app drives the upload:
+ * it appends selected files, then walks each one through fake progress to
+ * success.
+ */
+const UploadExample = (props: Partial<React.ComponentProps<typeof FileUpload>>) => {
+  const [items, setItems] = useState<FileUploadItem[]>([]);
+  const timers = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+
+  // Stop any in-flight fake uploads when the story unmounts (story switch / HMR).
+  useEffect(() => {
+    const active = timers.current;
+    return () => {
+      for (const timer of Object.values(active)) clearInterval(timer);
+    };
+  }, []);
+
+  const fakeUpload = (id: string) => {
+    timers.current[id] = setInterval(() => {
+      setItems((prev) =>
+        prev.map((item) => {
+          if (item.id !== id) return item;
+          const progress = Math.min(100, (item.progress ?? 0) + 20);
+          if (progress >= 100) {
+            clearInterval(timers.current[id]);
+            delete timers.current[id];
+            return { ...item, progress: 100, status: 'success' };
+          }
+          return { ...item, progress, status: 'uploading' };
+        })
+      );
+    }, 400);
+  };
+
+  const handleSelect = (files: File[]) => {
+    const added = files.map<FileUploadItem>((file) => ({
+      id: nextId(),
+      file,
+      progress: 0,
+      status: 'uploading',
+    }));
+    setItems((prev) => [...prev, ...added]);
+    added.forEach((item) => fakeUpload(item.id));
+  };
+
+  const handleRemove = (id: string) => {
+    clearInterval(timers.current[id]);
+    delete timers.current[id];
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  };
+
+  return (
+    <FileUpload
+      items={items}
+      onSelect={handleSelect}
+      onRemove={handleRemove}
+      {...props}
+    />
+  );
+};
+
+/** Single file, any type. */
+export const Basic: Story = {
+  render: () => <UploadExample label="Attachment" />,
+};
+
+/** Multiple image files with previews + size limit. */
+export const Images: Story = {
+  render: () => (
+    <UploadExample
+      label="Photos"
+      accept={['image/*']}
+      multiple
+      maxSize={5 * 1024 * 1024}
+      dropzoneLabel="Drag images here"
+    />
+  ),
+};
+
+/** Folder picking — the browse button selects a whole directory. */
+export const Folder: Story = {
+  render: () => (
+    <UploadExample
+      label="Import folder"
+      acceptDirectory
+      dropzoneLabel="Pick a folder to upload"
+      buttonLabel="Choose folder"
+    />
+  ),
+};
+
+/** Static error state (validation / failed upload). */
+export const ErrorState: Story = {
+  render: () => (
+    <FileUpload
+      label="Documents"
+      accept={['.pdf']}
+      onSelect={() => {}}
+      onRemove={() => {}}
+      items={[
+        {
+          id: 'a',
+          file: new File(['x'], 'contract.pdf', { type: 'application/pdf' }),
+          status: 'error',
+          error: 'Upload failed — try again',
+        },
+      ]}
+    />
+  ),
+};
+
+/** Disabled. */
+export const Disabled: Story = {
+  render: () => <UploadExample label="Attachment" isDisabled />,
+};

--- a/libs/ratio-ui/src/forms/FileUpload/FileUpload.tsx
+++ b/libs/ratio-ui/src/forms/FileUpload/FileUpload.tsx
@@ -1,0 +1,364 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Button, DropZone, FileTrigger, Text } from 'react-aria-components';
+import type { DropItem } from 'react-aria-components';
+import { AlertCircle, Check, CloudUpload, File as FileIcon, LoaderCircle, X } from '../../icons';
+import { cn } from '../../utils/cn';
+
+export type FileUploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+export interface FileUploadItem {
+  /** Stable id; the app generates and owns this. */
+  id: string;
+  file: File;
+  /** Upload progress, 0–100. Shown as a bar while `status` is `uploading`. */
+  progress?: number;
+  status?: FileUploadStatus;
+  /** Error message shown under the item when `status` is `error`. */
+  error?: string;
+}
+
+export interface FileUploadRejection {
+  file: File;
+  reason: 'type' | 'size' | 'count';
+}
+
+export interface FileUploadProps {
+  /**
+   * Tracked files (controlled). The app owns this list along with the actual
+   * upload + progress; the component only renders and emits selection events.
+   */
+  items?: FileUploadItem[];
+  /** Newly added files, already validated against `accept`/`maxSize`/`multiple`. */
+  onSelect: (files: File[]) => void;
+  /** Fired when the user removes an item via its remove button. */
+  onRemove?: (id: string) => void;
+  /** Files rejected by client-side validation. */
+  onError?: (rejections: FileUploadRejection[]) => void;
+  /** Accepted MIME types or extensions, e.g. `['image/*', '.pdf']`. */
+  accept?: string[];
+  /** Allow selecting more than one file. Default: false. */
+  multiple?: boolean;
+  /**
+   * Accept whole directories — both via the browse button and by dropping a
+   * folder, which is traversed recursively. All contained files are returned
+   * (still filtered by `accept`). Implies `multiple`.
+   */
+  acceptDirectory?: boolean;
+  /** Max size per file, in bytes. Larger files are rejected. */
+  maxSize?: number;
+  isDisabled?: boolean;
+  label?: string;
+  description?: string;
+  /** Primary text inside the drop zone. */
+  dropzoneLabel?: React.ReactNode;
+  buttonLabel?: string;
+  className?: string;
+  testId?: string;
+}
+
+const styles = {
+  wrapper: 'flex flex-col gap-2 w-full',
+  label: 'text-sm font-medium text-(--text) cursor-default',
+  description: 'text-xs text-(--text-muted)',
+  dropzone: {
+    base: [
+      'flex flex-col items-center justify-center gap-2',
+      'w-full px-4 py-8 rounded-lg text-center',
+      'border-2 border-dashed border-border-1',
+      'bg-card text-(--text-subtle)',
+      'transition-colors',
+      'data-[hovered]:border-(--primary)',
+      'data-[focus-visible]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-(--focus-ring)',
+    ].join(' '),
+    active: 'border-(--primary) bg-card-hover text-(--text)',
+    disabled: 'opacity-50 cursor-not-allowed',
+    icon: 'h-8 w-8',
+  },
+  button: [
+    'inline-flex items-center gap-2 px-3 py-1.5 rounded-lg',
+    'border border-border-1 bg-card text-(--text) text-sm font-medium',
+    'hover:border-(--primary)',
+    'data-[focus-visible]:outline-none data-[focus-visible]:ring-2 data-[focus-visible]:ring-(--focus-ring)',
+    'data-[disabled]:opacity-50 data-[disabled]:cursor-not-allowed',
+    'transition-colors',
+  ].join(' '),
+  list: 'flex flex-col gap-2',
+  item: {
+    base: 'flex items-center gap-3 p-2 rounded-lg border border-border-1 bg-card',
+    thumb: 'h-10 w-10 shrink-0 rounded object-cover bg-card-hover',
+    icon: 'h-10 w-10 shrink-0 rounded bg-card-hover p-2 text-(--text-subtle)',
+    body: 'min-w-0 flex-1',
+    name: 'truncate text-sm text-(--text)',
+    meta: 'text-xs text-(--text-muted)',
+    error: 'text-xs text-error-text',
+    remove: [
+      'shrink-0 rounded p-1 text-(--text-subtle)',
+      'hover:text-(--text) hover:bg-card-hover',
+      'focus:outline-none focus:ring-2 focus:ring-(--focus-ring)',
+      'disabled:opacity-50 disabled:cursor-not-allowed',
+    ].join(' '),
+  },
+  progress: {
+    track: 'mt-1 h-1 w-full overflow-hidden rounded-full bg-card-hover',
+    bar: 'h-full rounded-full bg-(--primary) transition-[width] duration-200',
+  },
+};
+
+const isImage = (file: File) => file.type.startsWith('image/');
+
+const formatBytes = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ['KB', 'MB', 'GB'];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value < 10 ? 1 : 0)} ${units[unit]}`;
+};
+
+const matchesAccept = (file: File, accept?: string[]): boolean => {
+  if (!accept || accept.length === 0) return true;
+  const name = file.name.toLowerCase();
+  const type = file.type;
+  return accept.some((rule) => {
+    const r = rule.trim().toLowerCase();
+    if (r.startsWith('.')) return name.endsWith(r);
+    if (r.endsWith('/*')) return type.startsWith(r.slice(0, -1));
+    return type === r;
+  });
+};
+
+/**
+ * Thumbnail that owns its object URL: created on mount, revoked on unmount.
+ * Falls back to a generic file icon for non-image files.
+ */
+const FilePreview: React.FC<{ file: File; thumbClassName: string; iconClassName: string }> = ({
+  file,
+  thumbClassName,
+  iconClassName,
+}) => {
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // Set the source imperatively so the object URL lives entirely inside the
+  // effect lifecycle (created here, revoked on cleanup) — no render-time state.
+  useEffect(() => {
+    const img = imgRef.current;
+    if (!img || !isImage(file)) return;
+    const objectUrl = URL.createObjectURL(file);
+    img.src = objectUrl;
+    return () => URL.revokeObjectURL(objectUrl);
+  }, [file]);
+
+  if (isImage(file)) {
+    return <img ref={imgRef} alt={file.name} className={thumbClassName} />;
+  }
+  return <FileIcon className={iconClassName} aria-hidden="true" />;
+};
+
+/**
+ * Flatten dropped items into a `File[]`, recursing into directories when
+ * `includeDirectories` is set. Works for both the sync `e.items` array and the
+ * async iterable returned by `DirectoryDropItem.getEntries()`.
+ */
+const collectDroppedFiles = async (
+  items: Iterable<DropItem> | AsyncIterable<DropItem>,
+  includeDirectories: boolean
+): Promise<File[]> => {
+  const files: File[] = [];
+  for await (const item of items) {
+    if (item.kind === 'file') {
+      files.push(await item.getFile());
+    } else if (item.kind === 'directory' && includeDirectories) {
+      files.push(...(await collectDroppedFiles(item.getEntries(), true)));
+    }
+  }
+  return files;
+};
+
+const StatusIcon: React.FC<{ status?: FileUploadStatus }> = ({ status }) => {
+  if (status === 'uploading') {
+    return <LoaderCircle className="h-4 w-4 animate-spin text-(--primary)" aria-hidden="true" />;
+  }
+  if (status === 'success') {
+    return <Check className="h-4 w-4 text-success-text" aria-hidden="true" />;
+  }
+  if (status === 'error') {
+    return <AlertCircle className="h-4 w-4 text-error-text" aria-hidden="true" />;
+  }
+  return null;
+};
+
+/**
+ * FileUpload — accessible file picker with drag-and-drop, image previews and
+ * upload progress, built on react-aria-components' `DropZone` + `FileTrigger`.
+ *
+ * Presentational and transport-agnostic: it emits validated `File[]` via
+ * `onSelect` and renders the controlled `items` list. The consuming app owns
+ * the actual upload and feeds back `progress`/`status`/`error` per item.
+ *
+ * @beta The API may change in a minor release while it stabilises.
+ *
+ * @example
+ * ```tsx
+ * <FileUpload
+ *   items={items}
+ *   accept={['image/*']}
+ *   multiple
+ *   maxSize={5 * 1024 * 1024}
+ *   onSelect={(files) => uploadAll(files)}
+ *   onRemove={(id) => cancel(id)}
+ * />
+ * ```
+ */
+export const FileUpload: React.FC<FileUploadProps> = ({
+  items = [],
+  onSelect,
+  onRemove,
+  onError,
+  accept,
+  multiple = false,
+  acceptDirectory = false,
+  maxSize,
+  isDisabled,
+  label,
+  description,
+  dropzoneLabel = 'Drag files here',
+  buttonLabel = 'Browse files',
+  className,
+  testId,
+}) => {
+  const acceptHint = useMemo(() => accept?.join(', '), [accept]);
+
+  const allowsMany = multiple || acceptDirectory;
+
+  const processFiles = (incoming: File[]) => {
+    if (incoming.length === 0) return;
+    const candidates = allowsMany ? incoming : incoming.slice(0, 1);
+    const accepted: File[] = [];
+    const rejections: FileUploadRejection[] = [];
+
+    // Surface (rather than silently drop) extras when only one file is allowed.
+    if (!allowsMany) {
+      for (const file of incoming.slice(1)) rejections.push({ file, reason: 'count' });
+    }
+
+    for (const file of candidates) {
+      if (!matchesAccept(file, accept)) {
+        rejections.push({ file, reason: 'type' });
+      } else if (maxSize != null && file.size > maxSize) {
+        rejections.push({ file, reason: 'size' });
+      } else {
+        accepted.push(file);
+      }
+    }
+
+    if (rejections.length > 0) onError?.(rejections);
+    if (accepted.length > 0) onSelect(accepted);
+  };
+
+  return (
+    <div className={cn(styles.wrapper, className)} data-testid={testId}>
+      {label && <span className={styles.label}>{label}</span>}
+
+      <DropZone
+        isDisabled={isDisabled}
+        aria-label={label ?? 'File upload drop zone'}
+        className={({ isDropTarget }) =>
+          cn(
+            styles.dropzone.base,
+            isDropTarget && styles.dropzone.active,
+            isDisabled && styles.dropzone.disabled
+          )
+        }
+        onDrop={async (e) => {
+          processFiles(await collectDroppedFiles(e.items, acceptDirectory));
+        }}
+      >
+        <CloudUpload className={styles.dropzone.icon} aria-hidden="true" />
+        <Text slot="label" className="text-sm">
+          {dropzoneLabel}
+        </Text>
+        <FileTrigger
+          acceptedFileTypes={accept}
+          allowsMultiple={allowsMany}
+          acceptDirectory={acceptDirectory}
+          onSelect={(fileList) => {
+            if (fileList) processFiles(Array.from(fileList));
+          }}
+        >
+          <Button className={styles.button} isDisabled={isDisabled}>
+            <CloudUpload className="h-4 w-4" aria-hidden="true" />
+            {buttonLabel}
+          </Button>
+        </FileTrigger>
+      </DropZone>
+
+      {(description || acceptHint || maxSize != null) && (
+        <span className={styles.description}>
+          {description ??
+            [acceptHint, maxSize != null ? `up to ${formatBytes(maxSize)}` : null]
+              .filter(Boolean)
+              .join(' · ')}
+        </span>
+      )}
+
+      {items.length > 0 && (
+        <ul className={styles.list}>
+          {items.map((item) => (
+            <li key={item.id} className={styles.item.base}>
+              <FilePreview
+                file={item.file}
+                thumbClassName={styles.item.thumb}
+                iconClassName={styles.item.icon}
+              />
+
+              <div className={styles.item.body}>
+                <div className="flex items-center gap-2">
+                  <span className={styles.item.name}>{item.file.name}</span>
+                  <StatusIcon status={item.status} />
+                </div>
+                <span className={styles.item.meta}>{formatBytes(item.file.size)}</span>
+
+                {item.status === 'uploading' && (
+                  <div
+                    className={styles.progress.track}
+                    role="progressbar"
+                    aria-label={`Uploading ${item.file.name}`}
+                    aria-valuenow={item.progress ?? 0}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  >
+                    <div
+                      className={styles.progress.bar}
+                      style={{ width: `${item.progress ?? 0}%` }}
+                    />
+                  </div>
+                )}
+
+                {item.status === 'error' && item.error && (
+                  <span className={styles.item.error}>{item.error}</span>
+                )}
+              </div>
+
+              {onRemove && (
+                <button
+                  type="button"
+                  className={styles.item.remove}
+                  onClick={() => onRemove(item.id)}
+                  disabled={isDisabled}
+                  aria-label={`Remove ${item.file.name}`}
+                >
+                  <X className="h-4 w-4" aria-hidden="true" />
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+FileUpload.displayName = 'FileUpload';

--- a/libs/ratio-ui/src/forms/FileUpload/README.md
+++ b/libs/ratio-ui/src/forms/FileUpload/README.md
@@ -1,0 +1,89 @@
+# FileUpload
+
+> **Status: beta.** The API may still change in a minor release while it stabilises.
+
+Accessible file picker with drag-and-drop, image previews and upload progress,
+built on [`react-aria-components`](https://react-spectrum.adobe.com/react-aria/)
+`DropZone` + `FileTrigger`.
+
+The component is **presentational and transport-agnostic**. It emits validated
+`File[]` through `onSelect` and renders the controlled `items` list. The
+consuming app owns the actual upload (e.g. a server action / `FormData`) and
+feeds `progress`/`status`/`error` back per item.
+
+## Usage
+
+```tsx
+'use client';
+import { FileUpload, type FileUploadItem } from '@eventuras/ratio-ui/forms';
+import { useState } from 'react';
+
+function AttachmentField() {
+  const [items, setItems] = useState<FileUploadItem[]>([]);
+
+  const onSelect = (files: File[]) => {
+    const added = files.map((file) => ({
+      id: crypto.randomUUID(),
+      file,
+      status: 'uploading' as const,
+      progress: 0,
+    }));
+    setItems((prev) => [...prev, ...added]);
+    added.forEach(upload); // your upload, updating items by id
+  };
+
+  return (
+    <FileUpload
+      items={items}
+      accept={['image/*', '.pdf']}
+      multiple
+      maxSize={5 * 1024 * 1024}
+      onSelect={onSelect}
+      onRemove={(id) => setItems((p) => p.filter((i) => i.id !== id))}
+      onError={(rejections) => console.warn(rejections)}
+    />
+  );
+}
+```
+
+> `FileUpload` ships **without** a `'use client'` directive — ratio-ui leaves the
+> client/server boundary to the consumer. It uses client-side state and browser
+> APIs, so in the Next.js App Router render it within a Client Component (a module
+> carrying the `'use client'` directive), as shown above.
+
+## Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `items` | `FileUploadItem[]` | Controlled file list. The app owns this together with the upload. |
+| `onSelect` | `(files: File[]) => void` | Newly added files, already validated against `accept`/`maxSize`. |
+| `onRemove` | `(id: string) => void` | User removed an item. Omit to hide remove buttons. |
+| `onError` | `(rejections: FileUploadRejection[]) => void` | Files rejected by validation (`type` / `size` / `count`). |
+| `accept` | `string[]` | Accepted MIME types or extensions, e.g. `['image/*', '.pdf']`. |
+| `multiple` | `boolean` | Allow more than one file. Default `false`. |
+| `acceptDirectory` | `boolean` | Accept whole folders — via the browse button or by dropping a folder (traversed recursively). Implies `multiple`. |
+| `maxSize` | `number` | Max bytes per file; larger files are rejected. |
+| `isDisabled` | `boolean` | Disable the whole control. |
+| `label` | `string` | Field label. |
+| `description` | `string` | Helper text. Defaults to an `accept` / `maxSize` summary. |
+| `dropzoneLabel` | `ReactNode` | Text inside the drop zone. |
+| `buttonLabel` | `string` | Browse-button text. |
+
+### `FileUploadItem`
+
+```ts
+interface FileUploadItem {
+  id: string;
+  file: File;
+  progress?: number; // 0–100, shown while status is 'uploading'
+  status?: 'pending' | 'uploading' | 'success' | 'error';
+  error?: string;
+}
+```
+
+## Accessibility
+
+- Drag-and-drop and keyboard picking are handled by React Aria's `DropZone` and
+  `FileTrigger`.
+- Each in-progress item exposes a labelled `progressbar`.
+- Remove buttons get an `aria-label` naming the file.

--- a/libs/ratio-ui/src/forms/FileUpload/index.ts
+++ b/libs/ratio-ui/src/forms/FileUpload/index.ts
@@ -1,0 +1,7 @@
+export { FileUpload } from './FileUpload';
+export type {
+  FileUploadProps,
+  FileUploadItem,
+  FileUploadStatus,
+  FileUploadRejection,
+} from './FileUpload';

--- a/libs/ratio-ui/src/forms/index.ts
+++ b/libs/ratio-ui/src/forms/index.ts
@@ -18,3 +18,10 @@ export { Select } from './Select';
 export type { SelectProps, SelectOption } from './Select';
 export { AutoComplete } from './Autocomplete';
 export type { AutoCompleteProps } from './Autocomplete';
+export { FileUpload } from './FileUpload';
+export type {
+  FileUploadProps,
+  FileUploadItem,
+  FileUploadStatus,
+  FileUploadRejection,
+} from './FileUpload';

--- a/libs/ratio-ui/src/icons/index.ts
+++ b/libs/ratio-ui/src/icons/index.ts
@@ -30,9 +30,15 @@ export {
 
   // Content
   FileText,
+  File,
+  Image as ImageIcon,
   Calendar,
   MapPin,
   Home,
+
+  // Upload
+  Upload,
+  CloudUpload,
 
   // E-commerce
   ShoppingCart,


### PR DESCRIPTION
## What

Adds a new `FileUpload` form component to `@eventuras/ratio-ui`, built on react-aria-components `DropZone` + `FileTrigger`. There was no file-upload primitive in the repo before.

Marked **beta** (`@beta` JSDoc + README note) so the API can still change in a minor release while it stabilises.

### Features
- Drag-and-drop **and** keyboard/click picking (React Aria handles a11y).
- Image previews (each thumbnail owns its object URL via an effect; created on mount, revoked on cleanup — leak-free).
- Per-file upload **progress**, status (`pending`/`uploading`/`success`/`error`) and error message, with a labelled `progressbar`.
- Client-side validation against `accept` (MIME/extension) and `maxSize`; rejects surface via `onError`.
- Optional **folder upload** (`acceptDirectory`) — both the browse button and dropping a folder (traversed recursively).

### Design
Presentational and **transport-agnostic**: emits validated `File[]` via `onSelect` and renders the controlled `items` list. The consuming app owns the actual upload (e.g. server action / `FormData`) and feeds `progress`/`status`/`error` back per item. No `'use client'` (the consumer adds it).

Follows the existing forms convention (single component like `Select`/`SearchField`, co-located stories + README).

## Notes
- Storybook stories: Basic, Images, Folder, ErrorState, Disabled.
- Not yet wired into any app — ships as a library component.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean (only the repo-wide `@storybook/react` renderer-import warning shared by existing stories)
- [ ] Visual check in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)