### PR TITLE
fix(e2e): match the real OTP code format (4–8 digits or tessera token)

### DIFF
--- a/tests/e2e/utils/otp/code.ts
+++ b/tests/e2e/utils/otp/code.ts
@@ -5,14 +5,16 @@
  * same way the Gmail path always has.
  */
 
-// tessera-otp codes are 4 chars from the alphabet 23456789ABCDEFGHJKLMNPQRSTUVWXYZ
-// (digits 2-9 + A-Z without I/O), so [2-9A-HJ-NP-Z].
+// Match either a numeric code (4–8 digits, e.g. tessera-otp's 6-digit "214923")
+// or a 4–8 char tessera token (digits 2–9 + A–Z without I/O). The code is sent
+// on its own line, so prefer the line-anchored match; fall back to a
+// word-bounded match for HTML→text bodies.
+const CODE = '[0-9]{4,8}|[2-9A-HJ-NP-Z]{4,8}';
+
 /** Ordered from most to least specific; first match wins. */
 export const OTP_CODE_PATTERNS: readonly RegExp[] = [
-  // The code on its own line.
-  /^\s*([2-9A-HJ-NP-Z]{4})\s*$/m,
-  // Fallback: the same token, word-bounded (after an HTML→text conversion).
-  /\b([2-9A-HJ-NP-Z]{4})\b/,
+  new RegExp(`^\\s*(${CODE})\\s*$`, 'm'),
+  new RegExp(`\\b(${CODE})\\b`),
 ];
 
 /** Extracts the verification code from an email body, or null. */


### PR DESCRIPTION
## How this was found

Ran the e2e auth setups locally against the demo tier (`web.eventuras.losol.no`, Los ID `losol-test` realm) with a Mailpit port-forward. The login reached the OTP step but timed out:

```
No verification emails received for test-…@e2e.test.losol.no after 20 attempts (Mailpit)
```

The email **had** arrived in Mailpit and was even marked read (we fetched it) — but the code was never extracted, so polling gave up. The actual email body:

```
Here is your one-time login code:

214923

This code is valid for 5 minutes.
```

The shared regex only matched a **4-char tessera token** (`[2-9A-HJ-NP-Z]{4}`), but tessera-otp emails a **6-digit numeric code**. So `extractLoginCode` returned null and the (misleading) "no verification emails" error fired.

## Fix

Accept either **4–8 digits** or a **4–8 char tessera token** (digits 2–9 + A–Z without I/O), matched on its own line (how the code is sent) with a word-bounded fallback.

## Verified locally

With this change, all three persona logins pass against the demo tier:

```
✓ [healthcheck] web app is reachable
✓ [setup-user] authenticate            (auto-created test-{random})
✓ [setup-admin] authenticate           (seeded admin@e2e.test.losol.no)
✓ [setup-systemadmin] authenticate     (seeded systemadmin@e2e.test.losol.no)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)