### PR TITLE
fix(vipps): keep stored payment details when Vipps redacts info

### DIFF
--- a/.changeset/vipps-expired-pii-merge.md
+++ b/.changeset/vipps-expired-pii-merge.md
@@ -1,0 +1,6 @@
+---
+'@eventuras/vipps': patch
+'@eventuras/historia': patch
+---
+
+Keep stored payment details when Vipps redacts PII to `[Expired]` instead of overwriting them on re-sync

--- a/apps/historia/src/app/api/webhooks/vipps/route.ts
+++ b/apps/historia/src/app/api/webhooks/vipps/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getPayload } from 'payload';
 
 import { Logger } from '@eventuras/logger';
-import { getPaymentDetails } from '@eventuras/vipps/epayment-v1';
+import { getPaymentDetails, mergeExpiredPaymentDetails } from '@eventuras/vipps/epayment-v1';
 import {
   getEventType,
   parseWebhookPayload,
@@ -781,7 +781,11 @@ async function processPaymentEvent(businessEventId: string, payload: WebhookPayl
     id: transaction.id,
     data: {
       status: newStatus as TransactionStatus,
-      ...(paymentDetails && { data: paymentDetails as any }),
+      // Vipps redacts PII to "[Expired]" after its retention period — keep
+      // the values stored at payment time instead of overwriting them.
+      ...(paymentDetails && {
+        data: mergeExpiredPaymentDetails(paymentDetails, transaction.data) as any,
+      }),
       ...(customerId && { customer: customerId }),
     },
   });

--- a/apps/historia/src/collections/Transactions/actions.ts
+++ b/apps/historia/src/collections/Transactions/actions.ts
@@ -8,7 +8,7 @@ import {
   ServerActionResult,
 } from '@eventuras/core-nextjs/actions';
 import { Logger } from '@eventuras/logger';
-import { getPaymentDetails } from '@eventuras/vipps/epayment-v1';
+import { getPaymentDetails, mergeExpiredPaymentDetails } from '@eventuras/vipps/epayment-v1';
 
 import { getVippsConfig } from '@/lib/vipps/config';
 import config from '@/payload.config';
@@ -118,7 +118,9 @@ export async function updateTransactionDetails(
       id: transactionId,
       data: {
         status: paymentDetails.state.toLowerCase(),
-        data: paymentDetails as any,
+        // Vipps redacts PII to "[Expired]" after its retention period — keep
+        // the values stored at payment time instead of overwriting them.
+        data: mergeExpiredPaymentDetails(paymentDetails, transaction.data) as any,
         ...(customerId && { customer: customerId }),
       },
     });

--- a/libs/vipps/src/__tests__/epayment-redaction.test.ts
+++ b/libs/vipps/src/__tests__/epayment-redaction.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for PII redaction handling — no Vipps credentials required.
+ *
+ * After the retention period Vipps replaces PII field values in payment
+ * details with the literal "[Expired]". Merging a redacted response with the
+ * copy stored at payment time must keep the stored values, while everything
+ * Vipps still reports (state, aggregate) follows the fresh response.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isExpiredValue, mergeExpiredPaymentDetails } from '../epayment-v1/redaction';
+import type { PaymentDetails } from '../epayment-v1/types';
+
+const storedAtPaymentTime = {
+  state: 'AUTHORIZED',
+  amount: { value: 59700, currency: 'NOK' },
+  aggregate: {
+    capturedAmount: { value: 0, currency: 'NOK' },
+    refundedAmount: { value: 0, currency: 'NOK' },
+    cancelledAmount: { value: 0, currency: 'NOK' },
+    authorizedAmount: { value: 59700, currency: 'NOK' },
+  },
+  reference: '04eba743-7612-4dfd-854a-2ff4aeac3198',
+  pspReference: '1883a92e-5d87-4942-9215-ca907f9c2ef1',
+  paymentMethod: { type: 'WALLET', cardBin: '410651' },
+  userDetails: {
+    email: 'ola@example.com',
+    lastName: 'Nordmann',
+    firstName: 'Ola',
+    mobileNumber: '4712345678',
+  },
+  shippingDetails: {
+    address: {
+      city: 'Oslo',
+      country: 'NO',
+      postCode: '0150',
+      addressLine1: 'Storgata 1',
+      addressLine2: 'Leilighet 2',
+    },
+    shippingCost: 5900,
+    shippingOptionId: 'posten-hjem',
+    shippingOptionName: 'Levering hjem med Posten',
+  },
+};
+
+/** The same payment re-fetched after Vipps' retention period. */
+const redactedResponse = {
+  ...storedAtPaymentTime,
+  state: 'AUTHORIZED',
+  aggregate: {
+    ...storedAtPaymentTime.aggregate,
+    capturedAmount: { value: 59700, currency: 'NOK' },
+  },
+  userDetails: {
+    email: '[Expired]',
+    lastName: '[Expired]',
+    firstName: '[Expired]',
+    mobileNumber: '[Expired]',
+  },
+  shippingDetails: {
+    ...storedAtPaymentTime.shippingDetails,
+    address: {
+      city: '[Expired]',
+      country: '[Expired]',
+      postCode: '[Expired]',
+      addressLine1: '[Expired]',
+      addressLine2: '[Expired]',
+    },
+  },
+} as unknown as PaymentDetails;
+
+describe('isExpiredValue', () => {
+  it('matches only the exact placeholder', () => {
+    expect(isExpiredValue('[Expired]')).toBe(true);
+    expect(isExpiredValue('expired')).toBe(false);
+    expect(isExpiredValue('')).toBe(false);
+    expect(isExpiredValue(undefined)).toBe(false);
+    expect(isExpiredValue(null)).toBe(false);
+  });
+});
+
+describe('mergeExpiredPaymentDetails', () => {
+  it('keeps stored values for fields redacted to [Expired]', () => {
+    const merged = mergeExpiredPaymentDetails(redactedResponse, storedAtPaymentTime);
+
+    expect(merged.userDetails).toEqual(storedAtPaymentTime.userDetails);
+    expect(merged.shippingDetails?.address).toEqual(storedAtPaymentTime.shippingDetails.address);
+  });
+
+  it('takes non-redacted fields from the fresh response', () => {
+    const merged = mergeExpiredPaymentDetails(redactedResponse, storedAtPaymentTime);
+
+    expect(merged.aggregate.capturedAmount.value).toBe(59700);
+    expect(merged.shippingDetails?.shippingOptionId).toBe('posten-hjem');
+    expect(merged.reference).toBe(storedAtPaymentTime.reference);
+  });
+
+  it('leaves [Expired] in place when no stored value exists', () => {
+    const merged = mergeExpiredPaymentDetails(redactedResponse, undefined);
+
+    expect(merged.userDetails?.email).toBe('[Expired]');
+    expect(merged.shippingDetails?.address.city).toBe('[Expired]');
+  });
+
+  it('leaves [Expired] in place when the stored value is also redacted', () => {
+    const merged = mergeExpiredPaymentDetails(redactedResponse, redactedResponse);
+
+    expect(merged.userDetails?.email).toBe('[Expired]');
+  });
+
+  it('ignores stored data that does not line up with the fresh structure', () => {
+    const merged = mergeExpiredPaymentDetails(redactedResponse, {
+      userDetails: 'not-an-object',
+      shippingDetails: { address: null },
+    });
+
+    expect(merged.userDetails?.email).toBe('[Expired]');
+    expect(merged.shippingDetails?.address.city).toBe('[Expired]');
+    expect(merged.state).toBe('AUTHORIZED');
+  });
+
+  it('does not treat empty strings or partial matches as redacted', () => {
+    const fresh = {
+      ...redactedResponse,
+      userDetails: { email: '', firstName: 'Expired', lastName: '[Expired]' },
+    } as unknown as PaymentDetails;
+
+    const merged = mergeExpiredPaymentDetails(fresh, storedAtPaymentTime);
+
+    expect(merged.userDetails?.email).toBe('');
+    expect(merged.userDetails?.firstName).toBe('Expired');
+    expect(merged.userDetails?.lastName).toBe('Nordmann');
+  });
+});

