### PR TITLE
refactor(docs-framework): extract headless useDocsSearch hook

### DIFF
--- a/.changeset/docs-framework-use-docs-search-hook.md
+++ b/.changeset/docs-framework-use-docs-search-hook.md
@@ -1,0 +1,13 @@
+---
+"@eventuras/docs-framework": minor
+---
+
+Add a headless `useDocsSearch` hook, exported from `./react`. It holds the
+debounced search logic that was previously embedded in the `<Search>` component
+— which is now a thin ratio-ui wrapper over the hook — making it possible to
+render docs search with a different design system by reusing the hook and
+providing your own UI.
+
+The extracted logic is also hardened: in-flight requests are invalidated when
+the query is cleared and on unmount, and `provider.search` rejections are
+handled, so a late or failed response can't overwrite the current results.

--- a/libs/docs-framework/src/search/components/Search.tsx
+++ b/libs/docs-framework/src/search/components/Search.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-
 import {
   CommandPalette,
   type CommandPaletteItem,
 } from '@eventuras/ratio-ui/core/CommandPalette';
 
 import type { SearchProvider, SearchResult } from '../types.js';
+import { useDocsSearch } from '../hooks/use-docs-search.js';
 
 interface SearchProps {
   /** Search provider instance (e.g. OramaProvider) */
@@ -27,59 +26,19 @@ function toItems(results: SearchResult[]): CommandPaletteItem[] {
 }
 
 /**
- * Full-text search powered by a SearchProvider, rendered via CommandPalette.
+ * Full-text search rendered via the ratio-ui CommandPalette.
  *
- * Handles debounced async search with stale-response protection.
+ * A thin wrapper over {@link useDocsSearch} — swap this component to render the
+ * same search logic with a different design system.
  */
 export function Search({ provider, placeholder = 'Search...', onNavigate }: Readonly<SearchProps>) {
-  const [items, setItems] = useState<CommandPaletteItem[]>([]);
-  const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
-  const searchIdRef = useRef(0);
-
-  const handleQueryChange = useCallback(
-    (query: string) => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-
-      if (!query.trim()) {
-        setItems([]);
-        return;
-      }
-
-      const requestId = ++searchIdRef.current;
-
-      debounceRef.current = setTimeout(async () => {
-        const hits = await provider.search(query);
-        if (requestId === searchIdRef.current) {
-          setItems(toItems(hits));
-        }
-      }, 200);
-    },
-    [provider],
-  );
-
-  // Cleanup debounce on unmount
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
-  }, []);
-
-  const handleSelect = useCallback(
-    (item: CommandPaletteItem) => {
-      if (onNavigate) {
-        onNavigate(item.id);
-      } else {
-        window.location.href = item.id;
-      }
-    },
-    [onNavigate],
-  );
+  const { results, onQueryChange, onSelect } = useDocsSearch({ provider, onNavigate });
 
   return (
     <CommandPalette
-      items={items}
-      onSelect={handleSelect}
-      onQueryChange={handleQueryChange}
+      items={toItems(results)}
+      onSelect={(item) => onSelect(item.id)}
+      onQueryChange={onQueryChange}
       placeholder={placeholder}
     />
   );

--- a/libs/docs-framework/src/search/hooks/use-docs-search.ts
+++ b/libs/docs-framework/src/search/hooks/use-docs-search.ts
@@ -1,0 +1,89 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { SearchProvider, SearchResult } from '../types.js';
+
+export interface UseDocsSearchOptions {
+  /** Search provider instance (e.g. OramaProvider) */
+  provider: SearchProvider;
+  /** Debounce delay in milliseconds before querying (default: 200) */
+  debounceMs?: number;
+  /** Custom navigation handler for SPA routers (e.g. Next.js router.push) */
+  onNavigate?: (url: string) => void;
+}
+
+export interface UseDocsSearchResult {
+  /** Latest results for the most recent query */
+  results: SearchResult[];
+  /** Feed the query on every keystroke; debounced internally */
+  onQueryChange: (query: string) => void;
+  /** Navigate to a result URL (uses onNavigate if given, else window.location) */
+  onSelect: (url: string) => void;
+}
+
+/**
+ * Headless full-text search: debounced querying against a SearchProvider with
+ * stale-response protection. UI-agnostic — render the returned results with any
+ * component (e.g. the ratio-ui-based Search, or your own design system).
+ */
+export function useDocsSearch({
+  provider,
+  debounceMs = 200,
+  onNavigate,
+}: UseDocsSearchOptions): UseDocsSearchResult {
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchIdRef = useRef(0);
+
+  const onQueryChange = useCallback(
+    (query: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+
+      // Bump the id on every change so any in-flight response is ignored —
+      // including when the query is cleared.
+      const requestId = ++searchIdRef.current;
+
+      if (!query.trim()) {
+        setResults([]);
+        return;
+      }
+
+      debounceRef.current = setTimeout(async () => {
+        try {
+          const hits = await provider.search(query);
+          if (requestId === searchIdRef.current) {
+            setResults(hits);
+          }
+        } catch {
+          if (requestId === searchIdRef.current) {
+            setResults([]);
+          }
+        }
+      }, debounceMs);
+    },
+    [provider, debounceMs],
+  );
+
+  // On unmount, cancel the timer and invalidate any in-flight request so a late
+  // response can't call setResults after the component is gone.
+  useEffect(() => {
+    return () => {
+      searchIdRef.current++;
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const onSelect = useCallback(
+    (url: string) => {
+      if (onNavigate) {
+        onNavigate(url);
+      } else {
+        window.location.href = url;
+      }
+    },
+    [onNavigate],
+  );
+
+  return { results, onQueryChange, onSelect };
+}

--- a/libs/docs-framework/src/search/react.ts
+++ b/libs/docs-framework/src/search/react.ts
@@ -1,2 +1,4 @@
 export { Search } from './components/Search.js';
+export { useDocsSearch } from './hooks/use-docs-search.js';
 export type { SearchProvider, SearchResult } from './types.js';
+export type { UseDocsSearchOptions, UseDocsSearchResult } from './hooks/use-docs-search.js';


### PR DESCRIPTION
## What

Extracts the search logic from the ratio-ui `<Search>` component into a headless `useDocsSearch` hook, exported from `@eventuras/docs-framework/react`.

- **`useDocsSearch`** holds the debounced, stale-response-safe query logic + navigation — zero ratio-ui.
- **`<Search>`** becomes a thin wrapper: `useDocsSearch()` + `<CommandPalette>`. Its props are unchanged, so `dev-docs` needs no changes.
- The hook lives in `src/search/hooks/`, mirroring `components/` and the repo's `hooks/` convention.

## Why

Keeps the door open to render docs search with a different design system (reuse the hook, bring your own UI) at near-zero cost — without committing to full pluggability now.

The core logic keeps the original 200 ms debounce and `onNavigate` → `window.location` fallback (`debounceMs` is now an option), and is hardened per review: in-flight requests are invalidated on query-clear and on unmount, and `provider.search` rejections are handled — so a late or failed response can't overwrite current results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)