### PR TITLE
feat(e2e): read email OTP from Mailpit on test realms

### DIFF
--- a/tests/e2e/specs/web/helpers/auth.ts
+++ b/tests/e2e/specs/web/helpers/auth.ts
@@ -3,7 +3,7 @@ import { chromium, expect, test as setup } from '@playwright/test';
 import { mkdirSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-import { cleanupOtpEmails, fetchLoginCode } from '../../shared/utils';
+import { cleanupOtpEmails, fetchLoginCode } from '../../../utils/otp';
 
 const logger = Logger.create({ namespace: 'e2e:auth' });
 const isCI = !!process.env.CI;

--- a/tests/e2e/specs/web/public/003-anonymous-register-through-event-registration.spec.ts
+++ b/tests/e2e/specs/web/public/003-anonymous-register-through-event-registration.spec.ts
@@ -8,7 +8,7 @@ import {
   validateRegistration,
   visitAndClickEventRegistrationButton,
 } from '../helpers/registration';
-import { cleanupOtpEmails, fetchLoginCode } from '../../shared/utils';
+import { cleanupOtpEmails, fetchLoginCode } from '../../../utils/otp';
 
 test.describe.configure({ mode: 'serial' });
 
@@ -37,7 +37,7 @@ test.describe('should be able to register as an anonymous user when hitting the 
     await visitAndClickEventRegistrationButton(page, createdEvent.eventId);
     // Should be redirected away from the public event page to the identity provider
     const publicEventUrl = `/events/${createdEvent.eventId}`;
-    await page.waitForURL((url) => !url.pathname.startsWith(publicEventUrl), { timeout: 15000 });
+    await page.waitForURL(url => !url.pathname.startsWith(publicEventUrl), { timeout: 15000 });
     // Verify we were redirected away (the exact URL depends on the IdP)
     expect(page.url()).not.toContain(publicEventUrl);
   });

