### PR TITLE
fix(api): make /v3/userprofile resilient to email/username drift

### DIFF
--- a/apps/api/src/Eventuras.Services/Users/IUserManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Users/IUserManagementService.cs
@@ -17,6 +17,16 @@ public interface IUserManagementService
         string phoneNumber = null,
         CancellationToken cancellationToken = default);
 
+    /// <summary>
+    ///     Returns the user matching the given email (by email or username), creating one if none
+    ///     exists. Resilient to email/username drift and to concurrent first-time requests, so it
+    ///     never surfaces a unique-constraint violation. Used by the current-user profile endpoint.
+    /// </summary>
+    Task<ApplicationUser> GetOrCreateUserByEmailAsync(
+        string email,
+        string phoneNumber = null,
+        CancellationToken cancellationToken = default);
+
     /// <exception cref="Exceptions.DuplicateException">Active user with the given email is already created.</exception>
     /// <exception cref="Exceptions.NotAccessibleException">Not permitted to update the given user.</exception>
     Task UpdateUserAsync(ApplicationUser user,

--- a/apps/api/src/Eventuras.Services/Users/UserManagementService.cs
+++ b/apps/api/src/Eventuras.Services/Users/UserManagementService.cs
@@ -40,21 +40,19 @@ public class UserManagementService : IUserManagementService
         }
 
         var normalizedEmail = email.ToUpperInvariant();
+
+        // Match on NormalizedUserName as well as NormalizedEmail: the unique key
+        // is NormalizedUserName, and a user's stored email can drift from it, so
+        // an email-only check would miss them and let the INSERT below blow up on
+        // the AspNetUsers_NormalizedUserName_key constraint.
         var existingUser = await _context.Users
-            .FirstOrDefaultAsync(u => u.NormalizedEmail == normalizedEmail, cancellationToken);
+            .FirstOrDefaultAsync(
+                u => u.NormalizedEmail == normalizedEmail || u.NormalizedUserName == normalizedEmail,
+                cancellationToken);
 
         if (existingUser != null)
         {
-            if (existingUser.Archived)
-            {
-                _logger.LogWarning("Found archived user with email {email}. Contact admin to unarchive the user.",
-                    email);
-                throw new DuplicateException(
-                    $"An archived user with email {email} already exists. Contact admin to unarchive the user.");
-            }
-
-            _logger.LogWarning("Found existing user with email {email}.", email);
-            throw new DuplicateException($"An user with email {email} already exists.");
+            throw DuplicateUserException(existingUser, email);
         }
 
         var user = new ApplicationUser
@@ -67,10 +65,123 @@ public class UserManagementService : IUserManagementService
         };
 
         _context.Users.Add(user);
-        await _context.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException e) when (e.IsUniqueKeyViolation())
+        {
+            // A concurrent request inserted a user with the same username/email
+            // between the check above and SaveChanges. Surface a clean
+            // DuplicateException instead of leaking the raw DbUpdateException (500).
+            // Non-unique failures bubble up unchanged via the exception filter.
+            _context.Entry(user).State = EntityState.Detached;
+            var racedUser = await _context.Users
+                .FirstOrDefaultAsync(
+                    u => u.NormalizedEmail == normalizedEmail || u.NormalizedUserName == normalizedEmail,
+                    cancellationToken);
+            if (racedUser == null)
+            {
+                throw;
+            }
+
+            throw DuplicateUserException(racedUser, email);
+        }
 
         _logger.LogDebug("CreateNewUserAsync finished.");
         return user;
