### PR TITLE
feat(api): ship migration script in image + detect pending migrations

### DIFF
--- a/.github/workflows/api-docker.yml
+++ b/.github/workflows/api-docker.yml
@@ -95,6 +95,11 @@ jobs:
             org.opencontainers.image.revision=${{ steps.ver.outputs.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
+      - name: Compute migration metadata
+        id: migr
+        working-directory: ${{ github.workspace }}
+        run: ./apps/api/scripts/migration-metadata.sh >> "$GITHUB_OUTPUT"
+
       - name: Login to Docker Hub
         if: inputs.push
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
@@ -109,7 +114,11 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            eventuras.migrations.latest=${{ steps.migr.outputs.latest }}
+            eventuras.migrations.count=${{ steps.migr.outputs.count }}
+            eventuras.migrations.sha=${{ steps.migr.outputs.sha }}
           build-args: |
             BUILD_VERSION=${{ steps.ver.outputs.version }}
             BUILD_SHA=${{ steps.ver.outputs.sha }}
@@ -176,6 +185,10 @@ jobs:
         id: sha
         run: echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Compute migration metadata
+        id: migr
+        run: ./apps/api/scripts/migration-metadata.sh >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
@@ -201,6 +214,9 @@ jobs:
             org.opencontainers.image.version=${{ needs.check-release.outputs.version }}
             org.opencontainers.image.revision=${{ steps.sha.outputs.commit }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            eventuras.migrations.latest=${{ steps.migr.outputs.latest }}
+            eventuras.migrations.count=${{ steps.migr.outputs.count }}
+            eventuras.migrations.sha=${{ steps.migr.outputs.sha }}
           build-args: |
             BUILD_VERSION=${{ needs.check-release.outputs.version }}
             BUILD_SHA=${{ steps.sha.outputs.commit }}

--- a/apps/api/scripts/migration-metadata.sh
+++ b/apps/api/scripts/migration-metadata.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# Emit migration metadata for the eventuras-api image as `key=value` lines
+# (latest, count, sha) for use as GitHub Actions step outputs / OCI labels.
+# Derived from the idempotent EF script so it can't drift from what ships.
+set -eu
+
+SQL="${1:-apps/api/src/Eventuras.Infrastructure/sqlscript/database-migrations.sql}"
+if [ ! -f "$SQL" ]; then
+  echo "error: migration script not found: $SQL" >&2
+  exit 1
+fi
+
+# One INSERT into __EFMigrationsHistory per migration; ids are <ts>_<Name>.
+IDS="$(grep -oE "VALUES \('[0-9]{14}_[^']*'" "$SQL" | sed -E "s/^VALUES \('//; s/'\$//" | sort -u)"
+if [ -z "$IDS" ]; then
+  echo "error: no migration ids found in $SQL (format changed or wrong path?)" >&2
+  exit 1
+fi
+
+COUNT="$(printf '%s\n' "$IDS" | grep -c . || true)"
+LATEST="$(printf '%s\n' "$IDS" | tail -1)"
+SHA="$(sha256sum "$SQL" | cut -d' ' -f1)"
+
+echo "latest=$LATEST"
+echo "count=$COUNT"
+echo "sha=$SHA"

--- a/apps/api/src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj
+++ b/apps/api/src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj
@@ -26,9 +26,13 @@
     <Folder Include="Migrations\" />
   </ItemGroup>
   <ItemGroup>
-    <!-- Ship the idempotent EF migration script in build/publish output (and the
-         runtime Docker image) at sqlscript/database-migrations.sql. -->
+    <!-- Ship the idempotent EF migration script and its pending-check helper in
+         build/publish output (and the runtime Docker image) under sqlscript/. -->
     <None Include="sqlscript/database-migrations.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+    <None Include="sqlscript/check-pending-migrations.sh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </None>

--- a/apps/api/src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj
+++ b/apps/api/src/Eventuras.Infrastructure/Eventuras.Infrastructure.csproj
@@ -25,4 +25,12 @@
   <ItemGroup>
     <Folder Include="Migrations\" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Ship the idempotent EF migration script in build/publish output (and the
+         runtime Docker image) at sqlscript/database-migrations.sql. -->
+    <None Include="sqlscript/database-migrations.sql">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/apps/api/src/Eventuras.Infrastructure/sqlscript/check-pending-migrations.sh
+++ b/apps/api/src/Eventuras.Infrastructure/sqlscript/check-pending-migrations.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env sh
+# Report EF migrations that are present in database-migrations.sql but have not
+# yet been applied to the target database (i.e. the migrations that still need
+# to run). The script reads its migration ids from the idempotent EF script, so
+# it stays correct for whatever image version it ships in.
+#
+# Usage:
+#   check-pending-migrations.sh [path-to-database-migrations.sql]
+#
+# Defaults to the database-migrations.sql sitting next to this script (the path
+# both files have inside the eventuras-api image: /app/sqlscript/).
+#
+# The database connection is taken from the standard libpq environment
+# (PGHOST, PGPORT, PGUSER, PGPASSWORD, PGDATABASE) or a PG* connection URI,
+# exactly like plain psql. Run this from a container that has psql.
+#
+# Pending migration ids are written to stdout, one per line (empty when up to
+# date); all human-readable messages go to stderr, so stdout stays parseable.
+#
+# Exit codes:
+#   0   database is up to date (no pending migrations)
+#   10  one or more pending migrations
+#   1   usage or runtime error
+set -eu
+
+SQL="${1:-$(dirname "$0")/database-migrations.sql}"
+if [ ! -f "$SQL" ]; then
+  echo "error: migration script not found: $SQL" >&2
+  exit 1
+fi
+
+# One INSERT into __EFMigrationsHistory exists per migration; pull the ids from
+# there. Matching up to the closing quote keeps names with underscores intact.
+IDS="$(grep -oE "VALUES \('[0-9]{14}_[^']*'" "$SQL" | sed -E "s/^VALUES \('//; s/'\$//" | sort -u)"
+if [ -z "$IDS" ]; then
+  echo "error: no migration ids found in $SQL" >&2
+  exit 1
+fi
+
+# Fresh database: the history table doesn't exist yet, so everything is pending.
+HAS_TABLE="$(psql -X -A -t -q -v ON_ERROR_STOP=1 \
+  -c "SELECT to_regclass('\"__EFMigrationsHistory\"') IS NOT NULL;" | tr -d '[:space:]')"
+if [ "$HAS_TABLE" != "t" ]; then
+  echo "Pending migrations (fresh database, no __EFMigrationsHistory):" >&2
+  printf '%s\n' "$IDS"
+  exit 10
+fi
+
+IDS_CSV="$(printf '%s' "$IDS" | tr '\n' ',')"
+PENDING="$(psql -X -A -t -q -v ON_ERROR_STOP=1 -v ids="$IDS_CSV" <<'SQL_EOF'
+WITH script(id) AS (
+  SELECT unnest(string_to_array(trim(both ',' from :'ids'), ','))
+)
+SELECT s.id
+FROM script s
+WHERE NOT EXISTS (
+  SELECT 1 FROM "__EFMigrationsHistory" h WHERE h."MigrationId" = s.id
+)
+ORDER BY s.id;
+SQL_EOF
+)"
+
+if [ -n "$PENDING" ]; then
+  echo "Pending migrations:" >&2
+  printf '%s\n' "$PENDING"
+  exit 10
+fi
+
+echo "Database is up to date; no pending migrations." >&2
+exit 0


### PR DESCRIPTION
## Summary

Supports an automated, versioned migration mechanism: a self-contained migration Job (run by infra) instead of running the EF script manually in pgAdmin.

Three parts:

### 1. Ship the migration script in the image
`sqlscript/database-migrations.sql` is marked `CopyToOutputDirectory` + `CopyToPublishDirectory` in `Eventuras.Infrastructure`, so it flows transitively into the `Eventuras.WebApi` publish output and the runtime `losolio/eventuras-api` image at **`/app/sqlscript/database-migrations.sql`**. No Dockerfile or entrypoint change.

It stays the idempotent EF script (`dotnet ef migrations script --idempotent`) you already maintain — same flow.

### 2. Image labels: new migrations since a prior release (no DB)
`api-docker.yml` computes migration metadata from the script (`scripts/migration-metadata.sh`) and stamps OCI labels on the image:

- `eventuras.migrations.latest` — newest migration id (e.g. `20260603180354_AddProductSalesAccount`)
- `eventuras.migrations.count` — total migrations in the script
- `eventuras.migrations.sha` — sha256 of the script

Comparing two image tags' labels (`docker inspect` / registry) tells you whether a build carries new migrations since a prior release — no database needed.

### 3. `check-pending-migrations.sh`: migrations to run vs a target DB
Shipped in the image at `/app/sqlscript/check-pending-migrations.sh`. It reads the migration ids from the script and diffs them against the target database's `__EFMigrationsHistory`:

- prints the pending migration ids and exits **10** when there are migrations to run
- exits **0** when the database is up to date
- handles a fresh database (no history table → everything pending)

Connection comes from standard libpq env vars, like plain `psql` — fits the infra migration Job (psql container).

## Verification
- `dotnet publish -c Release` → both files present under `sqlscript/` in the output (script keeps its executable bit).
- `migration-metadata.sh` → `latest=20260603180354_AddProductSalesAccount count=28 sha=962836cc…`.
- `check-pending-migrations.sh` tested against an ephemeral Postgres: fresh DB (28 pending, exit 10), partially applied (only the 2 newest pending, exit 10), fully applied (exit 0).

After the image builds:
```sh
docker run --rm --entrypoint sh losolio/eventuras-api:<tag> \
  -c 'ls -l /app/sqlscript/ && head -1 /app/sqlscript/database-migrations.sql'
docker inspect -f '{{json .Config.Labels}}' losolio/eventuras-api:<tag>
```

## Out of scope (infra)
The migration Job itself (initContainer copies the script from the api image → psql container applies it), PreSync hook, backup + gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)