### PR TITLE
fix(web): frontpage 500 — Navbar compound statics need a client boundary

### DIFF
--- a/.changeset/site-navbar-rsc-fix.md
+++ b/.changeset/site-navbar-rsc-fix.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Fix frontpage 500: split SiteNavbar into server/client halves — ratio-ui 2.14 made Navbar a `use client` module, so its compound statics (`Navbar.Brand`/`Navbar.Content`) are `undefined` when dotted from a server component

--- a/apps/web/src/components/eventuras/SiteNavbar.tsx
+++ b/apps/web/src/components/eventuras/SiteNavbar.tsx
@@ -1,9 +1,6 @@
-import Link from 'next/link';
 import { getTranslations } from 'next-intl/server';
 
-import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
-
-import UserMenu from '@/components/eventuras/UserMenu';
+import SiteNavbarClient from '@/components/eventuras/SiteNavbarClient';
 import getSiteSettings from '@/utils/site/getSiteSettings';
 
 export type SiteNavbarVariant = 'primary' | 'transparent' | 'dark';
@@ -15,11 +12,11 @@ export interface SiteNavbarProps {
   sticky?: boolean;
 }
 
-const BG_COLOR_BY_VARIANT: Record<Exclude<SiteNavbarVariant, 'dark'>, string> = {
-  primary: 'bg-primary w-full py-1',
-  transparent: 'bg-transparent w-full py-1',
-};
-
+/**
+ * Server half of the site navbar: fetches site settings and translations,
+ * then hands plain props to `SiteNavbarClient`, which owns all Navbar
+ * compound-component rendering (see the note there for why the split exists).
+ */
 export default async function SiteNavbar({
   variant = 'transparent',
   title,
@@ -29,33 +26,22 @@ export default async function SiteNavbar({
   const t = await getTranslations();
 
   const brand = title ?? site?.name ?? 'Eventuras';
-  const isDark = variant === 'dark';
 
   return (
-    <Navbar
-      {...(isDark
-        ? { dark: true, overlay: true, glass: true }
-        : { bgColor: BG_COLOR_BY_VARIANT[variant], sticky })}
-    >
-      <Navbar.Brand>
-        <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
-          {brand}
-        </Link>
-      </Navbar.Brand>
-      <Navbar.Content className="justify-end">
-        <UserMenu
-          translations={{
-            loginLabel: t('common.labels.login'),
-            accountLabel: t('common.labels.account'),
-            adminLabel: t('common.labels.admin'),
-            userLabel: t('common.labels.user'),
-            logoutLabel: t('common.labels.logout'),
-            loggingOutLabel: t('common.labels.loggingOut'),
-            lightThemeLabel: t('common.labels.lightTheme'),
-            darkThemeLabel: t('common.labels.darkTheme'),
-          }}
-        />
-      </Navbar.Content>
-    </Navbar>
+    <SiteNavbarClient
+      brand={brand}
+      variant={variant}
+      sticky={sticky}
+      translations={{
+        loginLabel: t('common.labels.login'),
+        accountLabel: t('common.labels.account'),
+        adminLabel: t('common.labels.admin'),
+        userLabel: t('common.labels.user'),
+        logoutLabel: t('common.labels.logout'),
+        loggingOutLabel: t('common.labels.loggingOut'),
+        lightThemeLabel: t('common.labels.lightTheme'),
+        darkThemeLabel: t('common.labels.darkTheme'),
+      }}
+    />
   );
 }

--- a/apps/web/src/components/eventuras/SiteNavbarClient.tsx
+++ b/apps/web/src/components/eventuras/SiteNavbarClient.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { Navbar } from '@eventuras/ratio-ui/core/Navbar';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+import UserMenu, { type UserMenuTranslations } from '@/components/eventuras/UserMenu';
+
+import type { SiteNavbarVariant } from './SiteNavbar';
+
+const BG_COLOR_BY_VARIANT: Record<Exclude<SiteNavbarVariant, 'dark'>, string> = {
+  primary: 'bg-primary w-full py-1',
+  transparent: 'bg-transparent w-full py-1',
+};
+
+export interface SiteNavbarClientProps {
+  brand: string;
+  variant: SiteNavbarVariant;
+  sticky?: boolean;
+  translations: UserMenuTranslations;
+}
+
+/**
+ * Client half of the site navbar. Navbar ships as a `use client` module since
+ * ratio-ui 2.14, so its compound statics (`Navbar.Brand`, `Navbar.Content`)
+ * only exist inside the client bundle — a server component dotting into them
+ * gets `undefined` from the client-reference proxy. The server half
+ * (`SiteNavbar`) fetches data and passes plain props across the boundary.
+ */
+export default function SiteNavbarClient({
+  brand,
+  variant,
+  sticky,
+  translations,
+}: Readonly<SiteNavbarClientProps>) {
+  const isDark = variant === 'dark';
+
+  return (
+    <Navbar
+      {...(isDark
+        ? { dark: true, overlay: true, glass: true }
+        : { bgColor: BG_COLOR_BY_VARIANT[variant], sticky })}
+    >
+      <Navbar.Brand>
+        <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">
+          {brand}
+        </Link>
+      </Navbar.Brand>
+      <Navbar.Content className="justify-end">
+        <UserMenu translations={translations} />
+      </Navbar.Content>
+    </Navbar>
+  );
+}


### PR DESCRIPTION
Fixes the staging 500 that has frozen the CD pipeline since 2026-07-21 (ref infra brief).

## Root cause

ratio-ui 2.8 → 2.14 (commit `ceb00a0`) made `Navbar` ship as a **`use client` module** (verified: 2.8's `dist/core/Navbar` has no directive, 2.14+ does). Compound statics are attached inside that client module, so when a **server component** dots into them, the client-reference proxy returns `undefined`:

- `<Navbar>` from a server component → renders fine
- `<Navbar.Brand>` from a server component → **`Element type is invalid … got: undefined`**

`SiteNavbar` is a server component using `Navbar.Brand`/`Navbar.Content` — and it renders on every page with a navbar, which is why staging 500s after data loads successfully. None of the seven frontpage imports from the brief were broken as *imports* — all named exports exist in 2.16; the failure is RSC-boundary semantics, invisible to static checks and to `next build` (frontpage is `force-dynamic`, so it only renders at request time).

Isolated empirically with throwaway routes against a local dev server (each suspect component rendered alone until `<Navbar.Brand>` reproduced the 500). `Footer.Classic`/`List.Item` in server components are fine — those modules ship without the directive.

## Fix

Split `SiteNavbar`: the async server half fetches site settings + translations; new `SiteNavbarClient` (`use client`) owns all Navbar compound rendering. No visual/behavioral change.

**Verified:** frontpage 500 → 200 locally against the same dev server; production build green; no other server-side compound usage of ratio-ui client modules in web (checked all non-client files against the full list of `use client` modules in the published package — only `SiteNavbar` was affected; `Dialog` usage is safe, it ships without the directive).

## Follow-up (ratio-ui)

The underlying regression belongs in ratio-ui: in 2.8 the statics were attached in a directive-free index, in 2.14+ inside the client module. A ratio-ui patch restoring server-safe statics attachment would fix all consumers properly — proposed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)