### PR TITLE
fix(e2e): read the access token from the split session_at cookie

### DIFF
--- a/.changeset/e2e-split-session-cookie.md
+++ b/.changeset/e2e-split-session-cookie.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/e2e': patch
+---
+
+Read the access token from the split `session_at` cookie in the API test helpers — fides-auth 0.7.0 no longer stores it in the main `session` cookie, which broke every authenticated API spec with "No access token found". The legacy single-cookie format still works as a fallback.

--- a/tests/e2e/specs/shared/api-helpers.ts
+++ b/tests/e2e/specs/shared/api-helpers.ts
@@ -32,10 +32,9 @@ function hexToUint8Array(hex: string): Uint8Array {
 }
 
 /**
- * Decrypts a JWE session token to extract the access token.
- * Uses the same encryption method as @eventuras/fides-auth.
- * @param jweToken - The encrypted JWE token from the session cookie
- * @returns The decrypted session object containing tokens
+ * Decrypts a JWE cookie value with the same key as @eventuras/fides-auth.
+ * @param jweToken - Encrypted value from a session cookie
+ * @returns The payload: `accessToken` (split session_at) or `tokens` (legacy session)
  */
 async function decryptSessionToken(
   jweToken: string

--- a/tests/e2e/specs/shared/api-helpers.ts
+++ b/tests/e2e/specs/shared/api-helpers.ts
@@ -39,7 +39,7 @@ function hexToUint8Array(hex: string): Uint8Array {
  */
 async function decryptSessionToken(
   jweToken: string
-): Promise<{ tokens?: { accessToken?: string } }> {
+): Promise<{ tokens?: { accessToken?: string }; accessToken?: string }> {
   if (!E2E_SESSION_SECRET) {
     throw new Error('E2E_SESSION_SECRET is required');
   }
@@ -51,7 +51,7 @@ async function decryptSessionToken(
     // Decrypt the JWE token using jose library
     const { payload } = await jose.jwtDecrypt(jweToken, secretKey);
 
-    return payload as { tokens?: { accessToken?: string } };
+    return payload as { tokens?: { accessToken?: string }; accessToken?: string };
   } catch (error) {
     logger.error({ error }, 'Error decrypting session token');
     throw new Error(`Failed to decrypt session token: ${error}`);
@@ -67,21 +67,27 @@ async function decryptSessionToken(
 export const getAccessTokenFromAuthFile = async (authFile: string): Promise<string | null> => {
   try {
     const authState = JSON.parse(fs.readFileSync(authFile, 'utf-8'));
+    const cookieValue = (name: string): string | undefined =>
+      authState.cookies?.find((cookie: { name: string }) => cookie.name === name)?.value;
 
-    // Get the session cookie
-    const sessionCookie = authState.cookies?.find(
-      (cookie: { name: string }) => cookie.name === 'session'
-    );
+    // Split format: the access token lives in its own session_at cookie.
+    const accessTokenCookie = cookieValue('session_at');
+    if (accessTokenCookie) {
+      const { accessToken } = await decryptSessionToken(accessTokenCookie);
+      if (accessToken) {
+        logger.debug({ authFile }, 'Extracted access token from session_at cookie');
+        return accessToken;
+      }
+    }
 
+    // Legacy format: the whole session, access token included, in one cookie.
+    const sessionCookie = cookieValue('session');
     if (!sessionCookie) {
       logger.debug({ authFile }, 'No session cookie found in auth file');
       return null;
     }
 
-    // Decrypt the JWE token to get the session data
-    logger.debug({ authFile }, 'Decrypting session token');
-    const session = await decryptSessionToken(sessionCookie.value);
-
+    const session = await decryptSessionToken(sessionCookie);
     const accessToken = session.tokens?.accessToken;
     if (!accessToken) {
       logger.debug('No access token found in decrypted session');


### PR DESCRIPTION
## What

The deploy-web CD run failed its E2E step after #1809: every authenticated API spec threw "No access token found in tmp/auth/*.json".

fides-auth 0.7.0 splits the session across cookies — the access token now lives in its own `session_at` cookie, while the test helper only decrypted the main `session` cookie and expected `tokens.accessToken` inside it.

## Fix

`getAccessTokenFromAuthFile` now decrypts `session_at` first and takes `accessToken` from its payload; the legacy single-cookie format still decrypts as a fallback. This was the only place in the e2e suite reading session cookies directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)