### PR TITLE
fix(api): gate Sentry on the FeatureManagement:UseSentry flag

### DIFF
--- a/apps/api/src/Eventuras.WebApi/Config/FeatureManagement.cs
+++ b/apps/api/src/Eventuras.WebApi/Config/FeatureManagement.cs
@@ -5,4 +5,5 @@ public class FeatureManagement
     public bool UsePowerOffice { get; set; } = false;
     public bool UseStripeInvoice { get; set; } = false;
     public bool EnableApiDocs { get; set; } = false;
+    public bool UseSentry { get; set; } = false;
 }

--- a/apps/api/src/Eventuras.WebApi/Program.cs
+++ b/apps/api/src/Eventuras.WebApi/Program.cs
@@ -46,11 +46,15 @@ builder.AddServiceDefaults();
 builder.Host.UseSerilog((context, config) =>
     config.ReadFrom.Configuration(context.Configuration), writeToProviders: true);
 
-// Configure Sentry (activates automatically when Sentry:Dsn is set)
-builder.WebHost.UseSentry();
-
 // Get configuration
 var features = GetFeatureManagement(builder.Configuration);
+
+// Configure Sentry. Enabled by the FeatureManagement:UseSentry flag; a DSN
+// (Sentry:Dsn) must also be configured for events to actually be sent.
+if (features.UseSentry)
+{
+    builder.WebHost.UseSentry();
+}
 var appSettings = GetAppSettings(builder.Configuration);
 if (!DisplayTimeZone.Configure(appSettings.TimeZone))
 {

--- a/apps/api/src/Eventuras.WebApi/appsettings.json
+++ b/apps/api/src/Eventuras.WebApi/appsettings.json
@@ -13,7 +13,8 @@
   "FeatureManagement": {
     "UsePowerOffice": true,
     "UseStripeInvoice": false,
-    "EnableApiDocs": false
+    "EnableApiDocs": false,
+    "UseSentry": false
   },
   "Auth": {
     "Issuer": "https://eventuras.eu.auth0.com",


### PR DESCRIPTION
## Problem

The documented `FeatureManagement__UseSentry` flag was **never read**:

- The `FeatureManagement` POCO ([Config/FeatureManagement.cs](apps/api/src/Eventuras.WebApi/Config/FeatureManagement.cs)) had only `UsePowerOffice`, `UseStripeInvoice`, `EnableApiDocs` — no `UseSentry`, so the config key bound to nothing.
- Sentry activated purely from `builder.WebHost.UseSentry()` ([Program.cs](apps/api/src/Eventuras.WebApi/Program.cs)), i.e. whenever `Sentry:Dsn` was set.

So toggling `FeatureManagement__UseSentry` (any value/casing) had no effect, and the [Sentry docs](docs/administrator/Sentry_error_tracking.md) describing it as the on/off switch were misleading.

## Fix

Wire the flag up so it actually controls Sentry:

- Add `UseSentry` to the `FeatureManagement` POCO (default `false`) and to the `appsettings.json` `FeatureManagement` section.
- Gate `builder.WebHost.UseSentry()` on `features.UseSentry`.

A DSN (`Sentry:Dsn`) must still be configured for events to be sent. This makes the existing Sentry documentation accurate (no doc change needed).

## ⚠️ Deployment note

The flag is now authoritative with a default of `false`, so **Sentry is off unless `FeatureManagement__UseSentry=true` is set for that environment**:

- **Production** — already set to `true` ✓
- **QA / other environments** — verify the flag is set, or they will lose Sentry (previously Sentry was on whenever a DSN was present).

If opt-out is preferred (default `true`, set `false` to disable), that's a one-line change to the POCO default.

## Testing

`dotnet build` clean (0 warnings, 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)