### PR TITLE
feat: show registration counts on admin events overview

### DIFF
--- a/.changeset/event-statistics-in-events-list.md
+++ b/.changeset/event-statistics-in-events-list.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/event-sdk': minor
+---
+
+Add `IncludeStatistics` query flag to `GET /v3/events` and an optional `statistics` field on `EventDto` (admin-only).

--- a/apps/api/docs/eventuras-v3.json
+++ b/apps/api/docs/eventuras-v3.json
@@ -3022,6 +3022,14 @@
             }
           },
           {
+            "name": "IncludeStatistics",
+            "in": "query",
+            "description": "Include registration statistics per event. Honored for administrators only;\nignored for anonymous or non-admin callers.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
             "name": "OrganizationId",
             "in": "query",
             "schema": {
@@ -5235,6 +5243,10 @@
               "null",
               "string"
             ]
+          },
+          "statistics": {
+            "description": "Registration statistics for the event, populated only for administrators when the list is\nrequested with IncludeStatistics=true and omitted from the response otherwise.",
+            "$ref": "#/components/schemas/EventStatisticsDto"
           }
         }
       },

--- a/apps/api/src/Eventuras.Services/Registrations/IRegistrationRetrievalService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/IRegistrationRetrievalService.cs
@@ -39,6 +39,14 @@ public interface IRegistrationRetrievalService
     Task<RegistrationStatistics> GetRegistrationStatisticsAsync(int eventId, CancellationToken cancellationToken);
 
     /// <summary>
+    ///     Returns registration statistics for several events at once, using a single
+    ///     grouped query instead of one round-trip per event. Every requested event id
+    ///     is present in the result; events without registrations get zeroed counts.
+    /// </summary>
+    Task<Dictionary<int, RegistrationStatistics>> GetRegistrationStatisticsForEventsAsync(
+        IReadOnlyCollection<int> eventIds, CancellationToken cancellationToken = default);
+
+    /// <summary>
     ///     Resolves the owning tenant's <see cref="Organization.Uuid" /> for a
     ///     registration by walking Registration → EventInfo → Organization.
     /// </summary>

--- a/apps/api/src/Eventuras.Services/Registrations/RegistrationRetrievalService.cs
+++ b/apps/api/src/Eventuras.Services/Registrations/RegistrationRetrievalService.cs
@@ -150,6 +150,64 @@ public class RegistrationRetrievalService : IRegistrationRetrievalService
         return new RegistrationStatistics { ByStatus = byStatus, ByType = byType };
     }
 
