### PR TITLE
ci: add npm publish workflows for mailer, notitia-templates, ratio-ui-next

### DIFF
--- a/.github/workflows/mailer-publish.yml
+++ b/.github/workflows/mailer-publish.yml
@@ -1,0 +1,51 @@
+name: Mailer Publish
+
+on:
+  push:
+    tags:
+      - "@eventuras/mailer@*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., @eventuras/mailer@0.1.2)"
+        required: true
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Resolve ref
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ref=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter @eventuras/mailer... --frozen-lockfile --ignore-scripts
+
+      - name: Build package
+        run: pnpm --filter @eventuras/mailer build
+
+      - name: Publish to npm
+        run: pnpm --filter @eventuras/mailer publish --access public --provenance --no-git-checks

--- a/.github/workflows/notitia-templates-publish.yml
+++ b/.github/workflows/notitia-templates-publish.yml
@@ -1,0 +1,51 @@
+name: Notitia Templates Publish
+
+on:
+  push:
+    tags:
+      - "@eventuras/notitia-templates@*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., @eventuras/notitia-templates@0.2.4)"
+        required: true
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Resolve ref
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ref=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter @eventuras/notitia-templates... --frozen-lockfile --ignore-scripts
+
+      - name: Build package
+        run: pnpm --filter @eventuras/notitia-templates build
+
+      - name: Publish to npm
+        run: pnpm --filter @eventuras/notitia-templates publish --access public --provenance --no-git-checks

--- a/.github/workflows/ratio-ui-next-publish.yml
+++ b/.github/workflows/ratio-ui-next-publish.yml
@@ -1,0 +1,51 @@
+name: Ratio UI Next Publish
+
+on:
+  push:
+    tags:
+      - "@eventuras/ratio-ui-next@*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., @eventuras/ratio-ui-next@0.1.28)"
+        required: true
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Resolve ref
+        id: ref
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "ref=$INPUT_TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=$GITHUB_REF" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.ref }}
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --filter @eventuras/ratio-ui-next... --frozen-lockfile --ignore-scripts
+
+      - name: Build package
+        run: pnpm --filter @eventuras/ratio-ui-next build
+
+      - name: Publish to npm
+        run: pnpm --filter @eventuras/ratio-ui-next publish --access public --provenance --no-git-checks


### PR DESCRIPTION
These three libs are version-bumped by changesets but have no publish workflow, so they never reach npm. Add per-package publish workflows modeled on the existing ones (logger, fides-auth, …): tag-triggered, OIDC provenance, no NPM_TOKEN.

Prerequisite for extracting idem to its own repo — idem-idp/idem-admin consume these via workspace:* and can't resolve them once standalone.