+    }
+
+    public async Task<ApplicationUser> GetOrCreateUserByEmailAsync(
+        string email,
+        string phoneNumber = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrEmpty(email))
+        {
+            throw new ArgumentException("User should have an email.", nameof(email));
+        }
+
+        var normalizedEmail = email.ToUpperInvariant();
+
+        var existingUser = await FindUserByEmailOrUserNameAsync(normalizedEmail, cancellationToken);
+        if (existingUser != null)
+        {
+            await RealignNormalizedEmailAsync(existingUser, email, normalizedEmail, cancellationToken);
+            return existingUser;
+        }
+
+        try
+        {
+            return await CreateNewUserAsync(email, phoneNumber, cancellationToken);
+        }
+        catch (DuplicateException)
+        {
+            // The user exists but the initial lookup missed it (username/email
+            // drift, or a concurrent request created it). Re-resolve and return
+            // instead of failing the profile request.
+            var racedUser = await FindUserByEmailOrUserNameAsync(normalizedEmail, cancellationToken);
+            if (racedUser == null)
+            {
+                throw;
+            }
+
+            await RealignNormalizedEmailAsync(racedUser, email, normalizedEmail, cancellationToken);
+            return racedUser;
+        }
+    }
+
+    private Task<ApplicationUser> FindUserByEmailOrUserNameAsync(
+        string normalizedEmail,
+        CancellationToken cancellationToken) =>
+        _context.Users
+            .Include(u => u.OrganizationMembership)
+            .ThenInclude(m => m.Roles)
+            .FirstOrDefaultAsync(
+                u => u.NormalizedEmail == normalizedEmail || u.NormalizedUserName == normalizedEmail,
+                cancellationToken);
+
+    private async Task RealignNormalizedEmailAsync(
+        ApplicationUser user,
+        string email,
+        string normalizedEmail,
+        CancellationToken cancellationToken)
+    {
+        if (user.NormalizedEmail == normalizedEmail)
+        {
+            return;
+        }
+
+        // The user was matched by username while their stored email had drifted.
+        // Don't realign if another user already owns this address (the email
+        // index is non-unique, but GetUserByEmailAsync expects a single match).
+        var emailTaken = await _context.Users
+            .AnyAsync(u => u.Id != user.Id && u.NormalizedEmail == normalizedEmail, cancellationToken);
+        if (emailTaken)
+        {
+            _logger.LogWarning(
+                "Skipped realigning email for user {UserId}: address already used by another user.", user.Id);
+            return;
+        }
+
+        _logger.LogWarning("Realigning drifted email for user {UserId}.", user.Id);
+        user.Email = email;
+        user.NormalizedEmail = normalizedEmail;
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    private DuplicateException DuplicateUserException(ApplicationUser existingUser, string email)
+    {
+        if (existingUser.Archived)
+        {
+            _logger.LogWarning("Found archived user with email {email}. Contact admin to unarchive the user.",
+                email);
+            return new DuplicateException(
+                $"An archived user with email {email} already exists. Contact admin to unarchive the user.");
+        }
+
+        _logger.LogWarning("Found existing user with email {email}.", email);
+        return new DuplicateException($"A user with email {email} already exists.");
     }
 
     public async Task UpdateUserAsync(ApplicationUser user,

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Userprofile/UserProfileController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Userprofile/UserProfileController.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Asp.Versioning;
-using Eventuras.Domain;
 using Eventuras.Services.Auth;
 using Eventuras.Services.Exceptions;
 using Eventuras.Services.Users;
@@ -61,30 +60,15 @@ public class UserProfileController : Controller
             throw new BadHttpRequestException("No email provided for user to in this request.");
         }
 
-        ApplicationUser user;
-
-        try
-        {
-            user = await _userRetrievalService.GetUserByEmailAsync(emailClaim,
-                new UserRetrievalOptions { IncludeOrgMembership = true }, cancellationToken);
-        }
-        catch (NotFoundException)
-        {
-            if (_authSettings.EnablePiiLogging)
-            {
-                _logger.LogDebug("No user found with email claim. Creating new user.");
-            }
-            else
-            {
-                _logger.LogDebug("No user found with email. Creating new user.");
-            }
-
-            user = await _userManagementService.CreateNewUserAsync(
-                emailClaim,
-                phoneClaim,
-                cancellationToken);
-
-        }
+        // Get-or-create keyed on the email claim. Resolving by email or username
+        // (and recovering from a lost create race) keeps this resilient to users
+        // whose stored email has drifted from their username — an email-only
+        // lookup followed by a create would hit the NormalizedUserName unique
+        // constraint and fail every profile load for that user.
+        var user = await _userManagementService.GetOrCreateUserByEmailAsync(
+            emailClaim,
+            phoneClaim,
+            cancellationToken);
 
         return new UserDto(user);
     }

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Users/UsersControllerTests.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/Users/UsersControllerTests.cs
@@ -74,6 +74,44 @@ public class UsersControllerTests : IClassFixture<CustomWebApiApplicationFactory
         token.CheckUser(dbUser);
     }
 