+    public async Task<Dictionary<int, RegistrationStatistics>> GetRegistrationStatisticsForEventsAsync(
+        IReadOnlyCollection<int> eventIds, CancellationToken cancellationToken = default)
+    {
+        // Seed every requested event so callers always get a complete map, even
+        // for events that have no registrations at all.
+        var result = eventIds.Distinct().ToDictionary(
+            id => id,
+            _ => new RegistrationStatistics { ByStatus = new ByStatus(), ByType = new ByType() });
+
+        if (result.Count == 0)
+        {
+            return result;
+        }
+
+        // Single grouped round-trip: counts per (event, status) and per (event, type).
+        var statusRows = await _context.Registrations
+            .Where(r => result.Keys.Contains(r.EventInfoId))
+            .GroupBy(r => new { r.EventInfoId, r.Status })
+            .Select(g => new { g.Key.EventInfoId, g.Key.Status, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        var typeRows = await _context.Registrations
+            .Where(r => result.Keys.Contains(r.EventInfoId))
+            .GroupBy(r => new { r.EventInfoId, r.Type })
+            .Select(g => new { g.Key.EventInfoId, g.Key.Type, Count = g.Count() })
+            .ToListAsync(cancellationToken);
+
+        foreach (var row in statusRows)
+        {
+            var byStatus = result[row.EventInfoId].ByStatus;
+            switch (row.Status)
+            {
+                case Registration.RegistrationStatus.Draft: byStatus.Draft = row.Count; break;
+                case Registration.RegistrationStatus.Cancelled: byStatus.Cancelled = row.Count; break;
+                case Registration.RegistrationStatus.Verified: byStatus.Verified = row.Count; break;
+                case Registration.RegistrationStatus.NotAttended: byStatus.NotAttended = row.Count; break;
+                case Registration.RegistrationStatus.Attended: byStatus.Attended = row.Count; break;
+                case Registration.RegistrationStatus.Finished: byStatus.Finished = row.Count; break;
+                case Registration.RegistrationStatus.WaitingList: byStatus.WaitingList = row.Count; break;
+            }
+        }
+
+        foreach (var row in typeRows)
+        {
+            var byType = result[row.EventInfoId].ByType;
+            switch (row.Type)
+            {
+                case Registration.RegistrationType.Participant: byType.Participant = row.Count; break;
+                case Registration.RegistrationType.Student: byType.Student = row.Count; break;
+                case Registration.RegistrationType.Staff: byType.Staff = row.Count; break;
+                case Registration.RegistrationType.Lecturer: byType.Lecturer = row.Count; break;
+                case Registration.RegistrationType.Artist: byType.Artist = row.Count; break;
+            }
+        }
+
+        return result;
+    }
+
     public Task<List<RegistrationProductDto>> GetRegistrationProductsAsync(
         Registration registration,
         CancellationToken cancellationToken = default)

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventDto.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventDto.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Text.Json.Serialization;
 using Eventuras.Domain;
+using Eventuras.Servcies.Registrations;
+using Eventuras.WebApi.Controllers.v3.Events.Statistics;
 using NodaTime;
 
 namespace Eventuras.WebApi.Controllers.v3.Events;
@@ -74,4 +77,41 @@ public class EventDto
     public Guid? OrganizerUserId { get; set; }
     public int? MaxParticipants { get; set; }
     public string ExternalInfoPageUrl { get; set; }
+
+    /// <summary>
+    ///     Registration statistics for the event, populated only for administrators when the list is
+    ///     requested with IncludeStatistics=true and omitted from the response otherwise.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public EventStatisticsDto Statistics { get; set; }
+
+    public static EventStatisticsDto ToStatisticsDto(RegistrationStatistics statistics)
+    {
+        if (statistics == null)
+        {
+            return null;
+        }
+
+        return new EventStatisticsDto
+        {
+            ByStatus = new Statistics.ByStatus
+            {
+                Draft = statistics.ByStatus.Draft,
+                Cancelled = statistics.ByStatus.Cancelled,
+                Verified = statistics.ByStatus.Verified,
+                NotAttended = statistics.ByStatus.NotAttended,
+                Attended = statistics.ByStatus.Attended,
+                Finished = statistics.ByStatus.Finished,
+                WaitingList = statistics.ByStatus.WaitingList
+            },
+            ByType = new Statistics.ByType
+            {
+                Participant = statistics.ByType.Participant,
+                Student = statistics.ByType.Student,
+                Staff = statistics.ByType.Staff,
+                Lecturer = statistics.ByType.Lecturer,
+                Artist = statistics.ByType.Artist
+            }
+        };
+    }
 }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventsController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventsController.cs
@@ -1,9 +1,12 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Asp.Versioning;
 using Eventuras.Domain;
+using Eventuras.Services;
 using Eventuras.Services.Events;
+using Eventuras.Services.Registrations;
 using Eventuras.WebApi.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -21,15 +24,19 @@ public class EventsController : ControllerBase
 {
     private readonly IEventInfoRetrievalService _eventInfoService;
     private readonly IEventManagementService _eventManagementService;
+    private readonly IRegistrationRetrievalService _registrationRetrievalService;
 
     private readonly ILogger<EventsController> _logger;
 
     public EventsController(IEventInfoRetrievalService eventInfoService, IEventManagementService eventManagementService,
+        IRegistrationRetrievalService registrationRetrievalService,
         ILogger<EventsController> logger)
     {
         _eventInfoService = eventInfoService ?? throw new ArgumentNullException(nameof(eventInfoService));
         _eventManagementService =
             eventManagementService ?? throw new ArgumentNullException(nameof(eventManagementService));
+        _registrationRetrievalService =
+            registrationRetrievalService ?? throw new ArgumentNullException(nameof(registrationRetrievalService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -59,7 +66,24 @@ public class EventsController : ControllerBase
             },
             cancellationToken: cancellationToken);
 
-        return PageResponseDto<EventDto>.FromPaging(query, events, e => new EventDto(e));
+        var response = PageResponseDto<EventDto>.FromPaging(query, events, e => new EventDto(e));
+
+        // Statistics are admin-only: the flag is ignored for anonymous/non-admin callers
+        // so registration counts are never exposed on the public events list. Mirrors the
+        // AdministratorRole policy, which covers both Admin and SystemAdmin.
+        if (query.IncludeStatistics && Roles.All.Any(User.IsInRole))
+        {
+            var eventIds = response.Data.Select(e => e.Id).ToArray();
+            var statistics =
+                await _registrationRetrievalService.GetRegistrationStatisticsForEventsAsync(eventIds, cancellationToken);
+
+            foreach (var dto in response.Data.Where(dto => statistics.ContainsKey(dto.Id)))
+            {
+                dto.Statistics = EventDto.ToStatisticsDto(statistics[dto.Id]);
+            }
+        }
+
+        return response;
     }
 
     // GET: v3/events/5

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventsQueryDto.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventsQueryDto.cs
@@ -17,6 +17,12 @@ public class EventsQueryDto : PageQueryDto
     public bool IncludePastEvents { get; set; }
     public bool IncludeDraftEvents { get; set; }
 
+    /// <summary>
+    ///     Include registration statistics per event. Honored for administrators only;
+    ///     ignored for anonymous or non-admin callers.
+    /// </summary>
+    public bool IncludeStatistics { get; set; }
+
     [Range(1, int.MaxValue)] public int? OrganizationId { get; set; }
 
     [Range(1, int.MaxValue)] public int? CollectionId { get; set; }

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Events/EventsControllerTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Events/EventsControllerTests.cs
@@ -38,6 +38,77 @@ public class EventsControllerTests : IClassFixture<CustomWebApiApplicationFactor
         token.CheckEmptyPaging();
     }
 
+    [Fact]
+    public async Task Should_Include_Statistics_For_Admin_When_Requested()
+    {
+        using var scope = _factory.Services.NewTestScope();
+        using var u1 = await scope.CreateUserAsync();
+        using var u2 = await scope.CreateUserAsync();
+        using var u3 = await scope.CreateUserAsync();
+        using var u4 = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync(
+            dateStart: SystemClock.Instance.Today().PlusDays(1), maxParticipants: 40);
+
+        using var r1 = await scope.CreateRegistrationAsync(evt.Entity, u1.Entity,
+            status: Registration.RegistrationStatus.Verified);
+        using var r2 = await scope.CreateRegistrationAsync(evt.Entity, u2.Entity,
+            status: Registration.RegistrationStatus.Attended);
+        using var r3 = await scope.CreateRegistrationAsync(evt.Entity, u3.Entity,
+            status: Registration.RegistrationStatus.WaitingList);
+        using var r4 = await scope.CreateRegistrationAsync(evt.Entity, u4.Entity,
+            status: Registration.RegistrationStatus.Cancelled);
+
+        var client = _factory.CreateClient().AuthenticatedAsAdmin();
+
+        var response = await client.GetAsync("/v3/events?includeStatistics=true");
+        response.CheckOk();
+
+        var token = await response.AsTokenAsync();
+        var byStatus = token.GetProperty("data")[0].GetProperty("statistics").GetProperty("byStatus");
+        Assert.Equal(1, byStatus.GetProperty("verified").GetInt32());
+        Assert.Equal(1, byStatus.GetProperty("attended").GetInt32());
+        Assert.Equal(1, byStatus.GetProperty("waitingList").GetInt32());
+        Assert.Equal(1, byStatus.GetProperty("cancelled").GetInt32());
+    }
+
+    [Fact]
+    public async Task Should_Include_Statistics_For_SystemAdmin_When_Requested()
+    {
+        using var scope = _factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync(
+            dateStart: SystemClock.Instance.Today().PlusDays(1), maxParticipants: 40);
+        using var registration = await scope.CreateRegistrationAsync(evt.Entity, user.Entity,
+            status: Registration.RegistrationStatus.Verified);
+
+        var client = _factory.CreateClient().AuthenticatedAsSystemAdmin();
+
+        var response = await client.GetAsync("/v3/events?includeStatistics=true");
+        response.CheckOk();
+
+        var token = await response.AsTokenAsync();
+        var byStatus = token.GetProperty("data")[0].GetProperty("statistics").GetProperty("byStatus");
+        Assert.Equal(1, byStatus.GetProperty("verified").GetInt32());
+    }
+
+    [Fact]
+    public async Task Should_Not_Expose_Statistics_To_Anonymous_Callers()
+    {
+        using var scope = _factory.Services.NewTestScope();
+        using var user = await scope.CreateUserAsync();
+        using var evt = await scope.CreateEventAsync(
+            dateStart: SystemClock.Instance.Today().PlusDays(1), maxParticipants: 40);
+        using var registration = await scope.CreateRegistrationAsync(evt.Entity, user.Entity);
+
+        var client = _factory.CreateClient();
+
+        var response = await client.GetAsync("/v3/events?includeStatistics=true");
+        response.CheckOk();
+
+        var token = await response.AsTokenAsync();
+        Assert.False(token.GetProperty("data")[0].TryGetProperty("statistics", out _));
+    }
+
     [Theory]
     [MemberData(nameof(GetInvalidFilterParams))]
     public async Task Should_Validate_Filter_Params_For_Event_List(string query)

--- a/apps/web/locales/en-US/admin.json
+++ b/apps/web/locales/en-US/admin.json
@@ -63,6 +63,7 @@
   "eventColumns": {
     "actions": "Actions",
     "location": "Location",
+    "registrations": "Registrations",
     "title": "Title",
     "when": "When"
   },

--- a/apps/web/locales/nb-NO/admin.json
+++ b/apps/web/locales/nb-NO/admin.json
@@ -63,6 +63,7 @@
   "eventColumns": {
     "actions": "Handlinger",
     "location": "Sted",
+    "registrations": "Påmeldte",
     "title": "Tittel",
     "when": "Når"
   },

--- a/apps/web/src/app/(admin)/admin/events/AdminEventList.tsx
+++ b/apps/web/src/app/(admin)/admin/events/AdminEventList.tsx
@@ -47,6 +47,7 @@ const AdminEventList = async ({
         title: t('admin.eventColumns.title'),
         location: t('admin.eventColumns.location'),
         when: t('admin.eventColumns.when'),
+        registrations: t('admin.eventColumns.registrations'),
         actions: t('admin.eventColumns.actions'),
         view: t('common.labels.view'),
       }}

--- a/apps/web/src/app/(admin)/admin/events/AdminEventListClient.tsx
+++ b/apps/web/src/app/(admin)/admin/events/AdminEventListClient.tsx
@@ -7,6 +7,22 @@ import { Link } from '@eventuras/ratio-ui-next/Link';
 
 import { EventDto } from '@/lib/eventuras-sdk';
 const columnHelper = createColumnHelper<EventDto>();
+
+/** Active registrations: everything except waiting list and cancelled (mirrors event statistics). */
+function activeRegistrations(event: EventDto): number {
+  const byStatus = event.statistics?.byStatus;
+  if (!byStatus) {
+    return 0;
+  }
+  return (
+    (byStatus.draft ?? 0) +
+    (byStatus.verified ?? 0) +
+    (byStatus.attended ?? 0) +
+    (byStatus.finished ?? 0) +
+    (byStatus.notAttended ?? 0)
+  );
+}
+
 interface AdminEventListClientProps {
   events: EventDto[];
   currentPage: number;
@@ -16,6 +32,7 @@ interface AdminEventListClientProps {
     title: string;
     location: string;
     when: string;
+    registrations: string;
     actions: string;
     view: string;
   };
@@ -56,6 +73,14 @@ export function AdminEventListClient({
       header: translations.when,
       cell: info => info.getValue(),
       enableSorting: true,
+    }),
+    columnHelper.accessor('maxParticipants', {
+      header: translations.registrations,
+      cell: info => {
+        const active = activeRegistrations(info.row.original);
+        const max = info.getValue();
+        return max ? `${active}/${max}` : `${active}`;
+      },
     }),
     columnHelper.accessor('id', {
       header: translations.actions,

--- a/apps/web/src/app/(admin)/admin/events/eventActions.ts
+++ b/apps/web/src/app/(admin)/admin/events/eventActions.ts
@@ -48,6 +48,7 @@ export async function fetchEvents({
       query: {
         OrganizationId: organizationId,
         IncludeDraftEvents: true,
+        IncludeStatistics: true,
         IncludePastEvents: includePastEvents,
         Start: startDate,
         Period: 'Contain',

--- a/libs/event-sdk/src/client-next/types.gen.ts
+++ b/libs/event-sdk/src/client-next/types.gen.ts
@@ -130,6 +130,11 @@ export type EventDto = {
     organizerUserId?: null | string;
     maxParticipants?: null | number;
     externalInfoPageUrl?: null | string;
+    /**
+     * Registration statistics for the event, populated only for administrators when the list is
+     * requested with IncludeStatistics=true and omitted from the response otherwise.
+     */
+    statistics?: EventStatisticsDto;
 };
 
 /**
@@ -2006,6 +2011,11 @@ export type GetV3EventsData = {
         Period?: PeriodMatchingKind;
         IncludePastEvents?: boolean;
         IncludeDraftEvents?: boolean;
+        /**
+         * Include registration statistics per event. Honored for administrators only;
+         * ignored for anonymous or non-admin callers.
+         */
+        IncludeStatistics?: boolean;
         OrganizationId?: number;
         CollectionId?: number;
         Page?: number;


### PR DESCRIPTION
## What

The admin events overview now shows registration counts per row — `active/max` (e.g. `25/40`), or just the active count when no capacity is set.

The counts come from the API in a single call. `GET /v3/events` gains an admin-only `IncludeStatistics` flag that populates a new `EventDto.statistics` field, gathered in one batched `GROUP BY` query for the whole page rather than one statistics round-trip per event.

## Why

Admins asked to see how full each event is at a glance, without opening each one.

## Notes

- **Admin-only:** `GET /v3/events` is `[AllowAnonymous]`, so the flag is honored only when the caller is in `Roles.Admin`; for anyone else `statistics` stays `null`. Registration data is never exposed on the public list.
- "Active" mirrors the detail-page statistics: everything except waiting list and cancelled (draft + verified + attended + finished + notAttended).
- The committed OpenAPI spec change was verified byte-identical (normalized) to what the API actually emits; the SDK is regenerated from it.

## Test

- New API tests: admin sees `statistics`, anonymous does not. Full `EventsControllerTests` (134) green.
- Web typechecks; SDK builds.

## Follow-ups (not in this PR)

- Expose a limited public availability number (active/max) on public event pages, with caching for the hot path.
- Handle an empty `Organizations` table gracefully (admin guidance or auto-seed root org) — creating an event currently 500s when no org exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)