### PR TITLE
feat(e2e): persona logins from env, add systemadmin setup

### DIFF
--- a/tests/e2e/.env-template
+++ b/tests/e2e/.env-template
@@ -9,14 +9,24 @@ E2E_API_URL=
 # Session secret for decrypting JWE tokens (must match the web app's SESSION_SECRET)
 E2E_SESSION_SECRET=
 
-# Base email for test users (Gmail address recommended for plus addressing)
-# Test users will be created as:
-#   - {base}+admin@gmail.com (admin user)
-#   - {base}+user@gmail.com (standard user)
-#   - {base}+newuser-{timestamp}@gmail.com (auto-generated users)
-E2E_BASE_EMAIL=
+# Persona email addresses (read from env — nothing is baked into the code).
+# admin/systemadmin are realm-seeded users in the eventuras-admins /
+# eventuras-systemadmins groups; the regular-user pattern must contain {random},
+# replaced per run so each run gets a fresh, isolated inbox. Anonymous = no login.
+E2E_ADMIN_EMAIL=
+E2E_SYSTEMADMIN_EMAIL=
+E2E_USER_EMAIL_PATTERN=test-{random}@e2e.test.example
 
-# Gmail OAuth credentials for reading OTP verification emails
+# OTP source: which inbox the suite reads the email verification code from.
+#   gmail   = a real Gmail inbox (default, back-compat) — needs E2E_GMAIL_* below
+#   mailpit = the Mailpit SMTP sink used by the Keycloak test realms
+E2E_OTP_SOURCE=gmail
+
+# Mailpit REST API base URL (only used when E2E_OTP_SOURCE=mailpit).
+# e.g. http://mailpit.mailpit.svc.cluster.local:8025 in-cluster, or a port-forward.
+E2E_MAILPIT_API_URL=
+
+# Gmail OAuth credentials for reading OTP verification emails (E2E_OTP_SOURCE=gmail)
 # See libs/google-api/README.md for setup instructions
 E2E_GMAIL_CLIENT_ID=
 E2E_GMAIL_CLIENT_SECRET=

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -68,8 +68,10 @@ ENV NODE_ENV=test
 
 # Test configuration (override via K8s env/secrets)
 # E2E_WEB_URL - URL of the web app to test
-# E2E_BASE_EMAIL - Gmail base address
-# E2E_GMAIL_* - OAuth credentials
+# E2E_OTP_SOURCE - gmail | mailpit
+# E2E_MAILPIT_API_URL - Mailpit REST API (when E2E_OTP_SOURCE=mailpit)
+# E2E_GMAIL_* - OAuth credentials (when E2E_OTP_SOURCE=gmail)
+# E2E_ADMIN_EMAIL / E2E_SYSTEMADMIN_EMAIL / E2E_USER_EMAIL_PATTERN - persona logins
 
 USER pwuser
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -43,6 +43,7 @@ const isCI = !!process.env.CI;
 const HEALTHCHECK = 'healthcheck';
 const SETUP_ADMIN = 'setup-admin';
 const SETUP_USER = 'setup-user';
