### PR TITLE
fix: make certificate PDF download reliable

### DIFF
--- a/apps/api/src/Eventuras.Services.Converto/ConvertTokenCache.cs
+++ b/apps/api/src/Eventuras.Services.Converto/ConvertTokenCache.cs
@@ -5,30 +5,39 @@ namespace Eventuras.Services.Converto;
 
 public class ConvertoTokenCache
 {
+    private const string CacheKey = "ConvertoApiToken";
     private static readonly ConcurrentDictionary<string, CachedToken> _cache = new();
 
     public static void SetToken(string token, int expiresIn)
     {
-        // Subtract a few seconds to be on the safe side
-        var expiryTime = DateTime.UtcNow.AddSeconds(expiresIn - 10);
+        // Expire the cached token early so we never hand out one that is about to
+        // expire on the Converto side (allowing for clock skew and latency).
+        // Converto tokens can be very short-lived (down to ~10s), so cap the buffer
+        // at half the lifetime instead of a flat amount that would push a short
+        // token's expiry into the past and disable caching entirely.
+        var buffer = Math.Min(60, expiresIn / 2);
+        var expiryTime = DateTime.UtcNow.AddSeconds(expiresIn - buffer);
         var cachedToken = new CachedToken { Token = token, Expiry = expiryTime };
-        _cache.AddOrUpdate("ConvertoApiToken", cachedToken, (oldkey, oldvalue) => cachedToken);
+        _cache.AddOrUpdate(CacheKey, cachedToken, (_, _) => cachedToken);
     }
 
     public static string GetToken()
     {
-        if (_cache.TryGetValue("ConvertoApiToken", out var cachedToken))
+        if (_cache.TryGetValue(CacheKey, out var cachedToken))
         {
             if (DateTime.UtcNow < cachedToken.Expiry)
             {
                 return cachedToken.Token;
             }
 
-            _cache.TryRemove("ConvertoApiToken", out cachedToken);
+            _cache.TryRemove(CacheKey, out _);
         }
 
         return null;
     }
+
+    /// <summary>Drops any cached token so the next request fetches a fresh one.</summary>
+    public static void Clear() => _cache.TryRemove(CacheKey, out _);
 
     private class CachedToken
     {

--- a/apps/api/src/Eventuras.Services.Converto/ConvertoClient.cs
+++ b/apps/api/src/Eventuras.Services.Converto/ConvertoClient.cs
@@ -17,10 +17,18 @@ namespace Eventuras.Services.Converto;
 internal class ConvertoClient : IConvertoClient
 {
     /// <summary>
-    ///     Name of the resilient HttpClient registered in <see cref="ConvertoServicesExtensions" />.
-    ///     Transient failures and timeouts are retried by the resilience handler on that client.
+    ///     Name of the resilient HttpClient (for PDF rendering) registered in
+    ///     <see cref="ConvertoServicesExtensions" />. Transient failures and timeouts are retried
+    ///     by the resilience handler on that client; its timeouts are tuned for slow PDF rendering.
     /// </summary>
     internal const string HttpClientName = "converto";
+
+    /// <summary>
+    ///     Name of the HttpClient used for token requests. Registered separately with shorter
+    ///     timeouts so an auth/token-endpoint outage fails fast instead of inheriting the long
+    ///     PDF-render timeouts.
+    /// </summary>
+    internal const string TokenHttpClientName = "converto-token";
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<ConvertoClient> _logger;
@@ -124,7 +132,7 @@ internal class ConvertoClient : IConvertoClient
             }
         }
 
-        var client = _httpClientFactory.CreateClient(HttpClientName);
+        var client = _httpClientFactory.CreateClient(TokenHttpClientName);
 
         // Get credentials
         var clientId = _options.Value.ClientId;

--- a/apps/api/src/Eventuras.Services.Converto/ConvertoClient.cs
+++ b/apps/api/src/Eventuras.Services.Converto/ConvertoClient.cs
@@ -16,6 +16,12 @@ namespace Eventuras.Services.Converto;
 
 internal class ConvertoClient : IConvertoClient
 {
+    /// <summary>
+    ///     Name of the resilient HttpClient registered in <see cref="ConvertoServicesExtensions" />.
+    ///     Transient failures and timeouts are retried by the resilience handler on that client.
+    /// </summary>
+    internal const string HttpClientName = "converto";
+
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ILogger<ConvertoClient> _logger;
     private readonly IOptions<ConvertoConfig> _options;
@@ -32,26 +38,24 @@ internal class ConvertoClient : IConvertoClient
 
     public async Task<Stream> GeneratePdfFromHtmlAsync(string html, float scale, PaperSize paperSize = PaperSize.A4)
     {
-        var client = _httpClientFactory.CreateClient();
         var endpointUrl = _options.Value.PdfEndpointUrl;
-        var convertoAccessToken = await GetApiTokenAsync();
 
         _logger.LogInformation("Sending request to generate PDF at {EndpointUrl}", endpointUrl);
 
         try
         {
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", convertoAccessToken);
+            var response = await PostPdfRequestAsync(endpointUrl, html, scale, paperSize, forceTokenRefresh: false);
 
-            var requestBody = new { html, scale, paperSize };
-
-            var options = new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } };
-
-            using var content = new StringContent(JsonSerializer.Serialize(requestBody, options), Encoding.UTF8,
-                "application/json");
-            var response = await client.PostAsync(
-                endpointUrl,
-                content
-            );
+            // A cached token can be rejected if it was rotated/revoked on the
+            // Converto side or there is clock skew. Drop it, fetch a fresh token, and retry once.
+            if (response.StatusCode == HttpStatusCode.Unauthorized)
+            {
+                _logger.LogWarning(
+                    "Converto returned 401 Unauthorized for PDF generation; clearing cached token and retrying once.");
+                response.Dispose();
+                ConvertoTokenCache.Clear();
+                response = await PostPdfRequestAsync(endpointUrl, html, scale, paperSize, forceTokenRefresh: true);
+            }
 
             if (!response.IsSuccessStatusCode)
             {
@@ -69,33 +73,58 @@ internal class ConvertoClient : IConvertoClient
 
             return await response.Content.ReadAsStreamAsync();
         }
+        catch (AuthenticationException)
+        {
+            // Already logged above (or in GetApiTokenAsync); surface as-is so the
+            // API can map it to 503 Service Unavailable.
+            throw;
+        }
+        catch (ConvertoClientException)
+        {
+            throw;
+        }
         catch (HttpRequestException e)
         {
-            _logger.LogError(e, "HTTP request error while calling Converto API: {ExceptionMessage}", e.Message);
-
-            if (e.Message.Contains("401"))
-            {
-                throw new AuthenticationException("Unauthorized request to Converto API.", e);
-            }
-
-            throw new HttpRequestException("Error occurred while communicating with Converto API.", e);
+            // Reached only after the resilience handler exhausted its retries.
+            _logger.LogError(e, "HTTP request to Converto API failed after retries: {ExceptionMessage}", e.Message);
+            throw new ConvertoClientException("Error occurred while communicating with Converto API.", e);
         }
         catch (Exception e)
         {
-            _logger.LogError(e, "Unexpected error: {ExceptionMessage}", e.Message);
-            throw new ConvertoClientException($"Unexpected error occurred: {e.Message}");
+            _logger.LogError(e, "Unexpected error while generating PDF via Converto: {ExceptionMessage}", e.Message);
+            throw new ConvertoClientException($"Unexpected error occurred: {e.Message}", e);
         }
     }
 
-    private async Task<string> GetApiTokenAsync()
+    private async Task<HttpResponseMessage> PostPdfRequestAsync(
+        string endpointUrl, string html, float scale, PaperSize paperSize, bool forceTokenRefresh)
     {
-        var cachedToken = ConvertoTokenCache.GetToken();
-        if (cachedToken != null)
+        var token = await GetApiTokenAsync(forceTokenRefresh);
+
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var requestBody = new { html, scale, paperSize };
+        var serializerOptions = new JsonSerializerOptions { Converters = { new JsonStringEnumConverter() } };
+
+        using var content = new StringContent(
+            JsonSerializer.Serialize(requestBody, serializerOptions), Encoding.UTF8, "application/json");
+
+        return await client.PostAsync(endpointUrl, content);
+    }
+
+    private async Task<string> GetApiTokenAsync(bool forceRefresh = false)
+    {
+        if (!forceRefresh)
         {
-            return cachedToken;
+            var cachedToken = ConvertoTokenCache.GetToken();
+            if (cachedToken != null)
+            {
+                return cachedToken;
+            }
         }
 
-        var client = _httpClientFactory.CreateClient();
+        var client = _httpClientFactory.CreateClient(HttpClientName);
 
         // Get credentials
         var clientId = _options.Value.ClientId;
@@ -103,6 +132,7 @@ internal class ConvertoClient : IConvertoClient
 
         if (string.IsNullOrEmpty(clientId) || string.IsNullOrEmpty(clientSecret))
         {
+            _logger.LogError("Converto client credentials are missing from configuration.");
             throw new AuthenticationException("Client ID or Client Secret is missing from configuration.");
         }
 
@@ -123,7 +153,7 @@ internal class ConvertoClient : IConvertoClient
 
         if (!response.IsSuccessStatusCode)
         {
-            _logger.LogError("Token request failed: {StatusCode}, Response: {ResponseContent}",
+            _logger.LogError("Converto token request failed: {StatusCode}, Response: {ResponseContent}",
                 response.StatusCode, responseContent);
 
             throw new AuthenticationException($"Failed to retrieve API token. Status: {response.StatusCode}");
@@ -132,6 +162,7 @@ internal class ConvertoClient : IConvertoClient
         var tokenResponse = JsonSerializer.Deserialize<TokenResponse>(responseContent);
         if (tokenResponse == null || string.IsNullOrEmpty(tokenResponse.AccessToken))
         {
+            _logger.LogError("Converto token endpoint returned an invalid token response.");
             throw new AuthenticationException("Invalid token response from server.");
         }
 

--- a/apps/api/src/Eventuras.Services.Converto/ConvertoServicesExtensions.cs
+++ b/apps/api/src/Eventuras.Services.Converto/ConvertoServicesExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Eventuras.Libs.Pdf;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,6 +12,21 @@ public static class ConvertoServicesExtensions
     public static IServiceCollection AddConvertoServices(this IServiceCollection services, IConfiguration config)
     {
         services.Configure<ConvertoConfig>(config);
+
+        // Resilient HttpClient for the Converto PDF service. Rendering runs a
+        // headless browser and can be slow (and cold-start), so each attempt gets
+        // a generous timeout, and transient failures (5xx, timeouts, connection
+        // blips) are retried instead of surfacing to the user as a 500.
+        services.AddHttpClient(ConvertoClient.HttpClientName)
+            .AddStandardResilienceHandler(options =>
+            {
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(30);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(90);
+                // CircuitBreaker.SamplingDuration must be at least 2x AttemptTimeout.
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(60);
+                options.Retry.MaxRetryAttempts = 2;
+            });
+
         services.TryAddSingleton<IConvertoClient, ConvertoClient>();
         services.TryAddTransient<IPdfRenderService, ConvertoPdfRenderService>();
 

--- a/apps/api/src/Eventuras.Services.Converto/ConvertoServicesExtensions.cs
+++ b/apps/api/src/Eventuras.Services.Converto/ConvertoServicesExtensions.cs
@@ -27,6 +27,19 @@ public static class ConvertoServicesExtensions
                 options.Retry.MaxRetryAttempts = 2;
             });
 
+        // Separate client for the token endpoint, which is fast — keep its timeouts
+        // short so an auth outage fails quickly instead of inheriting the long
+        // PDF-render timeouts above.
+        services.AddHttpClient(ConvertoClient.TokenHttpClientName)
+            .AddStandardResilienceHandler(options =>
+            {
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(10);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(30);
+                // CircuitBreaker.SamplingDuration must be at least 2x AttemptTimeout.
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromSeconds(20);
+                options.Retry.MaxRetryAttempts = 2;
+            });
+
         services.TryAddSingleton<IConvertoClient, ConvertoClient>();
         services.TryAddTransient<IPdfRenderService, ConvertoPdfRenderService>();
 

--- a/apps/api/src/Eventuras.Services.Converto/Eventuras.Services.Converto.csproj
+++ b/apps/api/src/Eventuras.Services.Converto/Eventuras.Services.Converto.csproj
@@ -6,6 +6,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
   </ItemGroup>

--- a/apps/api/tests/Eventuras.Services.Converto.Tests/ConvertoClientRetryTest.cs
+++ b/apps/api/tests/Eventuras.Services.Converto.Tests/ConvertoClientRetryTest.cs
@@ -6,15 +6,25 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Moq;
 using Xunit;
 
 namespace Eventuras.Services.Converto.Tests;
 
-public class ConvertoClientRetryTest
+public class ConvertoClientRetryTest : IDisposable
 {
+    private readonly List<HttpClient> _httpClients = [];
+
+    public void Dispose()
+    {
+        foreach (var httpClient in _httpClients)
+        {
+            httpClient.Dispose();
+        }
+    }
+
     [Fact]
     public async Task GeneratePdf_RetriesOnceWithFreshToken_When_PdfEndpoint_Returns401()
     {
@@ -90,9 +100,11 @@ public class ConvertoClientRetryTest
         ConvertoTokenCache.Clear();
     }
 
-    private static ConvertoClient NewClient(HttpMessageHandler handler)
+    private ConvertoClient NewClient(HttpMessageHandler handler)
     {
         var httpClient = new HttpClient(handler);
+        _httpClients.Add(httpClient);
+
         var factory = new Mock<IHttpClientFactory>();
         factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
 
@@ -104,7 +116,7 @@ public class ConvertoClientRetryTest
             ClientSecret = "secret"
         });
 
-        return new ConvertoClient(factory.Object, options, new LoggerFactory().CreateLogger<ConvertoClient>());
+        return new ConvertoClient(factory.Object, options, NullLogger<ConvertoClient>.Instance);
     }
 
     private static HttpResponseMessage Json(HttpStatusCode status, string body) =>

--- a/apps/api/tests/Eventuras.Services.Converto.Tests/ConvertoClientRetryTest.cs
+++ b/apps/api/tests/Eventuras.Services.Converto.Tests/ConvertoClientRetryTest.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Eventuras.Services.Converto.Tests;
+
+public class ConvertoClientRetryTest
+{
+    [Fact]
+    public async Task GeneratePdf_RetriesOnceWithFreshToken_When_PdfEndpoint_Returns401()
+    {
+        ConvertoTokenCache.Clear();
+
+        var tokenCalls = 0;
+        var pdfCalls = 0;
+        var handler = new StubHandler(request =>
+        {
+            var url = request.RequestUri!.AbsoluteUri;
+
+            if (url.Contains("/token"))
+            {
+                tokenCalls++;
+                return Json(HttpStatusCode.OK, $"{{\"access_token\":\"tok{tokenCalls}\",\"expires_in\":3600}}");
+            }
+
+            // PDF endpoint: reject the first (cached-token) attempt, accept the retry.
+            pdfCalls++;
+            if (pdfCalls == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.Unauthorized)
+                {
+                    Content = new StringContent("unauthorized")
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent([1, 2, 3])
+            };
+        });
+
+        var client = NewClient(handler);
+
+        await using var stream = await client.GeneratePdfFromHtmlAsync("<html></html>", 1f);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, ms.ToArray());
+        Assert.Equal(2, pdfCalls); // retried once after the 401
+        Assert.Equal(2, tokenCalls); // fetched a fresh token for the retry
+
+        ConvertoTokenCache.Clear();
+    }
+
+    [Fact]
+    public async Task GeneratePdf_DoesNotRetry_When_PdfEndpoint_Succeeds()
+    {
+        ConvertoTokenCache.Clear();
+
+        var pdfCalls = 0;
+        var handler = new StubHandler(request =>
+        {
+            if (request.RequestUri!.AbsoluteUri.Contains("/token"))
+            {
+                return Json(HttpStatusCode.OK, "{\"access_token\":\"tok\",\"expires_in\":3600}");
+            }
+
+            pdfCalls++;
+            return new HttpResponseMessage(HttpStatusCode.OK) { Content = new ByteArrayContent([9]) };
+        });
+
+        var client = NewClient(handler);
+
+        await using var stream = await client.GeneratePdfFromHtmlAsync("<html></html>", 1f);
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+
+        Assert.Equal(new byte[] { 9 }, ms.ToArray());
+        Assert.Equal(1, pdfCalls);
+
+        ConvertoTokenCache.Clear();
+    }
+
+    private static ConvertoClient NewClient(HttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var options = Options.Create(new ConvertoConfig
+        {
+            PdfEndpointUrl = "https://converto.test/pdf",
+            TokenEndpointUrl = "https://converto.test/token",
+            ClientId = "id",
+            ClientSecret = "secret"
+        });
+
+        return new ConvertoClient(factory.Object, options, new LoggerFactory().CreateLogger<ConvertoClient>());
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string body) =>
+        new(status) { Content = new StringContent(body, Encoding.UTF8, "application/json") };
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public List<string> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request.RequestUri!.AbsoluteUri);
+            return Task.FromResult(responder(request));
+        }
+    }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "@eventuras/core-nextjs": "workspace:^",
     "@eventuras/datatable": "workspace:^",
     "@eventuras/event-sdk": "workspace:^",
