### PR TITLE
chore(deps): upgrade @xstate/store to v4

### DIFF
--- a/.changeset/xstate-store-v4.md
+++ b/.changeset/xstate-store-v4.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/fides-auth-next": patch
+---
+
+Upgrade `@xstate/store` to v4. React hooks moved to the dedicated `@xstate/store-react` package; the store API itself is unchanged.

--- a/apps/idem-admin/next.config.ts
+++ b/apps/idem-admin/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   output: 'standalone',
 
-  transpilePackages: ['@eventuras/fides-auth-next', '@xstate/store'],
+  transpilePackages: ['@eventuras/fides-auth-next', '@xstate/store', '@xstate/store-react'],
 
   reactStrictMode: true,
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -29,6 +29,7 @@ const nextConfig: NextConfig = {
     '@eventuras/fides-auth-next',
     '@eventuras/markdown',
     '@xstate/store',
+    '@xstate/store-react',
   ],
 
   allowedDevOrigins: process.env.APPLICATION_URL

--- a/libs/fides-auth-next/package.json
+++ b/libs/fides-auth-next/package.json
@@ -55,7 +55,8 @@
   "dependencies": {
     "@eventuras/fides-auth": "workspace:*",
     "@eventuras/logger": "workspace:*",
-    "@xstate/store": "^3.17.1"
+    "@xstate/store": "^4.0.0",
+    "@xstate/store-react": "^2.0.0"
   },
   "devDependencies": {
     "@eventuras/typescript-config": "workspace:*",
@@ -73,7 +74,8 @@
   },
   "peerDependencies": {
     "@xstate/react": "^5.0.0 || ^6.0.0",
-    "@xstate/store": "^3.11.0",
+    "@xstate/store": "^4.0.0",
+    "@xstate/store-react": "^2.0.0",
     "next": "^16.0.0",
     "react": "^19.0.0",
     "xstate": "^5.0.0"

--- a/libs/fides-auth-next/src/store/hooks.ts
+++ b/libs/fides-auth-next/src/store/hooks.ts
@@ -1,4 +1,4 @@
-import { useSelector as useStoreSelector } from '@xstate/store/react';
+import { useSelector as useStoreSelector } from '@xstate/store-react';
 import type { SessionUser } from './types';
 import type { createAuthStore } from './store';
 

--- a/libs/fides-auth-next/vite.config.ts
+++ b/libs/fides-auth-next/vite.config.ts
@@ -13,7 +13,7 @@ export default defineNextLibConfig({
     'xstate',
     '@xstate/react',
     '@xstate/store',
-    '@xstate/store/react',
+    '@xstate/store-react',
     /^@xstate\//,
 
     // React

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,8 +1090,11 @@ importers:
         specifier: ^5.0.0 || ^6.0.0
         version: 6.1.0(@types/react@19.2.15)(react@19.2.6)(xstate@5.31.1)
       '@xstate/store':
-        specifier: ^3.17.1
-        version: 3.17.5(react@19.2.6)
+        specifier: ^4.0.0
+        version: 4.0.0
+      '@xstate/store-react':
+        specifier: ^2.0.0
+        version: 2.0.0(react@19.2.6)
       next:
         specifier: ^16.0.0
         version: 16.2.6(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.77.4)
@@ -6358,16 +6361,13 @@ packages:
       xstate:
         optional: true
 
-  '@xstate/store@3.17.5':
-    resolution: {integrity: sha512-ITajQVRAMa1pgmgM0OdRFYQ6OQ8GK4ynh391p13GKtZnELXn9Hgs9pr4mqO1Z95HH9INcmczmWi5xk3O18GBWg==}
+  '@xstate/store-react@2.0.0':
+    resolution: {integrity: sha512-i8rXkUHfZqHUijgA/IORXDESAuHwO939jHIsEtf3nitJkOy1AcZ73DMaAlLqH03nVS082PJkUZFRAu5nwb9Fxg==}
     peerDependencies:
-      react: ^18.2.0 || ^19.0.0
-      solid-js: ^1.7.6
-    peerDependenciesMeta:
-      react:
-        optional: true
-      solid-js:
-        optional: true
+      react: ^18.0.0 || ^19.0.0
+
+  '@xstate/store@4.0.0':
+    resolution: {integrity: sha512-uhsEuaG04t71GjkJubwfFr8ylxRmwe6y/un2/sbU699aA2ddfVizmj4ex7K4DB81pysL8CvKRjAQUMb6Eb6nng==}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -16883,9 +16883,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@xstate/store@3.17.5(react@19.2.6)':
-    optionalDependencies:
+  '@xstate/store-react@2.0.0(react@19.2.6)':
+    dependencies:
+      '@xstate/store': 4.0.0
       react: 19.2.6
+
+  '@xstate/store@4.0.0': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -18227,7 +18230,7 @@ snapshots:
       eslint-config-oclif: 5.2.2(eslint@10.4.0(jiti@2.7.0))
       eslint-config-xo: 0.49.0(eslint@10.4.0(jiti@2.7.0))
       eslint-config-xo-space: 0.35.0(eslint@10.4.0(jiti@2.7.0))
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-jsdoc: 50.8.0(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-mocha: 10.5.0(eslint@10.4.0(jiti@2.7.0))
@@ -18273,21 +18276,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.0(jiti@2.7.0)
-      get-tsconfig: 4.14.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.16
-      unrs-resolver: 1.12.2
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -18303,14 +18291,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.0(jiti@2.7.0)
+      get-tsconfig: 4.14.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.16
+      unrs-resolver: 1.12.2
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -18348,7 +18351,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.0(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
Completes the major `@xstate/store` v3 → v4 upgrade. **Supersedes #1544**, which only bumped the version and would break the build (see below).

## Why #1544 is incomplete
v4 [removes the `@xstate/store/react` subpath export](https://stately.ai/docs/xstate-store/migration) and moves the React hooks into a dedicated **`@xstate/store-react`** package. `@xstate/store@4.0.0`'s `exports` no longer include `./react`, so `libs/fides-auth-next/src/store/hooks.ts` (`import { useSelector } from '@xstate/store/react'`) fails to resolve. CI didn't catch it because no build/typecheck job runs on the deps PR. Since `dist` is gitignored, the consuming apps (`apps/web`, `apps/idem-admin`) rebuild fides-auth-next from source, so the break propagates to their builds.

## Changes
- **hooks.ts** — import `useSelector` from `@xstate/store-react` (signature unchanged).
- **package.json** — add `@xstate/store-react ^2.0.0` (dependency + peer); bump `@xstate/store` to `^4.0.0` in both dependency and peer (Renovate's `^3.11.0 || ^4.0.0` peer is invalid — v3 and v4 don't share an import path).
- **vite.config.ts** — replace stale `@xstate/store/react` external with `@xstate/store-react`.
- **apps/web & apps/idem-admin next.config.ts** — add `@xstate/store-react` to `transpilePackages`.
- Changeset: patch for `@eventuras/fides-auth-next`.

## Safe by inspection
The store API itself is unchanged — `store.ts` already uses the v4 `createStore({ context, on })` config form. None of the other v4 removals are used (`createStoreWithProducer`, `undoRedo`, atom `read` getters, `emits`, `persist`, `_snapshot`). Only store-instance API in use is `getSnapshot()` (in a doc comment), still valid in v4.

## Test plan
- [x] `pnpm install` updates lockfile to `@xstate/store@4.0.0` + `@xstate/store-react@2.0.0`
- [x] `pnpm build` (fides-auth-next) — succeeds; dts generated; `dist/store/hooks.js` imports `@xstate/store-react`
- [x] `pnpm test` (fides-auth-next) — 18/18 pass
- [ ] App builds verified in CI

## Follow-up
Close #1544 once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)