### PR TITLE
chore(docs-framework): move repo.json entry from apps to libs

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -8,10 +8,6 @@
       "path": "apps/conductor",
       "package": "@eventuras/conductor"
     },
-    "docs-framework": {
-      "path": "apps/docs-framework",
-      "package": "@eventuras/docs-framework"
-    },
     "dev-docs": {
       "path": "apps/dev-docs",
       "package": "@eventuras/dev-docs",
@@ -43,6 +39,9 @@
   "libs": {
     "datatable": {
       "package": "@eventuras/datatable"
+    },
+    "docs-framework": {
+      "package": "@eventuras/docs-framework"
     },
     "event-sdk": {
       "package": "@eventuras/event-sdk",


### PR DESCRIPTION
## What

Moves the `docs-framework` entry in `repo.json` from the `apps` section — where it pointed at a non-existent `apps/docs-framework` path — to `libs`, where the package actually lives (`libs/docs-framework`) and the path is implicit.

## Why

The `apps/docs-framework` path never existed, so the entry was stale metadata. Listing it correctly under `libs` also keeps `docs-framework` a valid commitlint scope (`repo.json` drives the scope enum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)