### PR TITLE
chore(ci): speed up web CI

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -2,8 +2,21 @@ name: Web CI
 
 on:
   workflow_call:
+    secrets:
+      TURBO_TOKEN:
+        required: false
+      TURBO_TEAM:
+        required: false
 
+# Remote turbo cache: shared with the docker build, so unchanged workspace
+# packages resolve as cache hits instead of rebuilding.
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
+# Lint and build are independent — no `needs` between them, they run in
+# parallel. Installs are filtered to web's dependency subtree; the full
+# workspace install pulls in historia/conductor-heavy deps web never uses.
 jobs:
   lint:
     name: Lint
@@ -23,15 +36,14 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --filter @eventuras/web... --frozen-lockfile --ignore-scripts
 
       - name: Lint
-        run: pnpm turbo run lint
+        run: pnpm turbo run lint --filter=@eventuras/web...
 
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -47,7 +59,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+        run: pnpm install --filter @eventuras/web... --frozen-lockfile --ignore-scripts
 
       - name: Build dependencies
         run: pnpm turbo run build --filter=@eventuras/web^...

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -17,6 +17,9 @@ env:
 # Lint and build are independent — no `needs` between them, they run in
 # parallel. Installs are filtered to web's dependency subtree; the full
 # workspace install pulls in historia/conductor-heavy deps web never uses.
+# `--filter eventuras` (the workspace root) keeps the turbo binary installed
+# explicitly — pnpm 11 includes the root in filtered installs, but that is
+# behavior we'd rather not depend on silently.
 jobs:
   lint:
     name: Lint
@@ -36,7 +39,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/web... --frozen-lockfile --ignore-scripts
+        run: pnpm install --filter @eventuras/web... --filter eventuras --frozen-lockfile --ignore-scripts
 
       - name: Lint
         run: pnpm turbo run lint --filter=@eventuras/web...
@@ -59,7 +62,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install --filter @eventuras/web... --frozen-lockfile --ignore-scripts
+        run: pnpm install --filter @eventuras/web... --filter eventuras --frozen-lockfile --ignore-scripts
 
       - name: Build dependencies
         run: pnpm turbo run build --filter=@eventuras/web^...

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -3,10 +3,10 @@ name: Web
 on:
   push:
     branches: [main]
-    paths: ['apps/web/**']
+    paths: ['apps/web/**', '.github/workflows/web*.yml']
   pull_request:
     branches: [main]
-    paths: ['apps/web/**']
+    paths: ['apps/web/**', '.github/workflows/web*.yml']
 
 concurrency:
   group: web-${{ github.ref }}
@@ -16,6 +16,9 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/web-ci.yml
+    secrets:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
   docker:
     name: Docker


### PR DESCRIPTION
Speeds up the **Web / CI** pipeline from ~2m10s wall-clock towards ~60s cold / ~35–45s warm.

Measured on the latest main run: Lint ~56s **then** Build ~71s (needs: lint), everything built cold ("0 cached, 9 total").

## Changes

- **Lint and build run in parallel** — build never consumed lint's result; the `needs` only serialized them.
- **Remote turbo cache in CI**: `TURBO_TOKEN`/`TURBO_TEAM` were already repo secrets and used by the docker build, but never reached web-ci. Now declared in the reusable workflow and passed from the orchestrator — unchanged workspace deps become cache hits, shared with docker.
- **Filtered installs**: `pnpm install --filter @eventuras/web...` instead of the full workspace (which pulls historia/conductor-heavy deps web never uses).
- **Filtered lint**: `turbo run lint --filter=@eventuras/web...` instead of linting the entire repo in web CI.
- **Workflow-file paths added to triggers** so changes to `web*.yml` (like this PR) are themselves validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)