### PR TITLE
chore: changeset for the fides-auth upgrade

### DIFF
--- a/.changeset/web-fides-auth-upgrade.md
+++ b/.changeset/web-fides-auth-upgrade.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Upgrade the fides-auth packages.


### PR DESCRIPTION
Adds a patch changeset for `@eventuras/web` covering the fides-auth dependency upgrade (dependabot's bump in d0f49bda landed without one), so the release flow versions and ships web.

🤖 Generated with [Claude Code](https://claude.com/claude-code)