### PR TITLE
fix(fides-auth-next): drive session refresh from token expiry, not a fixed interval

### DIFF
--- a/.changeset/expiry-driven-heartbeat.md
+++ b/.changeset/expiry-driven-heartbeat.md
@@ -1,0 +1,8 @@
+---
+'@eventuras/fides-auth-next': minor
+---
+
+`useHeartbeat` now schedules session refreshes from the access-token expiry
+instead of a fixed interval, so the cadence self-adjusts to any token TTL.
+Adds `fraction`, `minSkewMs`, `minRefreshIntervalMs` and `initialExpiresAt`
+config and decouples `idleThresholdMs` from the token TTL; removes `intervalMs`.

--- a/libs/fides-auth-next/src/store/use-heartbeat.test.tsx
+++ b/libs/fides-auth-next/src/store/use-heartbeat.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Tests for the useHeartbeat React hook.
  *
- * The hook combines an activity tracker, a setTimeout-driven schedule, fetch,
- * and a visibilitychange listener. Tests run under fake timers so we can
+ * The hook schedules refreshes from the access token's expiry (returned by the
+ * endpoint as `accessTokenExpiresAt`), primes once on mount to learn it, and
+ * defers when the tab is hidden/idle. Tests run under fake timers so we can
  * advance time deterministically, with a mocked global fetch.
  */
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -30,16 +31,28 @@ function setVisibility(state: 'visible' | 'hidden'): void {
   document.dispatchEvent(new Event('visibilitychange'));
 }
 
+/** A 200 response carrying an access-token expiry `ttlMs` from now (ISO). */
+function expiryResponse(ttlMs: number): Response {
+  return new Response(
+    JSON.stringify({ accessTokenExpiresAt: new Date(Date.now() + ttlMs).toISOString() }),
+    { status: 200, headers: { 'content-type': 'application/json' } },
+  );
+}
+
+/** Flush pending timers up to `ms`, draining microtasks in between. */
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
 let fetchMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   vi.useFakeTimers();
   setVisibility('visible');
-
-  // Default: every fetch succeeds with 200 + empty JSON body.
-  fetchMock = vi.fn().mockResolvedValue(
-    new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
-  );
+  // Default: every refresh succeeds with a 5-minute token.
+  fetchMock = vi.fn().mockImplementation(() => Promise.resolve(expiryResponse(5 * 60_000)));
   vi.stubGlobal('fetch', fetchMock);
 });
 
@@ -48,182 +61,157 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-// Params chosen so the activity gate is meaningful:
-//
-// - intervalMs > tracker throttle (1000) so keystrokes between ticks register
-// - idleThresholdMs < intervalMs so the tracker's initial mount-time timestamp
-//   has already fallen outside the idle window by the time the first tick
-//   fires. With these numbers, a tick can only fire if a keystroke was
-//   recorded in the last 500ms — proving the gate is exercised.
-const HAPPY_INTERVAL = 3000;
-const HAPPY_IDLE = 500;
-
-describe('useHeartbeat — happy path', () => {
-  it('POSTs to the default endpoint on each tick when active and visible', async () => {
+describe('useHeartbeat — priming', () => {
+  it('refreshes immediately on mount to discover the expiry', async () => {
     const onRefreshed = vi.fn();
-    const { unmount } = render(
-      <HeartbeatHost intervalMs={HAPPY_INTERVAL} idleThresholdMs={HAPPY_IDLE} onRefreshed={onRefreshed} />,
-    );
+    render(<HeartbeatHost onRefreshed={onRefreshed} />);
 
-    // Advance to just before the first tick, record a keystroke INSIDE the
-    // idle window, then let the tick fire. The initial mount timestamp is now
-    // 2900ms old, well outside the 500ms idle window, so only the fresh
-    // keystroke can keep the tick alive.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(HAPPY_INTERVAL - 100);
-    });
-    recordKeystroke();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
-    });
+    await advance(0);
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith('/api/auth/heartbeat', expect.objectContaining({
-      method: 'POST',
-      credentials: 'same-origin',
-    }));
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/auth/heartbeat',
+      expect.objectContaining({ method: 'POST', credentials: 'same-origin' }),
+    );
     expect(onRefreshed).toHaveBeenCalledTimes(1);
-
-    // Second tick: same pattern — fresh keystroke close to the next tick.
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(HAPPY_INTERVAL - 100);
-    });
-    recordKeystroke();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-
-    unmount();
   });
 
   it('honors a custom endpoint', async () => {
-    render(<HeartbeatHost endpoint="/custom/heartbeat" intervalMs={HAPPY_INTERVAL} idleThresholdMs={HAPPY_IDLE} />);
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(HAPPY_INTERVAL - 100);
-    });
-    recordKeystroke();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(100);
-    });
-
+    render(<HeartbeatHost endpoint="/custom/heartbeat" />);
+    await advance(0);
     expect(fetchMock).toHaveBeenCalledWith('/custom/heartbeat', expect.anything());
   });
 
