### PR TITLE
fix: read Mailpit OTP via oauth2-proxy bearer token (E2E)

### DIFF
--- a/tests/e2e/.env-template
+++ b/tests/e2e/.env-template
@@ -22,9 +22,16 @@ E2E_USER_EMAIL_PATTERN=test-{random}@e2e.test.example
 #   mailpit = the Mailpit SMTP sink used by the Keycloak test realms
 E2E_OTP_SOURCE=gmail
 
-# Mailpit REST API base URL (only used when E2E_OTP_SOURCE=mailpit).
-# e.g. http://mailpit.mailpit.svc.cluster.local:8025 in-cluster, or a port-forward.
+# Mailpit REST API base URL (only used when E2E_OTP_SOURCE=mailpit), no trailing path.
+# e.g. https://mailpit.admin.losol.no (public, behind oauth2-proxy) or a port-forward.
 E2E_MAILPIT_API_URL=
+
+# Mailpit oauth2-proxy bearer auth (only when the endpoint is behind ForwardAuth).
+# Leave unset for a local Mailpit reached directly. The helper fetches a Keycloak
+# service-account token (client_credentials) and sends it as a bearer token.
+E2E_MAILPIT_TOKEN_URL=
+E2E_MAILPIT_CLIENT_ID=
+E2E_MAILPIT_CLIENT_SECRET=
 
 # Gmail OAuth credentials for reading OTP verification emails (E2E_OTP_SOURCE=gmail)
 # See libs/google-api/README.md for setup instructions

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -58,6 +58,7 @@ ENV NODE_ENV=test
 # E2E_WEB_URL - URL of the web app to test
 # E2E_OTP_SOURCE - gmail | mailpit
 # E2E_MAILPIT_API_URL - Mailpit REST API (when E2E_OTP_SOURCE=mailpit)
+# E2E_MAILPIT_TOKEN_URL / E2E_MAILPIT_CLIENT_ID / E2E_MAILPIT_CLIENT_SECRET - oauth2-proxy bearer auth (optional)
 # E2E_GMAIL_* - OAuth credentials (when E2E_OTP_SOURCE=gmail)
 # E2E_ADMIN_EMAIL / E2E_SYSTEMADMIN_EMAIL / E2E_USER_EMAIL_PATTERN - persona logins
 

--- a/tests/e2e/utils/otp/mailpit.ts
+++ b/tests/e2e/utils/otp/mailpit.ts
@@ -10,6 +10,12 @@
  * `E2E_OTP_SOURCE=mailpit` by {@link ./index}.
  *
  * Mailpit HTTP API (default port 8025): https://mailpit.axllent.org/docs/api-v1/
+ *
+ * In CI the public Mailpit endpoint sits behind oauth2-proxy ForwardAuth, which
+ * accepts bearer tokens. When `E2E_MAILPIT_CLIENT_ID` / `E2E_MAILPIT_CLIENT_SECRET`
+ * / `E2E_MAILPIT_TOKEN_URL` are set, every request carries a
+ * service-account token (client_credentials grant). They are optional so a local
+ * Mailpit reached directly still works with no auth.
  */
 
 import { Logger } from '@eventuras/logger';
@@ -17,6 +23,64 @@ import { Logger } from '@eventuras/logger';
 import { extractLoginCode } from './code';
 
 const logger = Logger.create({ namespace: 'e2e:mailpit' });