-    "@eventuras/fides-auth-next": "workspace:*",
+    "@eventuras/fides-auth-next": "0.3.0",
     "@eventuras/logger": "workspace:^",
     "@eventuras/markdown": "workspace:*",
     "@eventuras/markdown-plugin-happening": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@tailwindcss/postcss": "^4.2.2",
     "@types/debug": "^4.1.13",
     "@xstate/react": "^6.1.0",
+    "@xstate/store": "4.2.0",
     "jose": "6.2.3",
     "lucide-react": "^1.8.0",
     "next": "16.2.9",

--- a/apps/web/src/app/api/certificates/[id]/pdf/route.ts
+++ b/apps/web/src/app/api/certificates/[id]/pdf/route.ts
@@ -1,11 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+import { Logger } from '@eventuras/logger';
+
 import {
   CORRELATION_ID_HEADER,
   createCorrelationId,
   readCorrelationIdFromResponse,
 } from '@/lib/correlation-id';
 import { getAccessToken } from '@/utils/getAccesstoken';
+
+const logger = Logger.create({
+  namespace: 'web:api:certificates',
+  context: { module: 'certificatePdfRoute' },
+});
 
 function errorResponse(error: string, status: number, correlationId: string) {
   return NextResponse.json(
@@ -47,17 +54,29 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         [CORRELATION_ID_HEADER]: correlationId,
       },
     });
