### PR TITLE
fix(fides-auth): type token expiry fields as ISO string, not Date

### DIFF
--- a/.changeset/fides-auth-token-expiry-string.md
+++ b/.changeset/fides-auth-token-expiry-string.md
@@ -1,0 +1,5 @@
+---
+"@eventuras/fides-auth": minor
+---
+
+Type `tokens.accessTokenExpiresAt` / `tokens.refreshTokenExpiresAt` as ISO 8601 `string` instead of `Date`. The session is a JSON/JWT envelope, so these values are always strings on the wire — the `Date` type was a lie after a `validateSessionJwt` round-trip. Consumers doing date math should wrap in `new Date(value)`.

--- a/apps/idem-admin/src/app/api/callback/route.ts
+++ b/apps/idem-admin/src/app/api/callback/route.ts
@@ -95,7 +95,7 @@ export async function GET(request: Request): Promise<Response> {
         tokens: {
           accessToken: tokens.access_token!,
           accessTokenExpiresAt: tokens.expires_in
-            ? new Date(Date.now() + tokens.expires_in * 1000)
+            ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
             : undefined,
           refreshToken: tokens.refresh_token,
         },

--- a/libs/fides-auth-next/src/heartbeat-handler.test.ts
+++ b/libs/fides-auth-next/src/heartbeat-handler.test.ts
@@ -110,7 +110,7 @@ describe('handleHeartbeat — authentication', () => {
 
 describe('handleHeartbeat — success', () => {
   it('returns 200 with accessTokenExpiresAt and no-store Cache-Control', async () => {
-    const expiresAt = new Date('2026-05-21T20:00:00.000Z');
+    const expiresAt = new Date('2026-05-21T20:00:00.000Z').toISOString();
     mockedGetCurrentSession.mockResolvedValue({
       tokens: { accessToken: 'a', refreshToken: 'r' },
     } as any);
@@ -130,7 +130,7 @@ describe('handleHeartbeat — success', () => {
 
     const body = await response.json();
     expect(body).toMatchObject({
-      accessTokenExpiresAt: expiresAt.toISOString(),
+      accessTokenExpiresAt: expiresAt,
     });
   });
 

--- a/libs/fides-auth/src/oauth.ts
+++ b/libs/fides-auth/src/oauth.ts
@@ -374,7 +374,7 @@ export function buildSessionFromTokens(
     tokens: {
       accessToken: tokens.access_token,
       accessTokenExpiresAt: tokens.expires_in
-        ? new Date(Date.now() + tokens.expires_in * 1000)
+        ? new Date(Date.now() + tokens.expires_in * 1000).toISOString()
         : undefined,
       refreshToken: tokens.refresh_token,
     },

--- a/libs/fides-auth/src/session-refresh.ts
+++ b/libs/fides-auth/src/session-refresh.ts
@@ -35,7 +35,7 @@ export const refreshSession = async (
         ...current_session.tokens,
         accessToken: newtokens.access_token,
         accessTokenExpiresAt: newtokens.expires_in
-          ? new Date(Date.now() + newtokens.expires_in * 1000)
+          ? new Date(Date.now() + newtokens.expires_in * 1000).toISOString()
           : undefined,
         refreshToken: newtokens.refresh_token ?? current_session.tokens?.refreshToken,
       },

--- a/libs/fides-auth/src/session-validation.test.ts
+++ b/libs/fides-auth/src/session-validation.test.ts
@@ -21,7 +21,7 @@ const testSession: Session = {
   tokens: {
     accessToken: 'eyJ.test.access-token',
     refreshToken: 'eyJ.test.refresh-token',
-    accessTokenExpiresAt: new Date('2099-01-01'),
+    accessTokenExpiresAt: new Date('2099-01-01').toISOString(),
   },
   user: {
     name: 'Ola Nordmann',
@@ -85,6 +85,25 @@ describe('session lifecycle: create → validate', () => {
 
     expect(result.status).toBe('VALID');
     expect(result.session?.scopes).toEqual(['openid', 'profile', 'operations.read']);
+  });
+
+  it('preserves ISO-string token expiry fields through the round-trip', async () => {
+    const session: Session = {
+      tokens: {
+        accessToken: 'eyJ.test.access-token',
+        accessTokenExpiresAt: '2099-01-01T00:00:00.000Z',
+        refreshToken: 'eyJ.test.refresh-token',
+        refreshTokenExpiresAt: '2099-06-01T00:00:00.000Z',
+      },
+      user: { name: 'Ola Nordmann', email: 'ola@example.com' },
+    };
+
+    const jwt = await createEncryptedJWT({ ...session }, SECRET);
+    const result = await validateSessionJwt(jwt, SECRET);
+
+    expect(result.status).toBe('VALID');
+    expect(result.session!.tokens!.accessTokenExpiresAt).toBe('2099-01-01T00:00:00.000Z');
+    expect(result.session!.tokens!.refreshTokenExpiresAt).toBe('2099-06-01T00:00:00.000Z');
   });
 
   it('handles a minimal session with only user info', async () => {

--- a/libs/fides-auth/src/types.ts
+++ b/libs/fides-auth/src/types.ts
@@ -1,9 +1,11 @@
 /** OAuth/OIDC token set stored in a session. */
 export interface Tokens {
   accessToken?: string;
-  accessTokenExpiresAt?: Date;
+  /** ISO 8601 string — the session is a JSON/JWT envelope, so dates live as strings on the wire. */
+  accessTokenExpiresAt?: string;
   refreshToken?: string;
-  refreshTokenExpiresAt?: Date;
+  /** ISO 8601 string — see {@link accessTokenExpiresAt}. */
+  refreshTokenExpiresAt?: string;
 }
 
 /** Authenticated user session with tokens, user info, and optional custom data. */


### PR DESCRIPTION
The session is a JSON/JWT envelope, so accessTokenExpiresAt and refreshTokenExpiresAt are always strings on the wire. The Date type lied after a validateSessionJwt round-trip, crashing consumers that called .getTime() directly. Type them as ISO 8601 string and convert the writers to .toISOString().