+const SETUP_SYSTEMADMIN = 'setup-systemadmin';
 
 const timeouts = {
   global: 1000 * 60 * 5,
@@ -90,6 +91,11 @@ export default defineConfig({
     { name: SETUP_ADMIN, testMatch: /setup\/admin\.auth\.setup\.ts/, dependencies: [HEALTHCHECK] },
     { name: SETUP_USER, testMatch: /setup\/user\.auth\.setup\.ts/, dependencies: [HEALTHCHECK] },
     {
+      name: SETUP_SYSTEMADMIN,
+      testMatch: /setup\/systemadmin\.auth\.setup\.ts/,
+      dependencies: [HEALTHCHECK],
+    },
+    {
       name: 'web:admin',
       testMatch: /web\/admin\/.+\.spec\.ts/,
       use: { ...chromeDesktop },
@@ -100,6 +106,12 @@ export default defineConfig({
       testMatch: /web\/user\/.+\.spec\.ts/,
       use: { ...chromeDesktop },
       dependencies: [SETUP_USER, 'web:admin'],
+    },
+    {
+      name: 'web:systemadmin',
+      testMatch: /web\/systemadmin\/.+\.spec\.ts/,
+      use: { ...chromeDesktop },
+      dependencies: [SETUP_SYSTEMADMIN],
     },
     {
       name: 'web:public',

--- a/tests/e2e/specs/setup/admin.auth.setup.ts
+++ b/tests/e2e/specs/setup/admin.auth.setup.ts
@@ -1,13 +1,4 @@
-/* eslint no-process-env: 0 */
-
 import { authenticate } from '../web/helpers/auth';
+import { adminEmail } from '../../utils/personas';
 
-const baseEmail = process.env.E2E_BASE_EMAIL;
-if (!baseEmail) {
-  throw new Error('E2E_BASE_EMAIL must be set');
-}
-
-const [localPart, domain] = baseEmail.split('@');
-const userName = `${localPart}+admin@${domain}`;
-
-authenticate(userName, 'tmp/auth/admin.json');
+authenticate(adminEmail(), 'tmp/auth/admin.json');

--- a/tests/e2e/specs/setup/systemadmin.auth.setup.ts
+++ b/tests/e2e/specs/setup/systemadmin.auth.setup.ts
@@ -1,0 +1,4 @@
+import { authenticate } from '../web/helpers/auth';
+import { systemAdminEmail } from '../../utils/personas';
+
+authenticate(systemAdminEmail(), 'tmp/auth/systemadmin.json');

--- a/tests/e2e/specs/setup/user.auth.setup.ts
+++ b/tests/e2e/specs/setup/user.auth.setup.ts
@@ -1,13 +1,4 @@
-/* eslint no-process-env: 0 */
-
 import { authenticate } from '../web/helpers/auth';
+import { newRegularEmail } from '../../utils/personas';
 
-const baseEmail = process.env.E2E_BASE_EMAIL;
-if (!baseEmail) {
-  throw new Error('E2E_BASE_EMAIL must be set');
-}
-
-const [localPart, domain] = baseEmail.split('@');
-const userName = `${localPart}+user@${domain}`;
-
-authenticate(userName, 'tmp/auth/user.json');
+authenticate(newRegularEmail(), 'tmp/auth/user.json');

--- a/tests/e2e/specs/web/public/003-anonymous-register-through-event-registration.spec.ts
+++ b/tests/e2e/specs/web/public/003-anonymous-register-through-event-registration.spec.ts
@@ -1,5 +1,3 @@
-/* eslint no-process-env: 0 */
-
 import { expect, test } from '@playwright/test';
 
 import { readCreatedEvent } from '../helpers/event';
@@ -9,22 +7,9 @@ import {
   visitAndClickEventRegistrationButton,
 } from '../helpers/registration';
 import { cleanupOtpEmails, fetchLoginCode } from '../../../utils/otp';
+import { newRegularEmail } from '../../../utils/personas';
 
 test.describe.configure({ mode: 'serial' });
-
-// Generate a unique test email using Gmail's plus addressing feature
-// This allows using a single Gmail account for multiple test identities
-const baseEmail = process.env.E2E_BASE_EMAIL;
-if (!baseEmail) {
-  throw new Error('E2E_BASE_EMAIL must be set');
-}
-
-// Extract the local part and domain from the base email
-const [localPart, domain] = baseEmail.split('@');
-// Create a unique identifier for this test run
-const timestamp = Math.floor(Date.now() / 1000 / 10);
-// Use Gmail's plus addressing: localpart+tag@domain.com
-const userName = `${localPart}+newuser-${timestamp}@${domain}`;
 
 test.describe('should be able to register as an anonymous user when hitting the event registration page', () => {
   let createdEvent: ReturnType<typeof readCreatedEvent>;
@@ -43,6 +28,9 @@ test.describe('should be able to register as an anonymous user when hitting the 
   });
 
   test('should be able to register user through the even registration page', async ({ page }) => {
+    // Generate inside the test so each retry signs up a fresh user (a reused
+    // address would hit "user already exists" instead of the sign-up flow).
+    const userName = newRegularEmail();
     // Clean up any old OTP emails before starting
     await cleanupOtpEmails(userName);
 

--- a/tests/e2e/utils/personas.ts
+++ b/tests/e2e/utils/personas.ts
@@ -1,0 +1,41 @@
+/* eslint no-process-env: 0 */
+
+/**
+ * Persona email addresses for the E2E suite.
+ *
+ * Read from env so no address or domain is baked into the code (update the env
+ * when the test realm's seeding changes). Authz is exercised via real logins:
+ * the admin/systemadmin addresses map to realm-seeded users in the
+ * `eventuras-admins` / `eventuras-systemadmins` groups, while the regular user
+ * is auto-created fresh each run. Anonymous = no login (the `web:public`
+ * project), so it needs no address here.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+const required = (envName: string): string => {
+  const value = process.env[envName];
+  if (!value) {
+    throw new Error(`${envName} must be set`);
+  }
+  return value;
+};
+
+/** Realm-seeded systemadmin (member of `eventuras-systemadmins`). */
+export const systemAdminEmail = (): string => required('E2E_SYSTEMADMIN_EMAIL');
+
+/** Realm-seeded admin (member of `eventuras-admins`). */
+export const adminEmail = (): string => required('E2E_ADMIN_EMAIL');
+
+/**
+ * A fresh, auto-created regular user (no seeding). The env pattern must contain
+ * the literal `{random}`, replaced per call so every run gets an isolated
+ * recipient — e.g. `E2E_USER_EMAIL_PATTERN=test-{random}@e2e.test.example`.
+ */
+export const newRegularEmail = (): string => {
+  const pattern = required('E2E_USER_EMAIL_PATTERN');
+  if (!pattern.includes('{random}')) {
+    throw new Error('E2E_USER_EMAIL_PATTERN must contain {random} so each run gets a fresh user');
+  }
+  return pattern.replaceAll('{random}', randomUUID());
+};


### PR DESCRIPTION
Follow-up to #1568 (Mailpit OTP reader). Now that the test realm seeds the persona users, this wires up the authz personas.

## Change

Drive persona email addresses from **env** instead of `E2E_BASE_EMAIL` plus-addressing — nothing is baked into the code (`tests/e2e/utils/personas.ts`):

| Persona | Source | Seeding |
|---------|--------|---------|
| systemadmin | `E2E_SYSTEMADMIN_EMAIL` | realm-seeded in `eventuras-systemadmins` |
| admin | `E2E_ADMIN_EMAIL` | realm-seeded in `eventuras-admins` |
| regular | `E2E_USER_EMAIL_PATTERN` (must contain `{random}`) | auto-created, fresh per run |
| anonymous | — | no login (`web:public`) |

A value with `{random}` is substituted per call (via `randomUUID()`), so the regular user gets an isolated inbox each run — which also plays nicely with the Mailpit catch-all sink (no plus-addressing, no stale-OTP races).

- Add `systemadmin.auth.setup.ts` + the `setup-systemadmin` and `web:systemadmin` Playwright projects. **Specs to follow** — wiring only, per the agreed scope (the project is ready for `specs/web/systemadmin/*.spec.ts`).
- Migrate `admin`/`user` setup and the anonymous-register spec off `E2E_BASE_EMAIL`.
- Update `.env-template`: `E2E_ADMIN_EMAIL`, `E2E_SYSTEMADMIN_EMAIL`, `E2E_USER_EMAIL_PATTERN`, `E2E_OTP_SOURCE`, `E2E_MAILPIT_API_URL`; drop `E2E_BASE_EMAIL`.

## Env to update (deploy/secrets)

`E2E_ADMIN_EMAIL`, `E2E_SYSTEMADMIN_EMAIL`, `E2E_USER_EMAIL_PATTERN` (with `{random}`) replace `E2E_BASE_EMAIL` on the e2e tiers.

## Out of scope

- The systemadmin **test specs** themselves (need an agreed systemadmin-gated surface to assert).
- Realm seeding and the service-account-client removal — infra/realm, nothing in this repo references those clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)