+    [Fact]
+    public async Task Profile_Endpoint_Should_Return_Existing_User_When_Email_Drifted_From_Username()
+    {
+        using var scope = _factory.Services.NewTestScope();
+
+        // A user whose stored email has drifted from their username: NormalizedUserName
+        // matches the login email, but NormalizedEmail does not. An email-only lookup
+        // misses them, so the previous code tried to create a new user. In production
+        // that INSERT violated the unique constraint on NormalizedUserName (HTTP 500 on
+        // every profile load); on the in-memory provider used here, which does not
+        // enforce the constraint, it instead created a duplicate row (count == 2 below).
+        const string loginEmail = "drifted-user@email.com";
+        var normalizedLogin = loginEmail.ToUpperInvariant();
+        scope.Db.Users.Add(new ApplicationUser
+        {
+            GivenName = "Drift",
+            FamilyName = "User",
+            UserName = loginEmail,
+            NormalizedUserName = normalizedLogin,
+            Email = "old-address@email.com",
+            NormalizedEmail = "OLD-ADDRESS@EMAIL.COM",
+            EmailConfirmed = true
+        });
+        await scope.Db.SaveChangesAsync();
+
+        var client = _factory.CreateClient().Authenticated(email: loginEmail);
+
+        var response = await client.GetAsync("/v3/userprofile");
+        response.CheckOk();
+
+        // No duplicate user was created for the same username.
+        Assert.Equal(1, scope.Db.Users.Count(u => u.NormalizedUserName == normalizedLogin));
+
+        // The drifted email was realigned so email-based lookups resolve the user next time.
+        var dbUser = scope.Db.Users.AsNoTracking().Single(u => u.NormalizedUserName == normalizedLogin);
+        Assert.Equal(normalizedLogin, dbUser.NormalizedEmail);
+    }
+
     [Theory]
     [InlineData(Roles.Admin)]
     [InlineData(Roles.SystemAdmin)]


### PR DESCRIPTION
## Problem

`GET /v3/userprofile` throws `Microsoft.EntityFrameworkCore.DbUpdateException` → `Npgsql 23505: duplicate key value violates unique constraint "AspNetUsers_NormalizedUserName_key"` (GlitchTip `KURSINORD-API-1H`, 11 events for the same user).

The `Me` endpoint does a **get-or-create keyed on the email claim**:
1. `GetUserByEmailAsync` looks up by `NormalizedEmail`.
2. If not found → `CreateNewUserAsync`, which also only checked `NormalizedEmail`, then `INSERT`s with `NormalizedUserName = normalizedEmail`.

But the DB enforces uniqueness on **`NormalizedUserName`**, not email:
```
ApplicationDbContext.cs:47  HasIndex(NormalizedEmail)              // not unique
ApplicationDbContext.cs:48  HasIndex(NormalizedUserName).IsUnique()
```

When a user's stored **email has drifted from their username** (e.g. the address changed after sign-up), the email lookup misses the existing row, the code tries to `INSERT`, and Postgres rejects it on the username constraint → **a permanent 500 on every profile load** for that user. The same gap also affects the admin create path and concurrent first-time requests (race).

## Fix

- **New `IUserManagementService.GetOrCreateUserByEmailAsync`** used by `Me`:
  - resolves by `NormalizedEmail` **OR** `NormalizedUserName`,
  - realigns a drifted `NormalizedEmail` so email-based lookups (incl. `DbUserClaimTransformation`) resolve the user next time — skipped if another user already owns that address,
  - recovers from a lost create race by re-resolving instead of failing.
- **`CreateNewUserAsync`**: broaden the existence check to username too, and catch the unique-violation race so it raises a clean `DuplicateException` instead of a raw `DbUpdateException` (also hardens the admin `POST /v3/users` path).
- Simplify `UserProfileController.Me`.

## Testing

- `dotnet build` clean (0 warnings, 0 errors).
- Added integration test `Profile_Endpoint_Should_Return_Existing_User_When_Email_Drifted_From_Username`; all 6 profile-endpoint tests pass. (Tests run on EF in-memory, which doesn't enforce the constraint, so the bug surfaces there as a duplicate row rather than a 500 — the assertion checks exactly one user remains and the email is realigned.)

## Follow-up (not in this PR)

Existing rows already in this state may need a one-off data repair (set `NormalizedEmail = NormalizedUserName` where they diverge), but new requests now self-heal on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)