-  } catch {
+  } catch (error) {
+    logger.error(
+      { certificateId: id, correlationId, error },
+      'Certificate PDF request to backend failed'
+    );
     return errorResponse('Certificate service is currently unavailable', 502, correlationId);
   }
 
   const backendCorrelationId = readCorrelationIdFromResponse(response) ?? correlationId;
 
   if (!response.ok) {
+    logger.error(
+      { certificateId: id, status: response.status, correlationId: backendCorrelationId },
+      'Backend returned an error fetching certificate PDF'
+    );
     return errorResponse('Failed to fetch certificate PDF', response.status, backendCorrelationId);
   }
 
   if (!response.body) {
+    logger.error(
+      { certificateId: id, correlationId: backendCorrelationId },
+      'Certificate PDF response had no body'
+    );
     return errorResponse('Failed to read certificate PDF stream', 502, backendCorrelationId);
   }
 

--- a/apps/web/src/components/eventuras/CertificateActionsButton.tsx
+++ b/apps/web/src/components/eventuras/CertificateActionsButton.tsx
@@ -40,13 +40,18 @@ export const CertificateActionsButton = ({
         return;
       }
 
-      // Convert base64 to blob and open in new window
+      // Convert base64 to a blob and trigger the download via a temporary anchor.
       const byteCharacters = atob(result.data);
       const byteNumbers = Array.from(byteCharacters, char => char.charCodeAt(0));
       const byteArray = new Uint8Array(byteNumbers);
       const blob = new Blob([byteArray], { type: 'application/pdf' });
       const fileURL = URL.createObjectURL(blob);
-      window.open(fileURL);
+      const link = document.createElement('a');
+      link.href = fileURL;
+      link.download = `certificate-${certificateId}.pdf`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
       // Revoke the object URL after a short delay to free up memory
       setTimeout(() => URL.revokeObjectURL(fileURL), 1000);
     } finally {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,8 +399,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/event-sdk
       '@eventuras/fides-auth-next':
-        specifier: workspace:*
-        version: link:../../libs/fides-auth-next
+        specifier: 0.3.0
+        version: 0.3.0(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.65.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@xstate/react@6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.1))(@xstate/store-react@2.0.0(react@19.2.7))(@xstate/store@4.2.0)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))(react@19.2.7)(xstate@5.32.1)
       '@eventuras/logger':
         specifier: workspace:^
         version: link:../../libs/logger
