### PR TITLE
fix(e2e): bake pnpm into the image so it isn't downloaded at runtime

### DIFF
--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -15,8 +15,12 @@ FROM mcr.microsoft.com/playwright:v1.60.0-noble AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
-RUN corepack enable \
-  && corepack prepare pnpm@11.5.0 --activate \
+# Install pnpm as a real global binary instead of via corepack. corepack fetches
+# the pinned pnpm into a per-user cache on first use, so the root-prepared copy
+# isn't visible to the non-root `pwuser` at runtime — it would re-download (and
+# need a writable HOME). A global install is world-readable and never downloads
+# at runtime. Keep the version matching the repo's packageManager field.
+RUN npm install -g pnpm@11.5.0 \
   && pnpm config set store-dir /pnpm/store
 
 ##########################


### PR DESCRIPTION
## Problem

The e2e image runs `pnpm test` as the non-root `pwuser`, but pnpm was set up via **corepack**. corepack fetches the pinned pnpm into a **per-user cache** on first use — and it was `corepack prepare`d as **root** at build time, so `pwuser` gets a cache miss at runtime and tries to **re-download pnpm**. That needs network egress + a writable `HOME`, which the locked-down e2e job doesn't have → the run fails.

## Fix (bake pnpm in)

Install pnpm as a real **global binary** with npm instead of via corepack:

```dockerfile
RUN npm install -g pnpm@11.5.0 && pnpm config set store-dir /pnpm/store
```

It's world-readable and runs directly as `pwuser` — no corepack, no runtime download, no writable-HOME requirement. Version stays pinned to the repo's `packageManager` (11.5.0).

This is option (a) from the diagnosis; the alternative (b) — setting `HOME=/tmp` in the run-e2e template — lives in eventuras-infra and isn't needed once pnpm is baked in.

## Verification

The `E2E Docker` PR build confirms the Dockerfile still builds. The runtime behavior (no pnpm download as `pwuser`) is exercised when the e2e gate actually runs the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)