--- a/tests/e2e/utils/otp/code.ts
+++ b/tests/e2e/utils/otp/code.ts
@@ -1,0 +1,27 @@
+/**
+ * Verification-code extraction shared by every OTP source (Gmail, Mailpit, …).
+ *
+ * Keeping the patterns in one place means a new mail backend reads the code the
+ * same way the Gmail path always has.
+ */
+
+// tessera-otp codes are 4 chars from the alphabet 23456789ABCDEFGHJKLMNPQRSTUVWXYZ
+// (digits 2-9 + A-Z without I/O), so [2-9A-HJ-NP-Z].
+/** Ordered from most to least specific; first match wins. */
+export const OTP_CODE_PATTERNS: readonly RegExp[] = [
+  // The code on its own line.
+  /^\s*([2-9A-HJ-NP-Z]{4})\s*$/m,
+  // Fallback: the same token, word-bounded (after an HTML→text conversion).
+  /\b([2-9A-HJ-NP-Z]{4})\b/,
+];
+
+/** Extracts the verification code from an email body, or null. */
+export const extractLoginCode = (emailBody: string): string | null => {
+  for (const pattern of OTP_CODE_PATTERNS) {
+    const match = pattern.exec(emailBody);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return null;
+};

--- a/tests/e2e/utils/otp/gmail.ts
+++ b/tests/e2e/utils/otp/gmail.ts
@@ -15,6 +15,8 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { gmail_v1 } from 'googleapis';
 
+import { extractLoginCode } from './code';
+
 const logger = Logger.create({ namespace: 'e2e:utils' });
 
 let gmailClient: gmail_v1.Gmail | null = null;
@@ -52,6 +54,8 @@ const getRefreshToken = (): string | undefined => {
 /**
  * Initialize Gmail client using OAuth2 credentials from environment variables.
  * Reuses the same client instance for subsequent calls.
+ *
+ * Only invoked on the Gmail OTP path; the Mailpit path needs no auth.
  */
 export const initializeGmailClient = async (): Promise<gmail_v1.Gmail> => {
   if (gmailClient) {
@@ -90,7 +94,10 @@ export const initializeGmailClient = async (): Promise<gmail_v1.Gmail> => {
       // Get token info to see scopes
       const credentials = oauth2Client.credentials;
       logger.debug({ scope: credentials.scope || 'not specified' }, 'OAuth credentials - scope');
-      logger.debug({ tokenType: credentials.token_type || 'not specified' }, 'OAuth credentials - token_type');
+      logger.debug(
+        { tokenType: credentials.token_type || 'not specified' },
+        'OAuth credentials - token_type'
+      );
     } catch (error) {
       logger.debug({ error }, 'Warning: Could not get token info');
     }
@@ -116,12 +123,9 @@ export const initializeGmailClient = async (): Promise<gmail_v1.Gmail> => {
 };
 
 /**
- * Fetches login/verification code from Gmail inbox.
- * @param userEmail - The email address to search for verification emails
- * @param maxRetries - Maximum number of polling attempts (default: 20)
- * @param intervalMs - Milliseconds between retry attempts (default: 5000)
+ * Fetches login/verification code from a Gmail inbox.
  */
-export const fetchLoginCode = async (
+export const fetchLoginCodeViaGmail = async (
   userEmail: string,
   maxRetries = 20,
   intervalMs = 3000
@@ -170,12 +174,15 @@ export const fetchLoginCode = async (
   const subjectHeader = headers.find(h => h.name?.toLowerCase() === 'subject');
   const dateHeader = headers.find(h => h.name?.toLowerCase() === 'date');
 
-  logger.debug({
-    from: fromHeader?.value || 'unknown',
-    subject: subjectHeader?.value || 'unknown',
-    date: dateHeader?.value || 'unknown',
-    internalDate: fullMessage.internalDate || 'unknown',
-  }, 'Email details');
+  logger.debug(
+    {
+      from: fromHeader?.value || 'unknown',
+      subject: subjectHeader?.value || 'unknown',
+      date: dateHeader?.value || 'unknown',
+      internalDate: fullMessage.internalDate || 'unknown',
+    },
+    'Email details'
+  );
 
   const emailBody = getPlainTextBody(fullMessage);
   if (!emailBody) {
@@ -187,26 +194,7 @@ export const fetchLoginCode = async (
   // Log the email body for debugging (first 300 chars)
   logger.debug({ bodyPreview: emailBody.substring(0, 300) }, 'Email body preview');
 
-  // Extract the login code using multiple regex patterns
-  // Pattern 1: "Your verification code is: 123456"
-  // Pattern 2: "verification code is: 123456" (more lenient)
-  // Pattern 3: Any 6-digit code after "code" (fallback)
-  const patterns = [
-    /Your verification code is:\s*(\d{6})/i,
-    /verification code is:\s*(\d{6})/i,
-    /code\s*(?:is)?:?\s*(\d{6})/i,
-  ];
-
-  let loginCode: string | null = null;
-  for (const pattern of patterns) {
-    const match = pattern.exec(emailBody);
-    if (match?.[1]) {
-      loginCode = match[1];
-      logger.debug({ pattern: pattern.source }, 'Matched verification code with pattern');
-      break;
-    }
-  }
-
+  const loginCode = extractLoginCode(emailBody);
   if (!loginCode) {
     logger.debug('Failed to match verification code in email body');
     throw new Error('No verification code found in email body');
@@ -232,13 +220,12 @@ export const fetchLoginCode = async (
 };
 
 /**
- * Cleans up all OTP/verification code emails for a specific user.
- * Useful to run before test suites to ensure a clean state.
+ * Cleans up all OTP/verification code emails for a specific user from Gmail.
  *
  * @param userEmail - The email address to clean up verification emails for
  * @returns Number of emails trashed
  */
-export const cleanupOtpEmails = async (userEmail: string): Promise<number> => {
+export const cleanupOtpEmailsViaGmail = async (userEmail: string): Promise<number> => {
   logger.debug({ userEmail }, 'Cleaning up all OTP emails');
 
   const gmail = await initializeGmailClient();

--- a/tests/e2e/utils/otp/index.ts
+++ b/tests/e2e/utils/otp/index.ts
@@ -1,0 +1,59 @@
+/* eslint no-process-env: 0 */
+
+/**
+ * Pluggable email-OTP reader for the E2E suite.
+ *
+ * The suite logs in via the real email-OTP flow; this reads the verification
+ * code from whichever inbox the tier delivers to, selected by `E2E_OTP_SOURCE`:
+ *
+ * - `gmail` (default, back-compat) — a real Gmail inbox via the Google API.
+ * - `mailpit` — the Mailpit SMTP sink used by the Keycloak test realms.
+ *
+ * Both backends share the same signature, polling, and code regex. All of this
+ * is test-only infrastructure — nothing here is reusable in production.
+ */
+
+import { cleanupOtpEmailsViaGmail, fetchLoginCodeViaGmail } from './gmail';
+import { cleanupOtpEmailsViaMailpit, fetchLoginCodeViaMailpit } from './mailpit';
+
+export { initializeGmailClient } from './gmail';
+
+type OtpSource = 'gmail' | 'mailpit';
+
+/** Selects the OTP backend from `E2E_OTP_SOURCE` (default `gmail`). */
+const getOtpSource = (): OtpSource => {
+  const source = (process.env.E2E_OTP_SOURCE ?? 'gmail').toLowerCase();
+  if (source === 'gmail' || source === 'mailpit') {
+    return source;
+  }
+  throw new Error(`Unknown E2E_OTP_SOURCE "${source}" (expected "gmail" or "mailpit")`);
+};
+
+/**
+ * Fetches the login/verification code for a recipient from the configured OTP
+ * source (Gmail or Mailpit).
+ *
+ * @param userEmail - The recipient address the suite logged in as
+ * @param maxRetries - Maximum number of polling attempts (default: 20)
+ * @param intervalMs - Milliseconds between retry attempts (default: 3000)
+ */
+export const fetchLoginCode = (
+  userEmail: string,
+  maxRetries = 20,
+  intervalMs = 3000
+): Promise<string> =>
+  getOtpSource() === 'mailpit'
+    ? fetchLoginCodeViaMailpit(userEmail, maxRetries, intervalMs)
+    : fetchLoginCodeViaGmail(userEmail, maxRetries, intervalMs);
+
+/**
+ * Cleans up all OTP/verification code emails for a recipient from the configured
+ * OTP source, so a run starts from a clean state.
+ *
+ * @param userEmail - The recipient address to clean up verification emails for
+ * @returns Number of emails removed
+ */
+export const cleanupOtpEmails = (userEmail: string): Promise<number> =>
+  getOtpSource() === 'mailpit'
+    ? cleanupOtpEmailsViaMailpit(userEmail)
+    : cleanupOtpEmailsViaGmail(userEmail);

--- a/tests/e2e/utils/otp/mailpit.ts
+++ b/tests/e2e/utils/otp/mailpit.ts
@@ -1,0 +1,130 @@
+/* eslint no-process-env: 0 */
+
+/**
+ * Mailpit OTP reader for the E2E suite.
+ *
+ * Test-only infrastructure: the non-production Keycloak test realms deliver
+ * email-OTP to a Mailpit SMTP sink instead of a real inbox, so this reads the
+ * verification code from Mailpit's REST API. It mirrors the Gmail reader in
+ * {@link ./gmail} (same signature, polling, and code regex) and is selected via
+ * `E2E_OTP_SOURCE=mailpit` by {@link ./index}.
+ *
+ * Mailpit HTTP API (default port 8025): https://mailpit.axllent.org/docs/api-v1/
+ */
+
+import { Logger } from '@eventuras/logger';
+
+import { extractLoginCode } from './code';
+
+const logger = Logger.create({ namespace: 'e2e:mailpit' });
+
+interface MailpitMessageSummary {
+  ID: string;
+  Subject?: string;
+}
+
+interface MailpitSearchResult {
+  messages?: MailpitMessageSummary[];
+}
+
+interface MailpitMessage {
+  ID: string;
+  Text?: string;
+  HTML?: string;
+}
+
+const sleep = (ms: number): Promise<void> => new Promise(resolve => setTimeout(resolve, ms));
+
+/** Base URL of the Mailpit API, without a trailing slash. */
+const getApiUrl = (): string => {
+  const url = process.env.E2E_MAILPIT_API_URL;
+  if (!url) {
+    throw new Error('E2E_MAILPIT_API_URL must be set when E2E_OTP_SOURCE=mailpit');
+  }
+  return url.replace(/\/+$/, '');
+};
+
+const mailpitGet = async <T>(base: string, path: string): Promise<T> => {
+  const response = await fetch(`${base}${path}`);
+  if (!response.ok) {
+    throw new Error(`Mailpit GET ${path} failed: ${response.status} ${response.statusText}`);
+  }
+  return response.json() as Promise<T>;
+};
+
+/** Messages addressed to `userEmail`, newest first. */
+const searchByRecipient = (
+  base: string,
+  userEmail: string,
+  limit: number
+): Promise<MailpitSearchResult> =>
+  mailpitGet(base, `/api/v1/search?query=${encodeURIComponent(`to:${userEmail}`)}&limit=${limit}`);
+
+/**
+ * Deletes the given message IDs. No-op on an empty list — Mailpit's DELETE
+ * endpoint would otherwise wipe *all* messages when handed an empty ID list.
+ */
+const deleteMessages = async (base: string, ids: string[]): Promise<void> => {
+  if (ids.length === 0) {
+    return;
+  }
+  const response = await fetch(`${base}/api/v1/messages`, {
+    method: 'DELETE',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ IDs: ids }),
+  });
+  if (!response.ok) {
+    // Non-fatal: the post-read delete is best-effort de-duplication.
+    logger.debug({ status: response.status, ids }, 'Mailpit delete failed (ignored)');
+  }
+};
+
+/**
+ * Fetches the login/verification code for `userEmail` from Mailpit.
+ * Polls newest-first until a message yields a code or the attempts run out, then
+ * deletes that message so a re-run can't pick up a stale code.
+ */
+export const fetchLoginCodeViaMailpit = async (
+  userEmail: string,
+  maxRetries = 20,
+  intervalMs = 3000
+): Promise<string> => {
+  const base = getApiUrl();
+  logger.debug({ userEmail, maxRetries, intervalMs }, 'Fetching login code from Mailpit');
+
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const { messages = [] } = await searchByRecipient(base, userEmail, 10);
+
+    for (const summary of messages) {
+      const message = await mailpitGet<MailpitMessage>(base, `/api/v1/message/${summary.ID}`);
+      const code = extractLoginCode(message.Text || message.HTML || '');
+      if (code) {
+        logger.debug({ messageId: summary.ID }, 'Matched verification code, deleting message');
+        await deleteMessages(base, [summary.ID]);
+        return code;
+      }
+    }
+
+    if (attempt < maxRetries) {
+      await sleep(intervalMs);
+    }
+  }
+
+  throw new Error(
+    `No verification emails received for ${userEmail} after ${maxRetries} attempts (Mailpit)`
+  );
+};
+
+/**
+ * Deletes all messages addressed to `userEmail` so a test run starts clean.
+ * @returns Number of messages deleted.
+ */
+export const cleanupOtpEmailsViaMailpit = async (userEmail: string): Promise<number> => {
+  const base = getApiUrl();
+  const { messages = [] } = await searchByRecipient(base, userEmail, 200);
+  const ids = messages.map(message => message.ID);
+
+  await deleteMessages(base, ids);
+  logger.debug({ count: ids.length, userEmail }, 'Cleaned up Mailpit OTP messages');
+  return ids.length;
+};


### PR DESCRIPTION
## Why

The E2E suite logs in via the real email-OTP flow and read the code from a real **Gmail** inbox. The non-prod Keycloak **test realms** now deliver OTP to a **Mailpit** SMTP sink instead, so the Gmail reader can't see the code there.

## Change

Make the OTP source pluggable behind the existing `fetchLoginCode` / `cleanupOtpEmails` interface (same signature, polling, timeout), selected by env:

- `E2E_OTP_SOURCE=gmail` (default, back-compat) → existing Gmail path.
- `E2E_OTP_SOURCE=mailpit` → new Mailpit path, via `E2E_MAILPIT_API_URL`.

**Mailpit reader** (`utils/otp/mailpit.ts`, test-only, plain `fetch` — no new dependency):
- finds the message by recipient (`GET /api/v1/search?query=to:<recipient>`, newest first),
- reads the body (`GET /api/v1/message/{ID}` → `Text`/`HTML`),
- extracts the code with the shared regex, polling until found or timeout,
- deletes the message after reading (and `cleanupOtpEmailsViaMailpit` deletes all to the recipient) so a re-run can't reuse a stale code.

`initializeGmailClient` is only invoked on the Gmail path (Mailpit needs no auth).

### Structure

Moved the OTP code out of `specs/shared` into a dedicated **`tests/e2e/utils/otp/`** module so `specs/` holds only test specs:

| File | Role |
|------|------|
| `code.ts` | shared `extractLoginCode` (one regex for every backend) |
| `gmail.ts` | Gmail reader (moved from `specs/shared/utils.ts` — tracked as a rename) |
| `mailpit.ts` | new Mailpit reader |
| `index.ts` | dispatcher on `E2E_OTP_SOURCE` |

The two importers (`specs/web/helpers/auth.ts`, the anonymous-register spec) switched to `../../../utils/otp`.

### OTP format

Switched the shared code regex to the **4-char tessera-otp** token (alphabet `23456789ABCDEFGHJKLMNPQRSTUVWXYZ` — digits 2-9 + A-Z without I/O), matched on its own line with a word-bounded fallback.

## Notes / out of scope (infra)

- The old `eventuras-e2e-*` service-account clients: nothing in this repo references them (`client_credentials` is unused — the suite authenticates by real login), so their removal is realm/infra-only.
- **Personas:** anonymous is already covered by the `web:public` project (no storageState). A systemadmin persona needs a `+systemadmin` user seeded in `eventuras-systemadmins` in the test realm (infra) **and** systemadmin specs before a setup project is worth adding — left as a follow-up rather than dead scaffolding.
- **Env / CI reachability** (`E2E_OTP_SOURCE`, `E2E_MAILPIT_API_URL`, the `allow-from-argo-workflows` netpol for port 8025): infra-coordinated, not in this change.
- **Gmail path caveat:** its Gmail search still filters `subject:"verification code"`; if tessera emails use a different subject, that query needs updating (the Mailpit path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)