@@ -2414,6 +2414,20 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eventuras/fides-auth-next@0.3.0':
+    resolution: {integrity: sha512-+87J1WZkQxqIg+zNoH7JgTQqtYlFlAMLLhKysuE4Ml8WhtdZmfVilpnycHGlpC5wxJOuVHMHD8Fz84XsFctWCw==}
+    peerDependencies:
+      '@xstate/react': ^5.0.0 || ^6.0.0
+      '@xstate/store': ^4.0.0
+      '@xstate/store-react': ^2.0.0
+      next: ^16.0.0
+      react: ^19.0.0
+      xstate: ^5.0.0
+
+  '@eventuras/fides-auth@0.9.0':
+    resolution: {integrity: sha512-N4gOEkLJLDuaRm0bnwdu2+DQUbyMHHyKzuEeLMEZ6DhhA9pJP9hAAD/+0B90FTij7BoXzNDO2DS7NZ/aHcmO2A==}
+    engines: {node: '>=18'}
 
   '@eventuras/logger@0.8.1':
     resolution: {integrity: sha512-gleM4HZLXepXMit4/mj8QSePgzivm/LN2/YW6u0wmsHZ3W+Wn5dT2rCZFB1AxDXiErRwOC+FNcuYsw6lwOF6Pg==}
