### PR TITLE
fix(e2e): refresh admin session after first-time org Admin grant

### DIFF
--- a/tests/e2e/specs/setup/grant-admin-role.setup.ts
+++ b/tests/e2e/specs/setup/grant-admin-role.setup.ts
@@ -3,6 +3,7 @@
 import { Logger } from '@eventuras/logger';
 import { test as setup } from '@playwright/test';
 
+import { loginPersona } from '../web/helpers/auth';
 import { getAccessTokenFromAuthFile } from '../shared/api-helpers';
 import { adminEmail } from '../../utils/personas';
 
@@ -75,11 +76,19 @@ setup('grant org Admin role to the admin persona', async () => {
     SYSTEMADMIN_AUTH
   );
   if (Array.isArray(roles) && roles.includes('Admin')) {
-    logger.info('Admin role already present');
+    // Already granted (e.g. a re-run) — the admin logged in with the role
+    // already in place, so its saved session is current. Nothing to refresh.
+    logger.info('Admin role already present; admin session is current');
     return;
   }
+
   await call('POST', `/v3/organizations/${ORG_ID}/members/${userId}/roles`, SYSTEMADMIN_AUTH, {
     role: 'Admin',
   });
-  logger.info('Admin role granted');
+  logger.info('Admin role granted; refreshing admin session to reflect it');
+
+  // The admin logged in (setup-admin) before this first-time grant, so its saved
+  // session predates the role. Re-login now — only on this fresh-grant path — so
+  // tmp/auth/admin.json reflects the new org Admin role for the admin specs.
+  await loginPersona(adminEmail(), ADMIN_AUTH);
 });

--- a/tests/e2e/specs/web/helpers/auth.ts
+++ b/tests/e2e/specs/web/helpers/auth.ts
@@ -32,29 +32,33 @@ export const submitTesseraOtpLogin = async (page: Page, email: string): Promise<
   ]);
 };
 
-export const authenticate = async (userName: string, authFile: string) => {
-  setup.use({
-    locale: 'en-GB',
-    timezoneId: 'Europe/Berlin',
-  });
-  setup('authenticate', async () => {
-    // Clean up any old OTP emails before starting authentication
-    logger.debug({ userName }, 'authenticate: cleaning up old OTP emails');
-    const cleanedCount = await cleanupOtpEmails(userName);
-    logger.debug({ cleanedCount }, 'authenticate: cleaned up old OTP emails');
+/**
+ * Logs the persona in via the tessera-otp flow in a fresh browser context and
+ * saves the storage state to `authFile`. Standalone (no Playwright fixtures), so
+ * it can be reused outside a `setup()` test — e.g. to refresh a session after a
+ * role change.
+ */
+export const loginPersona = async (userName: string, authFile: string): Promise<void> => {
+  // Clean up any old OTP emails before starting authentication
+  logger.debug({ userName }, 'login: cleaning up old OTP emails');
+  const cleanedCount = await cleanupOtpEmails(userName);
+  logger.debug({ cleanedCount }, 'login: cleaned up old OTP emails');
 
-    const browser = await chromium.launch(
-      isCI ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] } : undefined
-    );
-    const context = await browser.newContext();
+  const browser = await chromium.launch(
+    isCI ? { args: ['--no-sandbox', '--disable-setuid-sandbox'] } : undefined
+  );
+  try {
+    // A manually launched context doesn't inherit the config's `use.baseURL`, so
+    // set it explicitly for the relative navigations below.
+    const context = await browser.newContext({ baseURL: process.env.E2E_WEB_URL });
     const page = await context.newPage();
     await page.goto('/');
     await page.waitForLoadState('load');
     await page.locator('[data-testid="login-button"]').click();
 
-    logger.debug('authenticate: completing tessera-otp login');
+    logger.debug('login: completing tessera-otp login');
     await submitTesseraOtpLogin(page, userName);
-    logger.debug('authenticate: login redirect completed');
+    logger.debug('login: redirect completed');
 
     await page.goto('/user');
     await page.waitForLoadState('load');
@@ -62,8 +66,18 @@ export const authenticate = async (userName: string, authFile: string) => {
     await expect(page.getByText(userName).first()).toBeVisible();
     mkdirSync(dirname(authFile), { recursive: true });
     await context.storageState({ path: authFile });
-    logger.debug('Auth Complete');
+    logger.debug('login: complete');
+  } finally {
+    await browser.close();
+  }
+};
+
+export const authenticate = (userName: string, authFile: string) => {
+  setup.use({
+    locale: 'en-GB',
+    timezoneId: 'Europe/Berlin',
   });
+  setup('authenticate', () => loginPersona(userName, authFile));
 };
 
 export const checkIfLoggedIn = async (page: import('@playwright/test').Page) => {


### PR DESCRIPTION
Follow-up to #1577 (which was merged). `web:admin` still failed: the admin persona's stored session predates the org `Admin` grant.

## Sequencing problem

`setup-admin` logs in (saves the session) **before** `setup-grant-admin` grants the org `Admin` role. Since the web app derives `Admin` from backend org membership, the saved session is pre-grant → `/admin` renders `<Unauthorized />` and `add-event-button` never appears.

## Fix (conditional re-auth — only when needed)

The grant step already checks idempotently whether the role is present:

- **Re-run** (role already granted in a previous run): the admin logged in with the role already in place, so its session is current → **no re-login**.
- **First-time grant** (role newly added): re-login the admin so `tmp/auth/admin.json` reflects the new role.

`loginPersona()` is extracted from `authenticate()` so the grant step can reuse the exact login flow for the conditional refresh. No extra Playwright project; `web:admin` still depends on `setup-grant-admin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)