### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @losolio


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `* @losolio`, so GitHub requests review from @losolio on every PR not authored by them — dependabot, Copilot and other contributors alike. (GitHub never requests review from the PR author, so it is a no-op on losolio's own PRs.)

Context: `dependabot.yml`'s `reviewers` key was removed by GitHub. The first iteration of this PR was an Actions workflow scoped to dependabot; CODEOWNERS achieves the same with one line, no Actions run and no token elevation, and also covers future bot PRs.

Optional follow-up (not enabled here): branch protection's "Require review from Code Owners" can make this binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)