### PR TITLE
feat(e2e): grant admin persona the org Admin role via systemadmin

### DIFF
--- a/tests/e2e/.env-template
+++ b/tests/e2e/.env-template
@@ -41,3 +41,6 @@ E2E_GMAIL_REFRESH_TOKEN=
 
 # Optional: Authorization code for initial setup (if no refresh token yet)
 # E2E_GMAIL_AUTH_CODE=
+
+# Organization id used by the suite for org-scoped setup (default 1)
+E2E_ORG_ID=1

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -44,6 +44,7 @@ const HEALTHCHECK = 'healthcheck';
 const SETUP_ADMIN = 'setup-admin';
 const SETUP_USER = 'setup-user';
 const SETUP_SYSTEMADMIN = 'setup-systemadmin';
+const SETUP_GRANT_ADMIN = 'setup-grant-admin';
 
 const timeouts = {
   global: 1000 * 60 * 5,
@@ -96,10 +97,16 @@ export default defineConfig({
       dependencies: [HEALTHCHECK],
     },
     {
+      // Grants admin@ the backend org `Admin` role using the systemadmin token.
+      name: SETUP_GRANT_ADMIN,
+      testMatch: /setup\/grant-admin-role\.setup\.ts/,
+      dependencies: [SETUP_ADMIN, SETUP_SYSTEMADMIN],
+    },
+    {
       name: 'web:admin',
       testMatch: /web\/admin\/.+\.spec\.ts/,
       use: { ...chromeDesktop },
-      dependencies: [SETUP_ADMIN],
+      dependencies: [SETUP_GRANT_ADMIN],
     },
     {
       name: 'web:user',

--- a/tests/e2e/specs/setup/grant-admin-role.setup.ts
+++ b/tests/e2e/specs/setup/grant-admin-role.setup.ts
@@ -1,0 +1,85 @@
+/* eslint no-process-env: 0 */
+
+import { Logger } from '@eventuras/logger';
+import { test as setup } from '@playwright/test';
+
+import { getAccessTokenFromAuthFile } from '../shared/api-helpers';
+import { adminEmail } from '../../utils/personas';
+
+const logger = Logger.create({ namespace: 'e2e:grant-admin' });
+
+const ADMIN_AUTH = 'tmp/auth/admin.json';
+const SYSTEMADMIN_AUTH = 'tmp/auth/systemadmin.json';
+const ORG_ID = Number.parseInt(process.env.E2E_ORG_ID ?? '1', 10);
+if (!Number.isInteger(ORG_ID) || ORG_ID <= 0) {
+  throw new Error(`E2E_ORG_ID must be a positive integer (got "${process.env.E2E_ORG_ID}")`);
+}
+const API_URL = process.env.E2E_API_URL;
+
+/** Authenticated API call that tolerates empty (204) response bodies. */
+const call = async <T = unknown>(
+  method: string,
+  path: string,
+  authFile: string,
+  body?: unknown
+): Promise<T | null> => {
+  const token = await getAccessTokenFromAuthFile(authFile);
+  if (!token) {
+    throw new Error(`No access token in ${authFile}`);
+  }
+  const response = await fetch(`${API_URL}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'Eventuras-Org-Id': String(ORG_ID),
+      Authorization: `Bearer ${token}`,
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`${method} ${path} → ${response.status} ${await response.text()}`);
+  }
+  const text = (await response.text()).trim();
+  return text ? (JSON.parse(text) as T) : null;
+};
+
+/**
+ * Bootstrap: grant the admin persona the org-level `Admin` role.
+ *
+ * The web app resolves `Admin` from backend organization membership — only
+ * `SystemAdmin` comes from the token — so being in the Keycloak
+ * `eventuras-admins` group isn't enough on its own. We use the global
+ * systemadmin (whose `SystemAdmin` token role grants API access) to upsert admin@
+ * as an org member with the `Admin` role before the admin specs run.
+ *
+ * Later: split the suite so a freshly-granted admin performs the event creation
+ * as its own flow, separate from this bootstrap step.
+ */
+setup('grant org Admin role to the admin persona', async () => {
+  // The admin persona's own profile gives its backend user id (the user is
+  // auto-created on first login).
+  const profile = await call<{ id: string }>('GET', '/v3/userprofile', ADMIN_AUTH);
+  const userId = profile?.id;
+  if (!userId) {
+    throw new Error(`Could not resolve backend user id for ${adminEmail()}`);
+  }
+  logger.info({ userId, orgId: ORG_ID }, 'Granting org Admin role to admin persona');
+
+  // Ensure org membership (idempotent; no body).
+  await call('PUT', `/v3/organizations/${ORG_ID}/members/${userId}`, SYSTEMADMIN_AUTH);
+
+  // Assign the Admin role unless it's already there.
+  const roles = await call<string[]>(
+    'GET',
+    `/v3/organizations/${ORG_ID}/members/${userId}/roles`,
+    SYSTEMADMIN_AUTH
+  );
+  if (Array.isArray(roles) && roles.includes('Admin')) {
+    logger.info('Admin role already present');
+    return;
+  }
+  await call('POST', `/v3/organizations/${ORG_ID}/members/${userId}/roles`, SYSTEMADMIN_AUTH, {
+    role: 'Admin',
+  });
+  logger.info('Admin role granted');
+});


### PR DESCRIPTION
## Why

`web:admin` fails: the admin persona logs in fine but gets `<Unauthorized />` at `/admin` (so `add-event-button` never appears). The web app's `checkAuthorization('Admin')` resolves the **`Admin` role from backend organization membership** — only **`SystemAdmin`** comes from the token. So admin@ being in the Keycloak `eventuras-admins` group isn't enough; it needs an org membership with role `Admin` in the eventuras backend.

## Change

Add a setup step (`setup/grant-admin-role.setup.ts`) that **uses the global systemadmin** (whose `SystemAdmin` token role grants API access) to upsert admin@ as an org member with the `Admin` role:

1. resolve admin@'s backend user id via `/v3/userprofile` (admin token; user auto-created at login),
2. `PUT /v3/organizations/{org}/members/{userId}` (idempotent),
3. `POST …/roles {"role":"Admin"}` (skipped if already present).

Wired as a new `setup-grant-admin` Playwright project (deps: `setup-admin` + `setup-systemadmin`), and `web:admin` now depends on it. Org id from `E2E_ORG_ID` (default `1`).

```
// TODO (later): split the suite so a freshly-granted admin performs the event
// creation as its own flow, separate from this bootstrap step.
```

## Notes

- Depends on #1575 (OTP code regex) for the login step to pass — both need to land on `main` and the e2e image rebuilt before the gate goes green end-to-end.
- Verified locally: the login path (all personas) passes. The grant step itself is CI-verified — it needs the demo `E2E_SESSION_SECRET` (which CI has) to read the systemadmin token from storage state; not available locally.
- `web:user` / `web:public` were skipped in the last run (they depend on `web:admin`); they can be validated once admin access works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)