### PR TITLE
fix(historia): lowercase Vipps email before user lookup and creation

### DIFF
--- a/apps/historia/src/app/(frontend)/[locale]/checkout/vipps/actions.ts
+++ b/apps/historia/src/app/(frontend)/[locale]/checkout/vipps/actions.ts
@@ -429,8 +429,14 @@ export async function createOrderFromPayment({
     let effectiveUserId = userId;
 
     if (!userId) {
-      // Try to get user info from Vipps profile sharing or user details
-      const vippsEmail = paymentDetails.profile?.email || paymentDetails.userDetails?.email;
+      // Try to get user info from Vipps profile sharing or user details.
+      // Payload stores auth emails lowercased — lowercase before lookup/create so
+      // a mixed-case email from Vipps matches the customer's existing user instead
+      // of colliding with the unique index on create. Vipps also redacts personal
+      // data on old payments to the literal string '[Expired]' — treat as missing.
+      const rawVippsEmail = paymentDetails.profile?.email || paymentDetails.userDetails?.email;
+      const vippsEmail =
+        rawVippsEmail && rawVippsEmail !== '[Expired]' ? rawVippsEmail.toLowerCase() : undefined;
       const vippsPhone = paymentDetails.profile?.phoneNumber || paymentDetails.userDetails?.mobileNumber;
       const vippsFirstName = paymentDetails.profile?.givenName || paymentDetails.userDetails?.firstName;
       const vippsLastName = paymentDetails.profile?.familyName || paymentDetails.userDetails?.lastName;


### PR DESCRIPTION
## Summary
- Lowercase the customer email from the Vipps profile before both the user lookup and guest-user creation in Vipps checkout
- Treat Vipps' literal `[Expired]` PII-redaction value as a missing email so old payments fail with the clear guest-checkout error instead of a cryptic field-validation error

## Root cause / incident
Payload stores auth emails lowercased, but guest checkout used the raw mixed-case email from Vipps. A returning customer whose Vipps profile email contains capitals (`Stig.einar...`) missed the case-sensitive `email equals` lookup, and the subsequent `payload.create` collided with the unique email index — so order creation failed **after** the payment was authorized.

Incident: order `04eba743-7612-4dfd-854a-2ff4aeac3198` on losvikkommune.no, 2026-06-02 — 597 NOK authorized in Vipps, no order created, undetected for 8 weeks. Payment has since been captured manually and the order restored by hand; a Loki alert on `CRITICAL: Error creating order from payment` now pages within a minute if this class of failure recurs.

## Testing
- Verified against the production incident data: the existing user row is lowercase while Vipps returned mixed case; with this change the lookup matches and no create is attempted
- `eslint --fix` via lint-staged passed; change is confined to guest-checkout email normalization

🤖 Generated with [Claude Code](https://claude.com/claude-code)