### PR TITLE
fix(web): stop logging users out while the session is still refreshable

### DIFF
--- a/.changeset/session-refresh-logouts.md
+++ b/.changeset/session-refresh-logouts.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Stop logging users out while their session is still refreshable: upgrade `@eventuras/fides-auth-next` to 0.7.0 (expired access token + live refresh token now means "refresh", not "log in again"), make the proxy validation-only so it cannot burn a rotated refresh token, report expired-but-refreshable as authenticated from the status route, and adopt POST-only logout with `id_token_hint`. Auth paths now log the library's `session.*` event vocabulary with `sid` for correlation.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,7 +29,7 @@
     "@eventuras/core-nextjs": "^0.1.3",
     "@eventuras/datatable": "^0.6.0",
     "@eventuras/event-sdk": "workspace:^",
-    "@eventuras/fides-auth-next": "0.3.0",
+    "@eventuras/fides-auth-next": "0.7.0",
     "@eventuras/logger": "^0.8.1",
     "@eventuras/markdown": "^0.15.0",
     "@eventuras/markdown-plugin-happening": "workspace:*",

--- a/apps/web/src/app/(auth)/api/auth/logout/route.ts
+++ b/apps/web/src/app/(auth)/api/auth/logout/route.ts
@@ -1,45 +1,22 @@
-import { cookies } from 'next/headers';
-import { NextResponse } from 'next/server';
-
-import { buildOidcLogoutUrl } from '@eventuras/fides-auth-next';
-import { globalGETRateLimit } from '@eventuras/fides-auth-next/request';
-import { Logger } from '@eventuras/logger';
+import { handleOidcLogout } from '@eventuras/fides-auth-next/oidc-logout';
 
 import { appConfig } from '@/config.server';
 import { oauthConfig } from '@/utils/oauthConfig';
 