-  it('skips the tick when no fresh keystroke arrived before the activity window closed', async () => {
-    // Companion to the happy-path: with the SAME interval/threshold but no
-    // keystroke, the tick should be skipped — proving the gate works in both
-    // directions. (The "no recent activity" describe block below uses a
-    // broader scenario; this one shares params with the happy-path tests to
-    // pin down the gate.)
-    render(<HeartbeatHost intervalMs={HAPPY_INTERVAL} idleThresholdMs={HAPPY_IDLE} />);
+  it('skips the prime and schedules from initialExpiresAt when provided', async () => {
+    const tenMin = new Date(Date.now() + 10 * 60_000).toISOString();
+    render(<HeartbeatHost initialExpiresAt={tenMin} fraction={0.3} />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(HAPPY_INTERVAL);
-    });
-
+    // No immediate refresh — expiry is already known.
+    await advance(0);
     expect(fetchMock).not.toHaveBeenCalled();
+
+    // lead = 0.3 * 10min = 3min → refresh after 7min.
+    await advance(7 * 60_000 - 1000);
+    expect(fetchMock).not.toHaveBeenCalled();
+    await advance(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('useHeartbeat — gating', () => {
-  it('skips the tick when the tab is hidden', async () => {
-    render(<HeartbeatHost intervalMs={1000} idleThresholdMs={5000} />);
-    recordKeystroke();
-    setVisibility('hidden');
+describe('useHeartbeat — expiry-driven cadence', () => {
+  it('schedules the next refresh from the returned expiry (5-min token, fraction 0.3)', async () => {
+    render(<HeartbeatHost fraction={0.3} />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-    });
+    // Prime.
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    // lead = 0.3 * 5min = 90s → next refresh after 210s.
+    await advance(210_000 - 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await advance(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('skips the tick when there has been no recent activity', async () => {
-    // No keystroke is dispatched, so the tracker's initial timestamp is the
-    // only activity — and we advance time past the idle threshold before tick.
-    render(<HeartbeatHost intervalMs={5000} idleThresholdMs={1000} />);
+  it('self-adjusts to a short TTL via the skew floor (10-second token)', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(expiryResponse(10_000)));
+    render(<HeartbeatHost fraction={0.3} minSkewMs={5_000} minRefreshIntervalMs={5_000} />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
-    });
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    expect(fetchMock).not.toHaveBeenCalled();
+    // lead = max(5s, 0.3*10s=3s) = 5s → refresh 5s in.
+    await advance(4_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await advance(1_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('never refreshes faster than minRefreshIntervalMs for ultra-short tokens', async () => {
+    fetchMock.mockImplementation(() => Promise.resolve(expiryResponse(1_000)));
+    render(<HeartbeatHost minSkewMs={5_000} minRefreshIntervalMs={5_000} />);
+
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await advance(4_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await advance(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('useHeartbeat — session expired', () => {
-  it('fires onSessionExpired when the endpoint returns 401 and stops further ticks', async () => {
+  it('fires onSessionExpired on 401 and stops further refreshes', async () => {
     fetchMock.mockResolvedValueOnce(new Response(null, { status: 401 }));
     const onSessionExpired = vi.fn();
     const onRefreshed = vi.fn();
 
-    render(<HeartbeatHost
-      intervalMs={1000}
-      idleThresholdMs={5000}
-      onSessionExpired={onSessionExpired}
-      onRefreshed={onRefreshed}
-    />);
-    recordKeystroke();
+    render(<HeartbeatHost onSessionExpired={onSessionExpired} onRefreshed={onRefreshed} />);
 
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-    });
+    await advance(0);
     expect(onSessionExpired).toHaveBeenCalledTimes(1);
     expect(onRefreshed).not.toHaveBeenCalled();
 
-    // After teardown on 401, subsequent intervals should NOT fire fetch.
-    recordKeystroke();
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(5000);
-    });
+    // No further refreshes after teardown.
+    await advance(10 * 60_000);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(onSessionExpired).toHaveBeenCalledTimes(1);
   });
 });
 
-describe('useHeartbeat — visibilitychange refocus', () => {
-  it('beats immediately when tab regains focus after >= intervalMs away', async () => {
-    render(<HeartbeatHost intervalMs={1000} idleThresholdMs={10_000} />);
-    recordKeystroke();
+describe('useHeartbeat — transient failure', () => {
+  it('retries with backoff and reports via onError, then resumes', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockImplementation(() => Promise.resolve(expiryResponse(5 * 60_000)));
+    const onError = vi.fn();
 
-    // Hide the tab so the scheduled tick at t=1000 is skipped.
-    setVisibility('hidden');
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2000);
-    });
-    expect(fetchMock).not.toHaveBeenCalled();
+    render(<HeartbeatHost minRefreshIntervalMs={5_000} onError={onError} />);
 
-    // Now reveal — sinceLast (2s) >= intervalMs (1s), so beat should fire immediately.
-    recordKeystroke();
-    setVisibility('visible');
-
-    await act(async () => {
-      // Let the microtask queue drain.
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
+    // Prime fails.
+    await advance(0);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    // Backoff = minRefreshIntervalMs (first retry) → retry succeeds.
+    await advance(5_000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useHeartbeat — defer when hidden/idle', () => {
+  it('defers a due refresh while idle, then refreshes on the next interaction', async () => {
+    render(<HeartbeatHost fraction={0.3} idleThresholdMs={1_000} />);
+
+    // Prime at mount (active), token = 5min → next refresh at 210s.
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // By 210s the user has been idle far longer than 1s → refresh is deferred.
+    await advance(210_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Interaction wakes the deferred refresh.
+    recordKeystroke();
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
-  it('does NOT immediately beat when refocus happens within intervalMs', async () => {
-    render(<HeartbeatHost intervalMs={10_000} idleThresholdMs={60_000} />);
-    recordKeystroke();
+  it('defers while the tab is hidden, then refreshes when it becomes visible', async () => {
+    // idleThresholdMs is shorter than the time spent hidden, so returning to the
+    // tab must count as activity for the deferred refresh to run on focus alone.
+    render(<HeartbeatHost fraction={0.3} idleThresholdMs={1_000} />);
+
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
     setVisibility('hidden');
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-    });
+    await advance(210_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // deferred while hidden
+
     setVisibility('visible');
-
-    await act(async () => {
-      await Promise.resolve();
-    });
-
-    // sinceLast (1s) < intervalMs (10s), so no immediate beat.
-    expect(fetchMock).not.toHaveBeenCalled();
+    await advance(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -231,7 +219,6 @@ describe('useHeartbeat — unmount', () => {
   it('does not fire callbacks for fetches that resolve after unmount', async () => {
     let resolveFetch: (response: Response) => void = () => undefined;
     fetchMock.mockImplementation((_url: string, init: RequestInit) => {
-      // Mirror the AbortController behavior: reject if signal aborts.
       return new Promise<Response>((resolve, reject) => {
         resolveFetch = resolve;
         init.signal?.addEventListener('abort', () => {
@@ -242,21 +229,13 @@ describe('useHeartbeat — unmount', () => {
 
     const onRefreshed = vi.fn();
     const onError = vi.fn();
-    const { unmount } = render(<HeartbeatHost
-      intervalMs={1000}
-      idleThresholdMs={5000}
-      onRefreshed={onRefreshed}
-      onError={onError}
-    />);
-    recordKeystroke();
+    const { unmount } = render(<HeartbeatHost onRefreshed={onRefreshed} onError={onError} />);
 
-    // Tick fires; fetch is in-flight (pending promise).
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(1000);
-    });
+    // Prime fires; fetch is in-flight (pending promise).
+    await advance(0);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
-    // Unmount aborts the controller; resolve the pending fetch and let microtasks drain.
+    // Unmount aborts the controller; resolve the pending fetch and drain.
     unmount();
     resolveFetch(new Response('{}', { status: 200 }));
     await act(async () => {
@@ -264,8 +243,6 @@ describe('useHeartbeat — unmount', () => {
       await Promise.resolve();
     });
 
-    // Neither callback should have fired — the post-await `stopped` guard
-    // bails before they're called.
     expect(onRefreshed).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
   });

--- a/libs/fides-auth-next/src/store/use-heartbeat.ts
+++ b/libs/fides-auth-next/src/store/use-heartbeat.ts
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import {
   createActivityTracker,
+  DEFAULT_ACTIVITY_EVENTS,
   type ActivityTracker,
 } from '@eventuras/fides-auth/activity-tracker';
 import { Logger } from '@eventuras/logger';
@@ -13,24 +14,52 @@ import { Logger } from '@eventuras/logger';
 export interface HeartbeatConfig {
   /**
    * Endpoint to POST to in order to refresh the session.
-   * The endpoint must run server-side refresh and return 2xx on success or 401
-   * when the refresh token is no longer valid.
+   * The endpoint must run a server-side refresh and return 2xx with
+   * `{ accessTokenExpiresAt }` (ISO 8601) on success, or 401 when the refresh
+   * token is no longer valid.
    * @default '/api/auth/heartbeat'
    */
   endpoint?: string;
 
   /**
-   * Interval between heartbeat ticks, in ms.
-   * @default 300_000 (5 minutes)
+   * How much of the access-token lifetime to keep as headroom: the refresh is
+   * scheduled when `fraction` of the TTL remains. Governs long tokens (a 1 h
+   * token at 0.3 refreshes ~42 min in); short tokens are dominated by
+   * {@link minSkewMs} instead.
+   * @default 0.3
    */
-  intervalMs?: number;
+  fraction?: number;
 
   /**
-   * How recently the user must have interacted for a heartbeat to fire.
-   * Prevents background tabs from extending sessions indefinitely.
-   * @default 120_000 (2 minutes)
+   * Absolute floor for the refresh lead time (network round-trip + clock skew).
+   * Dominates for short-lived tokens: a 10 s token still refreshes ~5 s in.
+   * @default 5_000 (5 seconds)
+   */
+  minSkewMs?: number;
+
+  /**
+   * Floor on how often a refresh may fire, so ultra-short tokens don't hammer
+   * the endpoint.
+   * @default 5_000 (5 seconds)
+   */
+  minRefreshIntervalMs?: number;
+
+  /**
+   * How recently the user must have interacted for a due refresh to fire.
+   * Decoupled from the access-token TTL on purpose — this only suppresses
+   * refreshes in genuinely abandoned tabs, so keep it generous (tie it to the
+   * IdP's SSO/session idle, not the access token). When a refresh is suppressed
+   * the hook waits for the next interaction (or tab focus) and refreshes then.
+   * @default 1_800_000 (30 minutes)
    */
   idleThresholdMs?: number;
+
+  /**
+   * Known access-token expiry at mount (ISO 8601 string or epoch ms). When
+   * provided, the first refresh is scheduled from it instead of priming with an
+   * immediate refresh to discover the expiry.
+   */
+  initialExpiresAt?: string | number | null;
 
   /**
    * Called when the heartbeat endpoint returns 401 — refresh token is gone.
@@ -38,13 +67,13 @@ export interface HeartbeatConfig {
   onSessionExpired?: () => void;
 
   /**
-   * Called after a successful refresh tick.
+   * Called after a successful refresh.
    */
   onRefreshed?: () => void;
 
   /**
-   * Called on transient errors (network failure, 5xx). The hook keeps polling
-   * — this is just an observability hook.
+   * Called on transient errors (network failure, 5xx). The hook retries — this
+   * is just an observability hook.
    */
   onError?: (error: Error) => void;
 
@@ -57,17 +86,43 @@ export interface HeartbeatConfig {
 
 const DEFAULTS = {
   endpoint: '/api/auth/heartbeat',
-  intervalMs: 5 * 60_000,
-  idleThresholdMs: 2 * 60_000,
+  fraction: 0.3,
+  minSkewMs: 5_000,
+  minRefreshIntervalMs: 5_000,
+  idleThresholdMs: 30 * 60_000,
   loggerNamespace: 'fides:heartbeat',
 } as const;
 
+// Fallback cadence when a refresh succeeds but the response carries no usable
+// expiry — keeps the session alive without busy-looping on an unknown TTL.
+const FALLBACK_INTERVAL_MS = 60_000;
+// Upper bound for exponential backoff between transient-failure retries.
+const MAX_RETRY_DELAY_MS = 60_000;
+
+/** Parses an ISO 8601 string or epoch-ms number into epoch ms, or null. */
+function toEpochMs(value: string | number | null | undefined): number | null {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'string') {
+    const t = Date.parse(value);
+    return Number.isFinite(t) ? t : null;
+  }
+  return null;
+}
+
 /**
- * Activity-driven session keepalive.
+ * Expiry-driven session keepalive.
  *
- * Polls a server-side refresh endpoint at a fixed interval, but only when the
- * user has actually been active recently. Skips ticks when the tab is hidden,
- * and runs an immediate refresh when the tab regains focus after a long away.
+ * Schedules each refresh from the access token's actual expiry rather than a
+ * fixed interval, so the cadence self-adjusts to whatever TTL the IdP issues: a
+ * 5-minute token refreshes ~3.5 min in; a 10-second token refreshes ~5 s in
+ * (skew floor). It primes with one refresh on mount to learn the current expiry
+ * (pass {@link HeartbeatConfig.initialExpiresAt} to skip that), retries on
+ * transient failure, and — for hidden or idle tabs — defers the refresh until
+ * the tab is focused or the user interacts again.
+ *
+ * A 401 from the endpoint (refresh token / SSO session gone) is the logout
+ * trigger via {@link HeartbeatConfig.onSessionExpired}; the idle gate is only an
+ * optimization for abandoned tabs, never a gate on access-token freshness.
  *
  * Intended to be paired with {@link useSessionMonitor}: the monitor *detects*
  * session loss; this hook *prevents* it for active users.
@@ -86,8 +141,11 @@ const DEFAULTS = {
  */
 export function useHeartbeat(config: HeartbeatConfig = {}): void {
   const endpoint = config.endpoint ?? DEFAULTS.endpoint;
-  const intervalMs = config.intervalMs ?? DEFAULTS.intervalMs;
+  const fraction = config.fraction ?? DEFAULTS.fraction;
+  const minSkewMs = config.minSkewMs ?? DEFAULTS.minSkewMs;
+  const minRefreshIntervalMs = config.minRefreshIntervalMs ?? DEFAULTS.minRefreshIntervalMs;
   const idleThresholdMs = config.idleThresholdMs ?? DEFAULTS.idleThresholdMs;
+  const initialExpiresAt = toEpochMs(config.initialExpiresAt);
   const loggerNamespace = config.loggerNamespace ?? DEFAULTS.loggerNamespace;
 
   // Keep callbacks stable across renders without re-running the effect.
@@ -112,37 +170,97 @@ export function useHeartbeat(config: HeartbeatConfig = {}): void {
 
     const tracker: ActivityTracker = createActivityTracker();
     const abortController = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-    let lastTickAt = Date.now();
-    let stopped = false;
 
-    const teardown = (): void => {
-      if (stopped) return;
-      stopped = true;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let stopped = false;
+    let primed = initialExpiresAt !== null;
+    let expiresAt: number | null = initialExpiresAt;
+    let failureCount = 0;
+    let wakerArmed = false;
+
+    const clearTimer = (): void => {
       if (timeoutId) {
         clearTimeout(timeoutId);
         timeoutId = null;
       }
+    };
+
+    const disarmWaker = (): void => {
+      if (!wakerArmed) return;
+      wakerArmed = false;
+      for (const event of DEFAULT_ACTIVITY_EVENTS) {
+        globalThis.removeEventListener(event, onWake);
+      }
+      document.removeEventListener('visibilitychange', onVisibleWake);
+    };
+
+    const teardown = (): void => {
+      if (stopped) return;
+      stopped = true;
+      clearTimer();
+      disarmWaker();
       abortController.abort();
-      document.removeEventListener('visibilitychange', onVisibilityChange);
       tracker.dispose();
     };
 
-    const sendBeat = async (): Promise<void> => {
+    // Time until the next refresh should fire, from the current known expiry.
+    const nextDelay = (): number => {
+      if (!primed) return 0; // prime now to discover the expiry
+      if (expiresAt === null) return FALLBACK_INTERVAL_MS;
+      const now = Date.now();
+      const ttl = Math.max(0, expiresAt - now);
+      const lead = Math.max(minSkewMs, fraction * ttl);
+      return Math.max(minRefreshIntervalMs, expiresAt - lead - now);
+    };
+
+    const scheduleRefresh = (delay = nextDelay()): void => {
       if (stopped) return;
+      clearTimer();
+      timeoutId = setTimeout(onDue, delay);
+    };
 
-      // Skip while hidden — focus listener will catch up when tab returns.
-      if (document.visibilityState === 'hidden') {
-        logger.debug('Tab hidden, skipping heartbeat');
+    function onWake(): void {
+      if (stopped || !wakerArmed) return;
+      disarmWaker();
+      void onDue();
+    }
+
+    function onVisibleWake(): void {
+      if (document.visibilityState !== 'visible') return;
+      // Returning to the tab counts as activity, so a refresh deferred past
+      // idleThresholdMs while hidden runs now instead of deferring again
+      // (a visibility change does not touch the activity tracker on its own).
+      tracker.recordActivity();
+      onWake();
+    }
+
+    // Suspend refreshing until the tab is focused or the user interacts again.
+    const deferUntilActive = (): void => {
+      if (stopped || wakerArmed) return;
+      wakerArmed = true;
+      clearTimer();
+      for (const event of DEFAULT_ACTIVITY_EVENTS) {
+        globalThis.addEventListener(event, onWake, { passive: true });
+      }
+      document.addEventListener('visibilitychange', onVisibleWake);
+    };
+
+    async function onDue(): Promise<void> {
+      if (stopped) return;
+      timeoutId = null;
+
+      // Hidden or abandoned: don't refresh now; wake on focus/interaction.
+      if (document.visibilityState === 'hidden' || !tracker.isActiveWithin(idleThresholdMs)) {
+        logger.debug('Refresh due but tab hidden/idle — deferring until active');
+        deferUntilActive();
         return;
       }
 
-      if (!tracker.isActiveWithin(idleThresholdMs)) {
-        logger.debug({ idleThresholdMs }, 'No recent activity, skipping heartbeat');
-        return;
-      }
+      await beat();
+    }
 
-      lastTickAt = Date.now();
+    async function beat(): Promise<void> {
+      if (stopped) return;
       try {
         const response = await fetch(endpoint, {
           method: 'POST',
@@ -151,14 +269,13 @@ export function useHeartbeat(config: HeartbeatConfig = {}): void {
           signal: abortController.signal,
         });
 
-        // Component unmounted (or 401-driven teardown) during the fetch —
-        // bail before touching callbacks so we don't fire on a dead consumer.
+        // Unmounted (or 401-driven teardown) during the fetch — bail before
+        // touching callbacks so we don't fire on a dead consumer.
         if (stopped) return;
 
         if (response.status === 401) {
           logger.info('Heartbeat returned 401 — session expired');
           callbacksRef.current.onSessionExpired?.();
-          // Tear down eagerly so listeners and tracker don't linger until unmount.
           teardown();
           return;
         }
@@ -167,51 +284,50 @@ export function useHeartbeat(config: HeartbeatConfig = {}): void {
           throw new Error(`Heartbeat failed with status ${response.status}`);
         }
 
-        logger.debug('Heartbeat refresh succeeded');
+        failureCount = 0;
+        primed = true;
+        const body = (await response.json().catch(() => null)) as
+          | { accessTokenExpiresAt?: string | number | null }
+          | null;
+        expiresAt = toEpochMs(body?.accessTokenExpiresAt);
+
+        logger.debug({ expiresAt }, 'Heartbeat refresh succeeded');
         callbacksRef.current.onRefreshed?.();
+        scheduleRefresh();
       } catch (error) {
-        // Suppress AbortError-from-teardown and any error reported after stop.
         if (stopped) return;
         const err = error instanceof Error ? error : new Error(String(error));
-        logger.warn({ error: err.message }, 'Heartbeat tick failed');
+        logger.warn({ error: err.message }, 'Heartbeat tick failed, will retry');
         callbacksRef.current.onError?.(err);
-      }
-    };
 
-    const scheduleNext = (): void => {
-      if (stopped) return;
-      timeoutId = setTimeout(async () => {
-        timeoutId = null;
-        await sendBeat();
-        scheduleNext();
-      }, intervalMs);
-    };
-
-    function onVisibilityChange(): void {
-      if (stopped) return;
-      if (document.visibilityState !== 'visible') return;
-
-      // Tab regained focus. If we've been away longer than one tick, beat now —
-      // but cancel the pending tick first so we don't fire twice back-to-back.
-      const sinceLast = Date.now() - lastTickAt;
-      if (sinceLast >= intervalMs) {
-        logger.debug({ sinceLast }, 'Tab regained focus after long away, beating now');
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-          timeoutId = null;
-        }
-        void sendBeat().then(scheduleNext);
+        // Retry with capped exponential backoff; a real expiry resumes the
+        // normal cadence once a tick succeeds.
+        failureCount += 1;
+        const backoff = Math.min(
+          MAX_RETRY_DELAY_MS,
+          minRefreshIntervalMs * 2 ** (failureCount - 1),
+        );
+        scheduleRefresh(backoff);
       }
     }
 
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    scheduleNext();
-
-    logger.debug({ intervalMs, idleThresholdMs, endpoint }, 'Heartbeat started');
+    scheduleRefresh();
+    logger.debug(
+      { fraction, minSkewMs, minRefreshIntervalMs, idleThresholdMs, endpoint, primed },
+      'Heartbeat started',
+    );
 
     return () => {
       teardown();
       logger.debug('Heartbeat stopped');
     };
-  }, [endpoint, intervalMs, idleThresholdMs, loggerNamespace]);
+  }, [
+    endpoint,
+    fraction,
+    minSkewMs,
+    minRefreshIntervalMs,
+    idleThresholdMs,
+    initialExpiresAt,
+    loggerNamespace,
+  ]);
 }


### PR DESCRIPTION
## Symptom

Signed-in users on a Keycloak realm with a 5-minute access-token lifetime were logged out ~5 min after login, especially after a short idle.

## Root cause

`useHeartbeat` refreshed on a **fixed 5-minute interval** (== the access-token TTL → zero margin) and **skipped on short idle windows** (`idleThresholdMs` 2 min), so the token expired before any refresh fired. A fixed interval can never be correct across IdPs — some issue ~10 s tokens.

## Fix: expiry-driven scheduling

Schedule each refresh from the token's actual expiry (the heartbeat endpoint already returns `accessTokenExpiresAt`):

```
refreshAt = expiry − max(minSkewMs, fraction × TTL)
```

floored by `minRefreshIntervalMs`. Same code, no per-app tuning:

| TTL | refresh after | margin |
|----|---------------|--------|
| 5 min | ~3.5 min | ~1.5 min |
| 1 h | ~42 min | ~18 min |
| 10 s | ~5 s (skew floor) | ~5 s |

Also:
- **Prime once on mount** to learn the current expiry (or pass `initialExpiresAt` to skip it).
- **Retry transient failures** with capped exponential backoff.
- **Defer for hidden/idle tabs** until the tab is focused or the user interacts again, instead of dropping the tick — when they return the server refresh token is still valid, so the deferred refresh succeeds.
- **`idleThresholdMs` decoupled** from the access-token TTL (default 30 min) — only suppresses genuinely abandoned tabs. A **401** from the endpoint remains the logout trigger.

## API changes (`useHeartbeat`)

- **Added:** `fraction` (0.3), `minSkewMs` (5 s), `minRefreshIntervalMs` (5 s), `initialExpiresAt`.
- **Changed:** `idleThresholdMs` default → 30 min, decoupled from token TTL.
- **Removed:** `intervalMs`.

Only consumer in the monorepo is `apps/web/Providers.tsx`, which passes only `onSessionExpired` and works unchanged on the new defaults.

## Tests

Rewrote `use-heartbeat.test.tsx` for the new behavior (11 tests): prime-on-mount, `initialExpiresAt` skips prime, expiry-driven cadence (5-min token), short-TTL skew floor (10 s), ultra-short floor, 401 → `onSessionExpired` + stop, transient retry/backoff, defer-while-idle → wake on interaction, defer-while-hidden → wake on visibility, no callbacks after unmount. Full package suite green (20).
