### PR TITLE
fix(web): inject Eventuras-Org-Id on authenticated API calls

### DIFF
--- a/apps/web/src/app/(admin)/admin/events/[id]/products/actions.ts
+++ b/apps/web/src/app/(admin)/admin/events/[id]/products/actions.ts
@@ -15,6 +15,7 @@ import {
   postV3EventsByEventIdProducts,
   putV3EventsByEventIdProductsByProductId,
 } from '@/lib/eventuras-sdk';
+import { getOrganizationId } from '@/utils/organization';
 
 const logger = Logger.create({
   namespace: 'web:admin:products',
@@ -32,6 +33,7 @@ export async function fetchEventProducts(
   try {
     const response = await getV3EventsByEventIdProducts({
       path: { eventId },
+      headers: { 'Eventuras-Org-Id': getOrganizationId() },
     });
 
     if (!response.data) {
@@ -65,6 +67,7 @@ export async function createProduct(
   try {
     const response = await postV3EventsByEventIdProducts({
       path: { eventId },
+      headers: { 'Eventuras-Org-Id': getOrganizationId() },
       body: data,
     });
 
@@ -111,6 +114,7 @@ export async function updateProduct(
   try {
     const response = await putV3EventsByEventIdProductsByProductId({
       path: { eventId, productId },
+      headers: { 'Eventuras-Org-Id': getOrganizationId() },
       body: data,
     });
 

--- a/apps/web/src/lib/eventuras-client.ts
+++ b/apps/web/src/lib/eventuras-client.ts
@@ -64,6 +64,19 @@ function ensureConfigured() {
   // Configure base URL
   client.setConfig({ baseUrl });
 
+  // Resolve the configured organization once. Most v3 endpoints need a current
+  // org and the API can't infer it, so we inject this header by default below.
+  // Parsed leniently (no throw) so build-time/misconfigured runs degrade rather
+  // than crash every request.
+  const ORG_HEADER = 'Eventuras-Org-Id';
+  const rawOrgId = appConfig.env.ORGANIZATION_ID;
+  const organizationId =
+    typeof rawOrgId === 'number' ? rawOrgId : Number.parseInt(rawOrgId as string, 10);
+  const hasOrganizationId = !!organizationId && !Number.isNaN(organizationId);
+  if (!hasOrganizationId) {
+    logger.warn('ORGANIZATION_ID not configured - org header will not be injected');
+  }
+
   // Inject correlation ID and auth token on every request (server-side only)
   client.interceptors.request.use(async (options: RequestOptions) => {
     // Always set correlation ID — even if auth fails
@@ -75,6 +88,22 @@ function ensureConfigured() {
       options.headers.push([CORRELATION_ID_HEADER, correlationId]);
     } else {
       (options.headers as Record<string, string>)[CORRELATION_ID_HEADER] = correlationId;
+    }
+
+    // Inject the configured organization id, unless the call already set one
+    // explicitly (per-call headers win, so callers can target a different org).
+    if (hasOrganizationId) {
+      const orgValue = String(organizationId);
+      if (options.headers instanceof Headers) {
+        if (!options.headers.has(ORG_HEADER)) options.headers.set(ORG_HEADER, orgValue);
+      } else if (Array.isArray(options.headers)) {
+        if (!options.headers.some(([key]) => key === ORG_HEADER)) {
+          options.headers.push([ORG_HEADER, orgValue]);
+        }
+      } else {
+        const headers = options.headers as Record<string, string>;
+        if (!(ORG_HEADER in headers)) headers[ORG_HEADER] = orgValue;
+      }
     }
 
     try {

--- a/tests/e2e/specs/web/helpers/event.ts
+++ b/tests/e2e/specs/web/helpers/event.ts
@@ -73,12 +73,40 @@ export const addProductToEvent = async (page: Page, eventId: string) => {
   await page.locator('[data-testid="product-price-input"]').fill('10');
   await page.locator('[data-testid="product-vat-input"]').fill('10');
 
-  // Click submit and wait for the modal to close and product to be created
+  // Submit, then wait for either success (modal closes) or an error toast.
+  // The modal only closes when createProduct succeeds, so a bare "input never
+  // hidden" timeout hides the real cause — surface the error toast instead.
   logger.debug('Submitting product...');
-  await Promise.all([
-    page.waitForSelector('[data-testid="product-name-input"]', { state: 'hidden', timeout: 10000 }),
-    page.locator('[type="submit"]').click(),
+  await page.locator('[type="submit"]').click();
+
+  const nameInput = page.locator('[data-testid="product-name-input"]');
+  const errorToast = page.locator('[data-testid="toast-error"]');
+  const outcome = await Promise.race([
+    nameInput.waitFor({ state: 'hidden', timeout: 10000 }).then(
+      () => 'closed' as const,
+      () => null
+    ),
+    errorToast.waitFor({ state: 'visible', timeout: 10000 }).then(
+      () => 'error' as const,
+      () => null
+    ),
   ]);
+
+  if (outcome === 'error') {
+    const message = (await errorToast.innerText()).trim();
+    throw new Error(
+      `Product creation failed — error toast: "${message}". ` +
+        'The create request was rejected by the API. Check the web server log line ' +
+        '"Failed to create product" (logs response.error) or open the trace: ' +
+        'pnpm exec playwright show-trace <result-dir>/trace.zip'
+    );
+  }
+  if (outcome !== 'closed') {
+    throw new Error(
+      'Product form neither closed nor showed an error toast within 10s after submit — ' +
+        'the form may not have submitted. Verify the [type="submit"] button and form wiring.'
+    );
+  }
 
   // Wait for the product to appear in the table
   logger.debug('Waiting for product to appear in table...');


### PR DESCRIPTION
## Problem

Creating a product in the admin UI fails on staging: `POST /v3/events/{id}/products` returns **400 `OrgNotSpecifiedException`** ("Current org can't be determined"), so the modal never closes. The same exception hits `GET /v3/registrations`, so it's systemic, not product-specific.

## Root cause

The authenticated SDK client's request interceptor injects the **auth token** and **correlation id** on every call — but never the `Eventuras-Org-Id` header. The API's `CurrentOrganizationAccessorService` resolves the org by **header → `orgId` query → request hostname**. With no header, it falls back to matching the request hostname against registered org hostnames. Staging hosts (e.g. `web-staging.test.losol.no`) aren't registered org hostnames, so the fallback yields nothing and any org-scoped endpoint throws.

Most call sites set the header manually, but the product and registration calls didn't — and nothing provided a default, so each new action is one omission away from this bug.

## Fix

- Inject the configured `ORGANIZATION_ID` as a **default** `Eventuras-Org-Id` header in the client request interceptor, alongside the existing auth/correlation-id injection. Per-call headers still win, so callers can target a different org.
- Set the header explicitly on the product actions as well (create/update/fetch).

Safe for cross-org SystemAdmin endpoints: `OrganizationsController.List()`/`Get()` don't consult the current-org accessor, so the default header has no effect there.

## Tests

The e2e add-product helper previously reported only a bare 10s timeout when the modal didn't close, hiding the real cause. It now races the modal close against an error toast and throws the actual API message (or flags a form that never submitted), so a regression like this is self-explaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)