@@ -10859,6 +10873,27 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@eventuras/fides-auth-next@0.3.0(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.65.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))(@xstate/react@6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.1))(@xstate/store-react@2.0.0(react@19.2.7))(@xstate/store@4.2.0)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4))(react@19.2.7)(xstate@5.32.1)':
+    dependencies:
+      '@eventuras/fides-auth': 0.9.0
+      '@eventuras/logger': 0.8.1(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.65.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))
+      '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.1)
+      '@xstate/store': 4.2.0
+      '@xstate/store-react': 2.0.0(react@19.2.7)
+      next: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.77.4)
+      react: 19.2.7
+      xstate: 5.32.1
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/api-logs'
+      - '@opentelemetry/instrumentation-pino'
+      - '@opentelemetry/sdk-logs'
+
+  '@eventuras/fides-auth@0.9.0':
+    dependencies:
+      jose: 6.2.3
+      openid-client: 6.8.4
 
   '@eventuras/logger@0.8.1(@opentelemetry/api-logs@0.219.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.65.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.219.0(@opentelemetry/api@1.9.1))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,6 +437,9 @@ importers:
       '@xstate/react':
         specifier: ^6.1.0
         version: 6.1.0(@types/react@19.2.17)(react@19.2.7)(xstate@5.32.1)
