### PR TITLE
chore(api): check in aspire.config.json

### DIFF
--- a/aspire.config.json
+++ b/aspire.config.json
@@ -1,0 +1,5 @@
+{
+    "appHost": {
+        "path": "apps/api/src/Eventuras.AppHost/Eventuras.AppHost.csproj"
+    }
+}


### PR DESCRIPTION
## Summary

Checks in `aspire.config.json`, which the Aspire CLI writes at the repo root to record the default AppHost project:

```json
{
  "appHost": {
    "path": "apps/api/src/Eventuras.AppHost/Eventuras.AppHost.csproj"
  }
}
```

With it committed, `aspire run` / `aspire add` / etc. resolve the AppHost without needing `--project`, consistently for everyone on the team.

It's safe to commit: the path is **relative and portable**, there's no machine-specific data or secrets, and the referenced `.csproj` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)