### PR TITLE
feat(web): show read-only user metadata via UserEditor showMetadata prop

### DIFF
--- a/apps/web/src/app/(admin)/admin/users/UserDrawer.tsx
+++ b/apps/web/src/app/(admin)/admin/users/UserDrawer.tsx
@@ -6,17 +6,23 @@ import { Button } from '@eventuras/ratio-ui/core/Button';
 import { Drawer } from '@eventuras/ratio-ui/layout/Drawer';
 
 import UserEditor from '@/app/(admin)/admin/users/UserEditor';
+import { UserDto } from '@/lib/eventuras-sdk';
 
 const UserDrawer: React.FC = () => {
   const t = useTranslations();
   const [visible, setVisible] = useState(false);
-  const showDrawer = () => setVisible(true);
+  // Once the user is created, hold onto it so the metadata (the new id) shows.
+  const [createdUser, setCreatedUser] = useState<UserDto | undefined>(undefined);
+  const showDrawer = () => {
+    setCreatedUser(undefined); // fresh create form each time the drawer opens
+    setVisible(true);
+  };
   const onClose = () => setVisible(false);
   return (
     <>
       <Button onClick={showDrawer}>{t('admin.users.labels.createUser')}</Button>
       <Drawer isOpen={visible} onClose={onClose}>
-        <UserEditor adminMode />
+        <UserEditor adminMode showMetadata user={createdUser} onUserUpdated={setCreatedUser} />
       </Drawer>
     </>
   );

--- a/apps/web/src/app/(admin)/admin/users/UserEditor.tsx
+++ b/apps/web/src/app/(admin)/admin/users/UserEditor.tsx
@@ -12,6 +12,7 @@ import { Form, PhoneInput, TextField } from '@eventuras/smartform';
 import { UserDto, UserFormDto } from '@/lib/eventuras-sdk';
 
 import { createUser, updateUser, updateUserProfile } from './actions';
+import { UserMetadata } from './UserMetadata';
 const logger = Logger.create({
   namespace: 'web:admin:users',
   context: { component: 'UserEditor' },
@@ -22,9 +23,11 @@ interface UserEditorProps {
   testId?: string;
   adminMode?: boolean;
   submitButtonLabel?: string;
+  /** Show read-only account metadata (user id, etc.) below the form. */
+  showMetadata?: boolean;
 }
 const UserEditor: FC<UserEditorProps> = props => {
-  const { adminMode, user, onUserUpdated, submitButtonLabel } = props;
+  const { adminMode, user, onUserUpdated, submitButtonLabel, showMetadata } = props;
   const t = useTranslations();
   const [isUpdating, setIsUpdating] = useState(false);
   const toast = useToast();
@@ -84,103 +87,106 @@ const UserEditor: FC<UserEditorProps> = props => {
     return editMode ? t('user.account.update.label') : t('user.account.create.label');
   };
   return (
-    <Form onSubmit={onSubmit} defaultValues={user} testId={props.testId}>
-      {/* Given Name Field */}
-      <Fieldset label={t('common.account.name.legend')}>
-        <TextField
-          name="givenName"
-          label={t('common.labels.givenName')}
-          description={t('user.account.name.description')}
-          placeholder="Gerhard"
-          // Only allow letters, including accentuated characters
-          validation={{
-            required: t('user.account.name.requiredText'),
-            pattern: {
-              value: regex.lettersSpaceAndHyphen,
-              message: t('common.account.name.validationText'),
-            },
-          }}
-          testId="accounteditor-form-givenname"
-        />
-        <TextField
-          name="middleName"
-          label={t('common.labels.middleName')}
-          description={t('user.account.name.description')}
-          placeholder="Armauer"
-          // Only allow letters, including accentuated characters
-          validation={{
-            pattern: {
-              value: regex.lettersSpaceAndHyphen,
-              message: t('common.account.name.validationText'),
-            },
-          }}
-          testId="accounteditor-form-middlename"
-        />
-        {/* Family Name Field */}
-        <TextField
-          name="familyName"
-          label={t('common.labels.familyName')}
-          description={t('user.account.name.description')}
-          placeholder="Hansen"
-          validation={{
-            required: t('user.account.name.requiredText'),
-            pattern: {
-              value: regex.lettersSpaceAndHyphen,
-              message: t('common.account.name.validationText'),
-            },
-          }}
-          testId="accounteditor-form-familyname"
-        />
-      </Fieldset>
-      <Fieldset label={t('common.account.contactInfo.legend')}>
-        {/* Email Field */}
-        <TextField
-          name="email"
-          label={t('user.account.email.label')}
-          description={
-            editMode
-              ? t('user.account.email.existingDescription')
-              : t('user.account.email.description')
-          }
-          type="email"
-          placeholder={t('user.account.email.placeholder')}
-          validation={{ required: t('user.account.email.requiredText') }}
-          disabled={editMode} // Disable editing email field for existing users
-        />
-        {/* Phone Field */}
-        <PhoneInput
-          name="phoneNumber"
-          label={t('user.account.phoneNumber.label')}
-          description={t('user.account.phoneNumber.description')}
-          validation={{
-            required: adminMode ? false : t('user.account.phoneNumber.requiredText'),
-            pattern: {
-              value: regex.internationalPhoneNumber,
-              message: t('user.account.phoneNumber.invalidFormatText'),
-            },
-          }}
-          testId="accounteditor-form-phonenumber"
-        />
-      </Fieldset>
-      <Fieldset label={t('common.account.moreInfo.legend')}>
-        <TextField
-          name="professionalIdentityNumber"
-          label={t('common.account.professionalIdentityNumber.label')}
-          description={t('common.account.professionalIdentityNumber.description')}
-          testId="accounteditor-form-professionalIdentityNumber"
-        />
-        <TextField
-          name="supplementaryInformation"
-          label={t('common.account.supplementaryInformation.label')}
-          description={t('common.account.supplementaryInformation.description')}
-          testId="accounteditor-form-supplementaryInformation"
-        />
-      </Fieldset>
-      {/* Submit Button */}
-      <Button type="submit" testId="account-update-button" loading={isUpdating}>
-        {getButtonLabel()}
-      </Button>
-    </Form>
+    <>
+      <Form onSubmit={onSubmit} defaultValues={user} testId={props.testId}>
+        {/* Given Name Field */}
+        <Fieldset label={t('common.account.name.legend')}>
+          <TextField
+            name="givenName"
+            label={t('common.labels.givenName')}
+            description={t('user.account.name.description')}
+            placeholder="Gerhard"
+            // Only allow letters, including accentuated characters
+            validation={{
+              required: t('user.account.name.requiredText'),
+              pattern: {
+                value: regex.lettersSpaceAndHyphen,
+                message: t('common.account.name.validationText'),
+              },
+            }}
+            testId="accounteditor-form-givenname"
+          />
+          <TextField
+            name="middleName"
+            label={t('common.labels.middleName')}
+            description={t('user.account.name.description')}
+            placeholder="Armauer"
+            // Only allow letters, including accentuated characters
+            validation={{
+              pattern: {
+                value: regex.lettersSpaceAndHyphen,
+                message: t('common.account.name.validationText'),
+              },
+            }}
+            testId="accounteditor-form-middlename"
+          />
+          {/* Family Name Field */}
+          <TextField
+            name="familyName"
+            label={t('common.labels.familyName')}
+            description={t('user.account.name.description')}
+            placeholder="Hansen"
+            validation={{
+              required: t('user.account.name.requiredText'),
+              pattern: {
+                value: regex.lettersSpaceAndHyphen,
+                message: t('common.account.name.validationText'),
+              },
+            }}
+            testId="accounteditor-form-familyname"
+          />
+        </Fieldset>
+        <Fieldset label={t('common.account.contactInfo.legend')}>
+          {/* Email Field */}
+          <TextField
+            name="email"
+            label={t('user.account.email.label')}
+            description={
+              editMode
+                ? t('user.account.email.existingDescription')
+                : t('user.account.email.description')
+            }
+            type="email"
+            placeholder={t('user.account.email.placeholder')}
+            validation={{ required: t('user.account.email.requiredText') }}
+            disabled={editMode} // Disable editing email field for existing users
+          />
+          {/* Phone Field */}
+          <PhoneInput
+            name="phoneNumber"
+            label={t('user.account.phoneNumber.label')}
+            description={t('user.account.phoneNumber.description')}
+            validation={{
+              required: adminMode ? false : t('user.account.phoneNumber.requiredText'),
+              pattern: {
+                value: regex.internationalPhoneNumber,
+                message: t('user.account.phoneNumber.invalidFormatText'),
+              },
+            }}
+            testId="accounteditor-form-phonenumber"
+          />
+        </Fieldset>
+        <Fieldset label={t('common.account.moreInfo.legend')}>
+          <TextField
+            name="professionalIdentityNumber"
+            label={t('common.account.professionalIdentityNumber.label')}
+            description={t('common.account.professionalIdentityNumber.description')}
+            testId="accounteditor-form-professionalIdentityNumber"
+          />
+          <TextField
+            name="supplementaryInformation"
+            label={t('common.account.supplementaryInformation.label')}
+            description={t('common.account.supplementaryInformation.description')}
+            testId="accounteditor-form-supplementaryInformation"
+          />
+        </Fieldset>
+        {/* Submit Button */}
+        <Button type="submit" testId="account-update-button" loading={isUpdating}>
+          {getButtonLabel()}
+        </Button>
+      </Form>
+      {showMetadata && user && <UserMetadata user={user} />}
+    </>
   );
 };
 export default UserEditor;

--- a/apps/web/src/app/(admin)/admin/users/UserMetadata.tsx
+++ b/apps/web/src/app/(admin)/admin/users/UserMetadata.tsx
@@ -1,0 +1,38 @@
+'use client';
+import { useTranslations } from 'next-intl';
+
+import { Accordion } from '@eventuras/ratio-ui/core/Accordion';
+import { DescriptionList } from '@eventuras/ratio-ui/core/DescriptionList';
+
+import { UserDto } from '@/lib/eventuras-sdk';
+
+interface UserMetadataProps {
+  user: UserDto;
+}
+
+/**
+ * Read-only account metadata (user id, etc.) rendered by {@link UserEditor}
+ * when `showMetadata` is set. Renders nothing when the user has no id.
+ */
+export function UserMetadata({ user }: Readonly<UserMetadataProps>) {
+  const t = useTranslations();
+  if (!user.id) return null;
+
+  return (
+    <Accordion>
+      <Accordion.Item className="my-3">
+        <Accordion.Summary>{t('user.account.details.title')}</Accordion.Summary>
+        <Accordion.Content>
+          <DescriptionList>
+            <DescriptionList.Item>
+              <DescriptionList.Term>{t('user.account.details.userId')}</DescriptionList.Term>
+              <DescriptionList.Definition>
+                <span className="font-mono select-all">{user.id}</span>
+              </DescriptionList.Definition>
+            </DescriptionList.Item>
+          </DescriptionList>
+        </Accordion.Content>
+      </Accordion.Item>
+    </Accordion>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/users/[id]/page.tsx
@@ -37,8 +37,8 @@ const AdminUserDetailPage: React.FC<EventInfoProps> = async props => {
         </Container>
       </Section>
       <Section className="py-12">
-        <Container>
-          <UserEditor user={response.data} adminMode />
+        <Container paddingY="md">
+          <UserEditor user={response.data} adminMode showMetadata />
         </Container>
       </Section>
     </>

--- a/apps/web/src/app/(user)/user/account/page.tsx
+++ b/apps/web/src/app/(user)/user/account/page.tsx
@@ -1,7 +1,5 @@
 import { getTranslations } from 'next-intl/server';
 
-import { Accordion } from '@eventuras/ratio-ui/core/Accordion';
-import { DescriptionList } from '@eventuras/ratio-ui/core/DescriptionList';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 
@@ -15,29 +13,11 @@ const UserAccountPage = async () => {
   if (!response.data) {
     return <div>{t('user.page.profileNotFound')}</div>;
   }
-  const userId = response.data.id;
 
   return (
-    <Container>
+    <Container paddingY="md">
       <Heading>{t('user.profile.page.heading')}</Heading>
-      <UserEditor user={response.data} />
-      {userId && (
-        <Accordion>
-          <Accordion.Item className="mt-8">
-            <Accordion.Summary>{t('user.account.details.title')}</Accordion.Summary>
-            <Accordion.Content>
-              <DescriptionList>
-                <DescriptionList.Item>
-                  <DescriptionList.Term>{t('user.account.details.userId')}</DescriptionList.Term>
-                  <DescriptionList.Definition>
-                    <span className="font-mono select-all">{userId}</span>
-                  </DescriptionList.Definition>
-                </DescriptionList.Item>
-              </DescriptionList>
-            </Accordion.Content>
-          </Accordion.Item>
-        </Accordion>
-      )}
+      <UserEditor user={response.data} showMetadata />
     </Container>
   );
 };


### PR DESCRIPTION
## Summary

Extracts the read-only "account details" accordion (the user id) into a reusable **`UserMetadata`** component and renders it from **`UserEditor`** behind a new **`showMetadata`** prop, instead of being inlined on the account page.

## Changes

- **`UserMetadata.tsx`** (new) — client component, read-only; renders nothing when the user has no id.
- **`UserEditor`** — new `showMetadata?: boolean` prop; renders `<UserMetadata>` after the `<Form>` (in a fragment, so the read-only block isn't inside the `<form>` element).
- **Enabled where it makes sense:**
  - User account page (`showMetadata`)
  - Admin user detail page (`adminMode showMetadata`)
  - **Create-user drawer** — now keeps the created user (`onUserUpdated` → state), so the new id appears in the metadata after creation. Reopening the drawer resets to a fresh create form.
- Not enabled in the event-registration `AccountValidation` step.
- Minor: `Container paddingY="md"` on the two pages (valid spacing token; the previous `paddingY={3}` was not a valid `Space`).

## Note

In the drawer, once a user is created the editor flips to edit mode (`editMode = !!user`) — email disabled, button label becomes "update" — which is how the metadata gets an id to show. If we'd rather show the id without switching to edit mode, we'd split "show metadata" from `editMode` in `UserEditor`; happy to do that as a follow-up.

No changeset: all changes are in `apps/web` (not a publishable package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)