### PR TITLE
fix(web): add breathing room between registration wizard and footer

### DIFF
--- a/apps/web/src/app/(user)/user/events/[id]/page.tsx
+++ b/apps/web/src/app/(user)/user/events/[id]/page.tsx
@@ -77,7 +77,7 @@ export default async function UserEventPage({ params }: Readonly<UserEventPagePr
           logger.debug({ eventId: id }, 'User profile fetch successful after session refresh');
           // Continue with the rest of the page using retryUserResponse
           return (
-            <section className="mt-16">
+            <section className="my-16">
               {eventInfoResponse.data?.title && (
                 <>
                   <p className="text-sm text-gray-600 dark:text-gray-400">
@@ -158,7 +158,7 @@ export default async function UserEventPage({ params }: Readonly<UserEventPagePr
   );
 
   return (
-    <Container>
+    <Container marginY="xl">
       {eventInfoResponse.data.title && <Heading as="h1">{eventInfoResponse.data.title}</Heading>}
 
       <EventFlowContainer


### PR DESCRIPTION
The registration wizard's buttons sat flush against the dark site footer (screenshot from `/user/events/593`). Both render paths in `user/events/[id]/page.tsx` lacked bottom spacing:

- main path: bare `<Container>` with no vertical margin → now `<Container marginY="xl">` (~3rem symmetric air, largest SpacingProps token)
- retry path: `mt-16` top-only → `my-16`

Margin-only change, no structural edits. Lint + web production build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)