--- a/libs/vipps/src/epayment-v1/index.ts
+++ b/libs/vipps/src/epayment-v1/index.ts
@@ -8,4 +8,5 @@
 export * from './client';
 export * from './types';
 export * from './polling';
+export * from './redaction';
 

--- a/libs/vipps/src/epayment-v1/redaction.ts
+++ b/libs/vipps/src/epayment-v1/redaction.ts
@@ -1,0 +1,65 @@
+/**
+ * Handling of Vipps PII redaction.
+ *
+ * Vipps removes personal data from payment details after a retention period
+ * replacing each affected field value with the literal
+ * string "[Expired]" — e.g. userDetails and shippingDetails.address on
+ * Express Checkout payments. Re-fetching an old payment therefore returns a
+ * response where PII fields hold "[Expired]" instead of the original values.
+ * https://developer.vippsmobilepay.com/docs/knowledge-base/user-flow/#personal-information-expiry
+ */
+
+import type { PaymentDetails } from './types';
+
+const EXPIRED = '[Expired]';
+
+/** True when a field value is the Vipps redaction placeholder. */
+export function isExpiredValue(value: unknown): boolean {
+  return value === EXPIRED;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeValue(fresh: unknown, previous: unknown): unknown {
+  if (isExpiredValue(fresh)) {
+    // Keep the previously stored value when it is usable; if it is missing
+    // (or itself redacted) the placeholder is the most honest value we have.
+    return previous !== undefined && previous !== null && !isExpiredValue(previous)
+      ? previous
+      : fresh;
+  }
+
+  if (Array.isArray(fresh)) {
+    const prevArray = Array.isArray(previous) ? previous : [];
+    return fresh.map((item, index) => mergeValue(item, prevArray[index]));
+  }
+
+  if (isPlainObject(fresh)) {
+    const prevObject = isPlainObject(previous) ? previous : {};
+    const merged: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(fresh)) {
+      merged[key] = mergeValue(value, prevObject[key]);
+    }
+    return merged;
+  }
+
+  return fresh;
+}
+
+/**
+ * Merge freshly fetched payment details with a previously stored copy so that
+ * fields Vipps has redacted to "[Expired]" keep their stored values instead of
+ * overwriting them. Everything Vipps still reports (state, aggregate amounts,
+ * …) comes from the fresh response.
+ *
+ * `previous` is typically a persisted JSON blob of unknown shape; anything that
+ * does not line up with the fresh structure is ignored.
+ */
+export function mergeExpiredPaymentDetails(
+  fresh: PaymentDetails,
+  previous: unknown
+): PaymentDetails {
+  return mergeValue(fresh, previous) as PaymentDetails;
+}


### PR DESCRIPTION
…pired]

Vipps removes personal data from payment details after its retention period, returning "[Expired]" in userDetails and shippingDetails fields. Re-syncing an old transaction then overwrote the values stored at payment time with the placeholder.

Add mergeExpiredPaymentDetails to @eventuras/vipps and use it in historia's transaction sync action and Vipps webhook: redacted fields keep their stored values, everything Vipps still reports follows the fresh response.