+      '@xstate/store':
+        specifier: 4.2.0
+        version: 4.2.0
       jose:
         specifier: 6.2.3
         version: 6.2.3


### PR DESCRIPTION
## Problem

Clicking **Download certificate** on the event admin page was flaky — it often only worked after retrying a few times.

## Root causes & fixes

### API — Converto PDF path
- **No retry against a cold/transient Converto service.** A single transient failure (cold start, timeout, transient 5xx) surfaced as a 500. Added a resilient named HttpClient (`AddStandardResilienceHandler`) for Converto with a generous per-attempt timeout (PDF rendering runs a headless browser and can be slow).
- **Stale-token trap.** A cached Converto token rejected with 401 was never invalidated, so every retry reused it until the local cache expired (self-healing "after a while"). Now: on 401, clear the token cache and retry once with a fresh token. Widened the cache expiry buffer, capped at half the lifetime so it also handles very short (~10s) tokens.
- **Exception wrapping bug.** `AuthenticationException` (401) was caught by the generic `catch` and rewrapped as `ConvertoClientException`, so the controller's 503 branch was effectively dead. Auth failures now map to 503; transient/comms failures to 500.
- Added failure logging across the token + PDF paths.

### Web
- `window.open()` ran **after** an `await` in the download handler, so it was no longer a direct user gesture and got intermittently popup-blocked. Switched to a temporary `<a download>` click.
- Added failure logging (with correlation id) to the certificate PDF proxy route.

## Tests
New `ConvertoClientRetryTest` (runs in CI, not env-gated): verifies the 401 → fresh-token → retry path, and that a successful call does not retry. Both pass. `dotnet build` (Converto + WebApi) clean; eslint clean on the web files.

## Note
This branch also includes a separate commit pinning `@eventuras/fides-auth-next` to `0.3.0` (needed to get the web app running locally to test the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)