+
+interface TokenResponse {
+  access_token: string;
+  expires_in?: number;
+}
+
+let cachedToken: { value: string; expiresAt: number; } | null = null;
+
+/**
+ * Bearer token for the oauth2-proxy in front of Mailpit, via the Keycloak
+ * `client_credentials` grant. Returns null when no client credentials are
+ * configured (e.g. a local Mailpit reached directly), so auth is simply omitted.
+ * Cached until shortly before it expires.
+ */
+const getBearerToken = async (): Promise<string | null> => {
+  const tokenUrl = process.env.E2E_MAILPIT_TOKEN_URL;
+  const clientId = process.env.E2E_MAILPIT_CLIENT_ID;
+  const clientSecret = process.env.E2E_MAILPIT_CLIENT_SECRET;
+  if (!tokenUrl || !clientId || !clientSecret) {
+    return null;
+  }
+
+  const now = Date.now();
+  if (cachedToken && cachedToken.expiresAt > now) {
+    return cachedToken.value;
+  }
+
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Mailpit token request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const token = (await response.json()) as TokenResponse;
+  if (!token.access_token) {
+    throw new Error('Mailpit token response did not contain an access_token');
+  }
+
+  // Refresh a little early so a token never expires mid-request. Cap the skew at
+  // half the TTL so a short-lived token still gets a positive lifetime here.
+  const ttlMs = (token.expires_in ?? 60) * 1000;
+  const skewMs = Math.min(5000, Math.floor(ttlMs / 2));
+  cachedToken = { value: token.access_token, expiresAt: now + ttlMs - skewMs };
+  return token.access_token;
+};
+
+/** Authorization header for Mailpit requests; empty when no credentials are set. */
+const authHeaders = async (): Promise<Record<string, string>> => {
+  const token = await getBearerToken();
+  return token ? { authorization: `Bearer ${token}` } : {};
+};
 
 interface MailpitMessageSummary {
   ID: string;
@@ -45,7 +109,7 @@ const getApiUrl = (): string => {
 };
 
 const mailpitGet = async <T>(base: string, path: string): Promise<T> => {
-  const response = await fetch(`${base}${path}`);
+  const response = await fetch(`${base}${path}`, { headers: await authHeaders() });
   if (!response.ok) {
     throw new Error(`Mailpit GET ${path} failed: ${response.status} ${response.statusText}`);
   }
@@ -70,7 +134,7 @@ const deleteMessages = async (base: string, ids: string[]): Promise<void> => {
   }
   const response = await fetch(`${base}/api/v1/messages`, {
     method: 'DELETE',
-    headers: { 'content-type': 'application/json' },
+    headers: { 'content-type': 'application/json', ...(await authHeaders()) },
     body: JSON.stringify({ IDs: ids }),
   });
   if (!response.ok) {


### PR DESCRIPTION
## Problem

The E2E `authenticate` setup fails in CI because the Mailpit reader fetches the Mailpit API over a cluster-internal address:

```
TypeError: fetch failed
[cause]: Error: getaddrinfo ENOTFOUND <mailpit-service>.svc.cluster.local
```

The CD pipeline runs E2E on a GitHub-hosted runner (plain `docker run`, no kubeconfig/port-forward), so cluster DNS is unresolvable.

## Change

The public Mailpit endpoint (`https://mailpit.admin.losol.no`) sits behind oauth2-proxy ForwardAuth, which now accepts bearer tokens. A dedicated Keycloak service-account client (`e2e-mailpit`, losol realm) clears ForwardAuth via the `client_credentials` grant.

`tests/e2e/utils/otp/mailpit.ts` now, **when the credentials env is set**:
1. Fetches a token from Keycloak (`client_credentials`), cached until shortly before expiry.
2. Sends `Authorization: Bearer <token>` on every Mailpit request (search, message read, delete).

New optional env (documented in `.env-template` + `Dockerfile`):
- `E2E_MAILPIT_API_URL` → point at `https://mailpit.admin.losol.no` (no trailing path)
- `E2E_MAILPIT_TOKEN_URL`, `E2E_MAILPIT_CLIENT_ID`, `E2E_MAILPIT_CLIENT_SECRET`

The credentials are optional — a local Mailpit reached directly still works with no auth, so this is backwards compatible.

## Coordinated rollout

This is the repo-side change. The matching `cd-api.yml` / `e2e.yml` env passthrough + GitHub secrets land in **eventuras-infra after** this merges, so staging E2E doesn't break in between. Once merged we flip the secret and test against staging manually before re-enabling in CD.

## Verification

- ESLint: 0 errors (only the pre-existing `turbo/no-undeclared-env-vars` warnings shared with the other `E2E_*` vars).
- Type-checked in isolation: no errors from the new token/auth code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)