-const logger = Logger.create({ namespace: 'web:api:logout' });
+/**
+ * RP-initiated logout: clears all session cookies and redirects to the
+ * provider's end-session endpoint with `id_token_hint`. POST-only.
+ */
+export async function POST(request: Request): Promise<Response> {
+  const applicationUrl = String(appConfig.env.APPLICATION_URL ?? '');
+  const postLogoutRedirectUri = new URL(
+    String(appConfig.env.LOGOUT_URL_REDIRECT ?? '/'),
+    applicationUrl
+  ).toString();
 
-export async function GET() {
-  logger.info('Logout request received');
-
-  try {
-    const applicationUrl = appConfig.env.APPLICATION_URL as string;
-
-    if (!(await globalGETRateLimit())) {
-      logger.warn('Rate limit exceeded');
-      return NextResponse.redirect(new URL('/rate-limited', applicationUrl));
-    }
-
-    (await cookies()).delete('session');
-
-    const postLogoutRedirect = (appConfig.env.LOGOUT_URL_REDIRECT as string) || '/';
-    const postLogoutUrl = new URL(postLogoutRedirect, applicationUrl).toString();
-
-    const logoutUrl = await buildOidcLogoutUrl(oauthConfig, postLogoutUrl);
-
-    if (logoutUrl) {
-      logger.info({ logoutUrl: logoutUrl.toString() }, 'Redirecting to OIDC provider logout');
-      return NextResponse.redirect(logoutUrl.toString());
-    }
-
-    logger.info({ postLogoutUrl }, 'No end_session_endpoint, redirecting to app');
-    return NextResponse.redirect(postLogoutUrl);
-  } catch (error) {
-    logger.error({ error }, 'Error in logout route');
-    return new NextResponse('Internal Server Error', {
-      status: 500,
-      headers: { 'Content-Type': 'text/plain' },
-    });
-  }
+  return handleOidcLogout(request, {
+    oauthConfig,
+    postLogoutRedirectUri,
+    applicationUrl,
+  });
 }

--- a/apps/web/src/app/(auth)/api/auth/status/route.ts
+++ b/apps/web/src/app/(auth)/api/auth/status/route.ts
@@ -1,6 +1,4 @@
-import { cookies } from 'next/headers';
-
-import { getSessionSecret, validateSessionJwt } from '@eventuras/fides-auth-next';
+import { accessTokenExpires, tryGetCurrentSession } from '@eventuras/fides-auth-next';
 import { Logger } from '@eventuras/logger';
 
 import type { AuthStatus } from '@/utils/auth/getAuthStatus';
@@ -23,32 +21,30 @@ function notAuthenticated(status = 200): Response {
  */
 export async function GET(): Promise<Response> {
   try {
-    const sessionCookie = (await cookies()).get('session')?.value;
-    if (!sessionCookie) {
+    const { session, reason } = await tryGetCurrentSession();
+
+    if (!session?.user) {
+      // no_session_cookie is the ordinary anonymous case — not worth a line.
+      if (reason && reason !== 'no_session_cookie') {
+        logger.warn({ reason }, 'No usable session, reporting logged out');
+      }
       return notAuthenticated();
     }
 
-    const { status, session, accessTokenExpiresIn, reason } = await validateSessionJwt(
-      sessionCookie,
-      getSessionSecret()
-    );
+    const { accessToken, refreshToken } = session.tokens ?? {};
+    const accessTokenExpired = !!accessToken && accessTokenExpires(accessToken, 0);
 
-    if (status === 'INVALID' || !session?.user) {
-      logger.warn({ status, reason }, 'Unusable session cookie, reporting logged out');
-      return notAuthenticated();
-    }
-
-    if (status === 'EXPIRED' && !session.tokens?.refreshToken) {
+    if (accessTokenExpired && !refreshToken) {
       logger.warn(
-        { accessTokenExpiresIn },
+        { sid: session.sid },
         'Access token expired with no refresh token, reporting logged out'
       );
       return notAuthenticated();
     }
 
-    if (status === 'EXPIRED') {
+    if (accessTokenExpired) {
       logger.debug(
-        { accessTokenExpiresIn },
+        { sid: session.sid },
         'Access token expired but refreshable, still authenticated'
       );
     }
@@ -57,9 +53,9 @@ export async function GET(): Promise<Response> {
       {
         authenticated: true,
         user: {
-          name: session.user.name,
-          email: session.user.email,
-          roles: session.user.roles,
+          name: session.user.name ?? '',
+          email: session.user.email ?? '',
+          roles: session.user.roles ?? [],
         },
       } satisfies AuthStatus,
       { headers: noStore }

--- a/apps/web/src/app/Providers.tsx
+++ b/apps/web/src/app/Providers.tsx
@@ -37,6 +37,14 @@ function HeartbeatRunner() {
       logger.warn('Heartbeat detected expired refresh token');
       authStore.send({ type: 'sessionExpired' });
     },
+    onEvent: event => {
+      // Failures are signal; routine refreshes are noise.
+      if (event.event === 'session.rejected' || event.event === 'session.refresh_failed') {
+        logger.warn({ ...event }, 'Heartbeat event');
+      } else {
+        logger.debug({ ...event }, 'Heartbeat event');
+      }
+    },
   });
   return null;
 }
@@ -56,6 +64,13 @@ export default function Providers({ children }: Readonly<ProvidersProps>) {
       interval: 30_000, // Check every 30 seconds
       onSessionExpired: () => {
         logger.warn('Session expired');
+      },
+      onEvent: event => {
+        if (event.event === 'session.rejected' || event.event === 'session.refresh_failed') {
+          logger.warn({ ...event }, 'Session monitor event');
+        } else {
+          logger.debug({ ...event }, 'Session monitor event');
+        }
       },
     });
 

--- a/apps/web/src/components/eventuras/UserMenu.tsx
+++ b/apps/web/src/components/eventuras/UserMenu.tsx
@@ -103,8 +103,12 @@ function UserDropdownMenu({
   const handleLogout = () => {
     setIsLoggingOut(true);
     onLogout();
-    // Redirect to logout endpoint which clears cookies
-    window.location.href = '/api/auth/logout';
+    // The logout endpoint is POST-only (CSRF), so navigate via a form submit.
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/api/auth/logout';
+    document.body.appendChild(form);
+    form.submit();
   };
 
   // Add warning indicator to menu label if session is unstable

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -2,6 +2,10 @@ import * as Sentry from '@sentry/nextjs';
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    // Route fides-auth's server-side logs through @eventuras/logger.
+    const { configureAuthLogger } = await import('@eventuras/fides-auth-next/store');
+    configureAuthLogger();
+
     await import('../sentry.server.config');
   }
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getSessionSecret, validateSessionJwt } from '@eventuras/fides-auth-next';
+import {
+  getSessionSecret,
+  SESSION_EVENT,
+  type SessionRejectedReason,
+  validateSessionJwt,
+} from '@eventuras/fides-auth-next';
 import { Logger } from '@eventuras/logger';
 
 const logger = Logger.create({ namespace: 'web:proxy' });
@@ -54,7 +59,7 @@ function validateCorsHeaders(request: NextRequest): NextResponse | null {
 
 /** Redirects to login with returnTo, clearing session cookies; `reason` is logged. */
 function redirectToLogin(
-  reason: string,
+  reason: SessionRejectedReason,
   details: Record<string, unknown>,
   pathname: string,
   search: string,
@@ -64,7 +69,10 @@ function redirectToLogin(
   const loginUrl = new URL('/api/auth/login', originUrl);
   loginUrl.searchParams.set('returnTo', returnTo);
 
-  logger.warn({ reason, ...details, returnTo }, 'Redirecting to login');
+  logger.warn(
+    { event: SESSION_EVENT.REJECTED, reason, source: 'proxy', ...details, returnTo },
+    'Redirecting to login'
+  );
 
   const response = NextResponse.redirect(loginUrl.toString());
   for (const name of SESSION_COOKIE_NAMES) {
@@ -108,7 +116,7 @@ export async function proxy(request: NextRequest) {
 
   if (status === 'INVALID') {
     return redirectToLogin(
-      'invalid_session_cookie',
+      'unreadable_session',
       { validationReason: reason },
       pathname,
       search,
@@ -119,8 +127,9 @@ export async function proxy(request: NextRequest) {
   // EXPIRED only fires for stale legacy single-cookie sessions — one re-login.
   if (status === 'EXPIRED') {
     return redirectToLogin(
-      'legacy_session_expired',
+      'stale_legacy_session',
       {
+        sid: session?.sid,
         expiredSecondsAgo: accessTokenExpiresIn !== undefined ? -accessTokenExpiresIn : undefined,
         hasRefreshToken: !!session?.tokens?.refreshToken,
       },
@@ -131,7 +140,10 @@ export async function proxy(request: NextRequest) {
   }
 
   // ─── 3) All checks passed ─────────────────────────────────────────────────
-  logger.debug({ pathname, accessTokenExpiresIn }, 'Request authorized, proceeding');
+  logger.debug(
+    { pathname, sid: session?.sid, accessTokenExpiresIn },
+    'Request authorized, proceeding'
+  );
   return NextResponse.next();
 }
 

--- a/apps/web/src/utils/auth/getAuthStatus.ts
+++ b/apps/web/src/utils/auth/getAuthStatus.ts
@@ -1,16 +1,9 @@
+import type { AuthStatus } from '@eventuras/fides-auth-next/store';
 import { Logger } from '@eventuras/logger';
 
 const logger = Logger.create({ namespace: 'web:utils:getAuthStatus' });
 
-export type AuthStatus = {
-  authenticated: boolean;
-  user?: {
-    name?: string;
-    email?: string;
-    roles?: string[];
-    [key: string]: unknown;
-  };
-};
+export type { AuthStatus };
 
 /**
  * Fetches the current authentication status from the server.

--- a/apps/web/src/utils/getAccesstoken.ts
+++ b/apps/web/src/utils/getAccesstoken.ts
@@ -1,11 +1,9 @@
 'use server';
 
-import { cookies } from 'next/headers';
-
 import {
   accessTokenExpires,
   getCurrentSession,
-  refreshCurrentSession,
+  tryRefreshCurrentSession,
 } from '@eventuras/fides-auth-next';
 import { Logger } from '@eventuras/logger';
 
@@ -14,79 +12,43 @@ import { oauthConfig } from '@/utils/oauthConfig';
 const logger = Logger.create({ namespace: 'web:utils:getAccessToken' });
 
 /**
- * Returns a valid access token for the current session.
- *
- * This function will:
- * 1. Check if a session exists
- * 2. Validate the access token
- * 3. If token is expired or about to expire (within 10s), attempt to refresh it
- * 4. Return the valid token or null if refresh fails
- *
- * Token refresh updates the session cookie, so subsequent calls will use the new token.
- *
- * @returns {Promise<string | null>} A valid access token or null if unavailable.
+ * Returns a valid access token for the current session, refreshing when the
+ * stored one is missing, expired or about to expire (within 10s). Refreshing
+ * updates the session cookies, so subsequent calls use the new token.
  */
 export async function getAccessToken(): Promise<string | null> {
-  // Retrieve the session cookie
-  const sessionCookie = (await cookies()).get('session')?.value;
-  if (!sessionCookie) {
-    logger.debug('No session cookie found');
-    return null;
-  }
-
-  // Get the current session
-  const session = await getCurrentSession(oauthConfig);
-
+  const session = await getCurrentSession();
   if (!session) {
-    logger.warn('Session decoding failed');
+    logger.debug('No session found');
     return null;
   }
 
-  if (!session.tokens?.accessToken) {
-    logger.warn('No access token found in session');
+  const accessToken = session.tokens?.accessToken;
+  if (accessToken && !accessTokenExpires(accessToken, 10)) {
+    return accessToken;
+  }
+
+  if (!session.tokens?.refreshToken) {
+    logger.warn({ sid: session.sid }, 'No refresh token available, cannot refresh');
     return null;
   }
 
-  // Check if token is expired or about to expire (within 10 seconds)
-  const tokenExpiring = accessTokenExpires(session.tokens.accessToken, 10);
-
-  if (tokenExpiring) {
-    logger.info('Access token expired or expiring soon, attempting refresh');
-
-    // Check if we have a refresh token
-    if (!session.tokens?.refreshToken) {
-      logger.warn('No refresh token available, cannot refresh');
-      return null;
+  const result = await tryRefreshCurrentSession(oauthConfig);
+  if (!result.ok) {
+    if (result.reason === 'refresh_failed' && result.cause !== 'invalid_grant') {
+      // Provider blip — the session is likely still fine, just no token now.
+      logger.warn(
+        { reason: result.reason, cause: result.cause, sid: result.sid },
+        'Token refresh failed transiently'
+      );
+    } else {
+      logger.info(
+        { reason: result.reason, cause: result.cause, sid: result.sid },
+        'Token refresh failed, re-authentication required'
+      );
     }
-
-    try {
-      // Attempt to refresh the session
-      const refreshedSession = await refreshCurrentSession(oauthConfig);
-
-      if (!refreshedSession) {
-        logger.info('Token refresh failed - user needs to re-authenticate');
-        return null;
-      }
-
-      if (!refreshedSession.tokens?.accessToken) {
-        logger.error('Refreshed session has no access token');
-        return null;
-      }
-
-      logger.info('Token refreshed successfully');
-      return refreshedSession.tokens.accessToken;
-    } catch (error) {
-      // Check if it's an invalid_grant error (expected when refresh token is expired)
-      const err = error as { code?: string; error?: string };
-      if (err?.code === 'OAUTH_RESPONSE_BODY_ERROR' && err?.error === 'invalid_grant') {
-        logger.info('Refresh token expired or invalid - user needs to re-authenticate');
-      } else {
-        logger.error({ error }, 'Unexpected error refreshing token');
-      }
-      return null;
-    }
+    return null;
   }
 
-  logger.debug('Returning valid access token');
-  return session.tokens.accessToken;
+  return result.session.tokens?.accessToken ?? null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,8 +114,8 @@ importers:
         specifier: workspace:^
         version: link:../../libs/event-sdk
       '@eventuras/fides-auth-next':
-        specifier: 0.3.0
-        version: 0.3.0(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@xstate/react@6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5))(@xstate/store-react@2.0.0(react@19.2.8))(@xstate/store@4.2.2)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)(xstate@5.32.5)
+        specifier: 0.7.0
+        version: 0.7.0(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@xstate/store-react@2.0.0(react@19.2.8))(@xstate/store@4.2.2)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)
       '@eventuras/logger':
         specifier: ^0.8.1
         version: 0.8.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
@@ -1155,22 +1155,30 @@ packages:
     peerDependencies:
       eslint: ^10.0.0
 
-  '@eventuras/fides-auth-next@0.3.0':
-    resolution: {integrity: sha512-+87J1WZkQxqIg+zNoH7JgTQqtYlFlAMLLhKysuE4Ml8WhtdZmfVilpnycHGlpC5wxJOuVHMHD8Fz84XsFctWCw==}
+  '@eventuras/fides-auth-next@0.7.0':
+    resolution: {integrity: sha512-hG5Wj2BcJbx+CnUF0SHCWtemNzKHgrLAwT1WGenwyEbVtlG91s7syNRIq4PkC0j6wt67a0M088kGGBAS8scneQ==}
     peerDependencies:
-      '@xstate/react': ^5.0.0 || ^6.0.0
-      '@xstate/store': ^4.0.0
-      '@xstate/store-react': ^2.0.0
       next: ^16.0.0
       react: ^19.0.0
-      xstate: ^5.0.0
+
+  '@eventuras/fides-auth-react@0.1.5':
+    resolution: {integrity: sha512-4Qco9q8VDuJMEeYwBLxGXCEVndEp7KMnU7bVKyBmug/hLvgHo76klpyjsLsQTaw19Z+gOnTlyIH7ZojedVE/dQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@xstate/store': ^4.2.2
+      '@xstate/store-react': ^2.0.0
+      react: ^19.0.0
+
+  '@eventuras/fides-auth-store@0.2.1':
+    resolution: {integrity: sha512-Vurd5360gex6pc1te7oC+iD7OUDtnfWfGRUCq9E9ZYITgtwQC83dRrLJSiemse2OSCMwMMiYdVQnLJU5rdX6XA==}
+    engines: {node: '>=18'}
 
   '@eventuras/fides-auth@0.11.0':
     resolution: {integrity: sha512-P7eU6Wr7n5gw4PwUnxmCh8XA8Eept8C09LPHO80OehvkSWmW8oMddTvduz1mjtvvaEnxF8DK97pxQ3NGmJcW4Q==}
     engines: {node: '>=18'}
 
-  '@eventuras/fides-auth@0.9.0':
-    resolution: {integrity: sha512-N4gOEkLJLDuaRm0bnwdu2+DQUbyMHHyKzuEeLMEZ6DhhA9pJP9hAAD/+0B90FTij7BoXzNDO2DS7NZ/aHcmO2A==}
+  '@eventuras/fides-auth@0.13.0':
+    resolution: {integrity: sha512-a5nAMyuU2xKHeH6QMRxpmWocxtHETQq5qSuPDMvsbWLt8h9xLLa/ZEHRA38kOzYgNfUd3anDol7pp1gisMuRIw==}
     engines: {node: '>=18'}
 
   '@eventuras/lectio-docs-react@0.1.3':
@@ -4150,9 +4158,6 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
-
   jose@6.2.8:
     resolution: {integrity: sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==}
 
@@ -6741,16 +6746,40 @@ snapshots:
       - turbo
       - typescript
 
-  '@eventuras/fides-auth-next@0.3.0(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@xstate/react@6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5))(@xstate/store-react@2.0.0(react@19.2.8))(@xstate/store@4.2.2)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)(xstate@5.32.5)':
+  '@eventuras/fides-auth-next@0.7.0(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@xstate/store-react@2.0.0(react@19.2.8))(@xstate/store@4.2.2)(next@16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)':
     dependencies:
-      '@eventuras/fides-auth': 0.9.0
-      '@eventuras/logger': 0.8.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
-      '@xstate/react': 6.1.0(@types/react@19.2.17)(react@19.2.8)(xstate@5.32.5)
-      '@xstate/store': 4.2.2
-      '@xstate/store-react': 2.0.0(react@19.2.8)
+      '@eventuras/fides-auth': 0.13.0
+      '@eventuras/fides-auth-react': 0.1.5(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@xstate/store-react@2.0.0(react@19.2.8))(@xstate/store@4.2.2)(react@19.2.8)
+      '@eventuras/fides-auth-store': 0.2.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
       next: 16.3.0(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
       react: 19.2.8
-      xstate: 5.32.5
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/api-logs'
+      - '@opentelemetry/instrumentation-pino'
+      - '@opentelemetry/sdk-logs'
+      - '@xstate/store'
+      - '@xstate/store-react'
+
+  '@eventuras/fides-auth-react@0.1.5(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))(@xstate/store-react@2.0.0(react@19.2.8))(@xstate/store@4.2.2)(react@19.2.8)':
+    dependencies:
+      '@eventuras/fides-auth': 0.13.0
+      '@eventuras/fides-auth-store': 0.2.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
+      '@eventuras/logger': 0.8.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
+      '@xstate/store': 4.2.2
+      '@xstate/store-react': 2.0.0(react@19.2.8)
+      react: 19.2.8
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/api-logs'
+      - '@opentelemetry/instrumentation-pino'
+      - '@opentelemetry/sdk-logs'
+
+  '@eventuras/fides-auth-store@0.2.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))':
+    dependencies:
+      '@eventuras/fides-auth': 0.13.0
+      '@eventuras/logger': 0.8.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
+      '@xstate/store': 4.2.2
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/api-logs'
@@ -6762,9 +6791,9 @@ snapshots:
       jose: 6.2.8
       openid-client: 6.8.4
 
-  '@eventuras/fides-auth@0.9.0':
+  '@eventuras/fides-auth@0.13.0':
     dependencies:
-      jose: 6.2.3
+      jose: 6.2.8
       openid-client: 6.8.4
 
   '@eventuras/lectio-docs-react@0.1.3(@eventuras/ratio-ui@2.17.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
@@ -9954,8 +9983,6 @@ snapshots:
   jiti@2.6.1: {}
 
   jiti@2.7.0: {}
-
-  jose@6.2.3: {}
 
   jose@6.2.8: {}
 

--- a/tests/e2e/specs/web/helpers/auth.ts
+++ b/tests/e2e/specs/web/helpers/auth.ts
@@ -88,7 +88,17 @@ export const checkIfLoggedIn = async (page: import('@playwright/test').Page) => 
 
 export const logout = async (page: import('@playwright/test').Page) => {
   logger.debug('Logging out user');
-  await page.goto('/api/logout');
-  await page.waitForLoadState('load');
-  logger.debug('User logged out, redirected to homepage');
+  const beforeUrl = page.url();
+  // The logout endpoint is POST-only; navigate via a form submit like the app does.
+  await page.evaluate(() => {
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = '/api/auth/logout';
+    document.body.appendChild(form);
+    form.submit();
+  });
+  // Wait for the navigation itself — plain waitForLoadState can resolve against
+  // the pre-submit page.
+  await page.waitForURL(url => url.toString() !== beforeUrl);
+  logger.debug('User logged out, redirected to post-logout page');
 };


### PR DESCRIPTION
## What

Upgrades `@eventuras/fides-auth-next` 0.3.0 → 0.7.0 and adopts the new session contract: an expired access token beside a live refresh token means "refresh now", not "log in again". This targets the reported issue where admin users are thrown out after a few minutes of work and have to log in again with Vipps.

## Changes

- **proxy**: validation-only. The middleware refresh could never persist cookies, and with refresh-token rotation it could burn the rotated token and brick the session. Login redirects now log `session.rejected` events with a typed `reason` and `sid`, and clear the split-format cookies (`session_at`, `session_it`) too.
- **status route**: `tryGetCurrentSession()`; expired-but-refreshable reports `authenticated: true`, so the 30s session monitor stops kicking users the heartbeat could still rescue. Reads the split cookie format correctly.
- **getAccessToken**: `tryRefreshCurrentSession()` separates `invalid_grant` (re-auth required) from transient provider faults, and refreshes when the access token is missing entirely.
- **logout**: POST-only `handleOidcLogout` with `id_token_hint`, clearing all session cookies (the old route deleted only `session`); UserMenu submits a form instead of a GET navigation.
- **observability**: client heartbeat/session-monitor events logged via `onEvent`; `configureAuthLogger()` wired server-side in instrumentation so all fides-auth server logs flow through `@eventuras/logger`.
- **e2e**: the unused logout helper pointed at a nonexistent `/api/logout`; now form-POSTs the real endpoint.

## Rollout note

Users with pre-split cookies whose access token has already expired get **one** re-login after deploy; active users migrate seamlessly on their next heartbeat refresh.

## Verification

`tsc --noEmit` clean, eslint 0 errors, full `next build` green (proxy compiles as middleware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)