### PR TITLE
fix(e2e): declare implicit config deps + smoke-test the image before push

### DIFF
--- a/.changeset/e2e-declare-config-deps.md
+++ b/.changeset/e2e-declare-config-deps.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/e2e': patch
+---
+
+Declare `@eventuras/typescript-config` and `@eventuras/eslint-config` as devDependencies — the configs extended them while the workspace copies existed, and the implicit resolution broke when the packages moved to npm (origo)

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Smoke test — configs load and tests are discoverable
         run: |
           COUNT=$(docker run --rm \
-            -e E2E_WEB_URL=http://smoke \
-            -e E2E_API_URL=http://smoke \
+            -e E2E_WEB_URL=https://smoke.invalid \
+            -e E2E_API_URL=https://smoke.invalid \
             -e E2E_ADMIN_EMAIL=smoke@example.com \
             -e E2E_SYSTEMADMIN_EMAIL=smoke2@example.com \
             -e E2E_USER_EMAIL_PATTERN='smoke+{random}@example.com' \

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -47,6 +47,37 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=,format=short
 
+      - name: Build for smoke test
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: tests/e2e/Dockerfile
+          load: true
+          tags: e2e-smoke:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # A broken image used to reach :latest with a green check and only fail
+      # days later in the infra repo's CD (e.g. an unresolvable tsconfig).
+      # Listing tests needs no staging, secrets or network — but Playwright
+      # exits 0 with "0 tests" when spec loading fails, so assert the count.
+      - name: Smoke test — configs load and tests are discoverable
+        run: |
+          COUNT=$(docker run --rm \
+            -e E2E_WEB_URL=http://smoke \
+            -e E2E_API_URL=http://smoke \
+            -e E2E_ADMIN_EMAIL=smoke@example.com \
+            -e E2E_SYSTEMADMIN_EMAIL=smoke2@example.com \
+            -e E2E_USER_EMAIL_PATTERN='smoke+{random}@example.com' \
+            -e E2E_SESSION_SECRET=smoke \
+            e2e-smoke:local pnpm exec playwright test --list 2>&1 | tee smoke.log | grep -oE 'Total: [0-9]+ tests' | grep -oE '[0-9]+' || echo 0)
+          echo "Playwright listed ${COUNT} tests"
+          if [ "${COUNT}" -lt 1 ]; then
+            echo "::error::Playwright listed ${COUNT} tests — config or spec loading is broken:"
+            tail -40 smoke.log
+            exit 1
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/.github/workflows/e2e-docker.yml
+++ b/.github/workflows/e2e-docker.yml
@@ -70,7 +70,7 @@ jobs:
             -e E2E_SYSTEMADMIN_EMAIL=smoke2@example.com \
             -e E2E_USER_EMAIL_PATTERN='smoke+{random}@example.com' \
             -e E2E_SESSION_SECRET=smoke \
-            e2e-smoke:local pnpm exec playwright test --list 2>&1 | tee smoke.log | grep -oE 'Total: [0-9]+ tests' | grep -oE '[0-9]+' || echo 0)
+            e2e-smoke:local pnpm exec playwright test --list 2>&1 | tee smoke.log | grep -oE 'Total: [0-9]+ tests?' | grep -oE '[0-9]+' || echo 0)
           echo "Playwright listed ${COUNT} tests"
           if [ "${COUNT}" -lt 1 ]; then
             echo "::error::Playwright listed ${COUNT} tests — config or spec loading is broken:"
@@ -79,11 +79,14 @@ jobs:
           fi
 
       - name: Build and push
+        # PRs stop at the smoke build — this step only exists to push, and
+        # resolves instantly from the shared build cache when it runs.
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: tests/e2e/Dockerfile
-          push: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -538,6 +538,13 @@ importers:
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
+    devDependencies:
+      '@eventuras/eslint-config':
+        specifier: ^1.0.4
+        version: 1.0.4(eslint@10.8.0(jiti@2.7.0))(turbo@2.10.7)(typescript@6.0.3)
+      '@eventuras/typescript-config':
+        specifier: ^1.0.0
+        version: 1.0.0
 
 packages:
 
@@ -8065,6 +8072,7 @@ snapshots:
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/nodemailer@8.0.1':
     dependencies:
@@ -8103,7 +8111,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.3
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -8573,7 +8581,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.3
     optional: true
 
   bundle-name@4.1.0:
@@ -9314,7 +9322,7 @@ snapshots:
 
   happy-dom@20.10.6:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.3
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -11289,7 +11297,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
 
   undici@6.27.0: {}
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -27,5 +27,9 @@
     "jose": "6.2.4",
     "tsx": "^4.23.1"
   },
+  "devDependencies": {
+    "@eventuras/eslint-config": "^1.0.4",
+    "@eventuras/typescript-config": "^1.0.0"
+  },
   "readme": "README.md"
 }


### PR DESCRIPTION
Fixes the E2E startup failure gating prod since Aug 6 (ref infra brief: Playwright can't load `tests/e2e/tsconfig.json` in the image).

## Root cause

`tests/e2e` extended `@eventuras/typescript-config/nextjs` (tsconfig) and imported `@eventuras/eslint-config/base` (eslint.config.js) **without declaring either** — they resolved implicitly while the workspace copies existed. The origo phase 2 removal (`4da06c8`) deleted the local packages; the consumer sweep only checked `package.json` specifiers, so config-only references were invisible. Playwright 1.62 validates tsconfig at startup → hard failure before any test runs.

## Changes

1. **`fix(e2e)`**: declare both packages as devDependencies. Verified: npm's `typescript-config@1.0.0` `nextjs.json` is **byte-identical** to the deleted copy (sha-compared), and `playwright test --list` now loads everything and lists **25 tests in 9 files** locally. Swept every workspace package for the same pattern — only `tests/e2e` was affected.
2. **`chore(ci)`**: the E2E Docker workflow pushed `:latest` without ever running the suite, so broken images shipped green and failed days later in infra CD. Now: build with `load`, run `playwright test --list` in the image with dummy env, **assert the listed count is ≥1** (Playwright exits 0 with "0 tests" when spec loading fails — exit codes alone prove nothing), and push only after the smoke passes.

The playwright image bump to v1.62.0-noble (#1782) is already merged, so with this the image has matching browsers, loadable configs, and a smoke gate in front of `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)