### PR TITLE
fix(smartform): stop scroll and stray clicks changing number inputs

### DIFF
--- a/.changeset/product-sales-account-input.md
+++ b/.changeset/product-sales-account-input.md
@@ -1,0 +1,6 @@
+---
+'@eventuras/smartform': patch
+'@eventuras/web': patch
+---
+
+Tame the "hyperactive mouse" in number inputs: scrolling past a focused number field no longer steps its value, and `NumberInput` gets a `noSpinner` mode that renders a numeric text field without arrows — used for the product sales account, whose spinner sat right above the save button and got misclicked into changing the account number.

--- a/apps/web/src/app/(admin)/admin/events/[id]/products/ProductModal.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/products/ProductModal.tsx
@@ -123,6 +123,9 @@ const ProductModal: React.FC<ProductModalProps> = ({
             label={t('common.products.labels.salesAccount')}
             description={t('common.products.labels.salesAccountDescription')}
             testId="product-sales-account-input"
+            // Account numbers are identifiers: no spinner arrows next to the
+            // save button, no scroll-stepping.
+            noSpinner
           />
           <Dialog.Footer>
             <Button type="reset" variant="secondary" onClick={onClose}>

--- a/libs/smartform/src/inputs/NumberInput.tsx
+++ b/libs/smartform/src/inputs/NumberInput.tsx
@@ -3,9 +3,27 @@ import { useFormContext } from 'react-hook-form';
 
 import { formStyles, Label, InputProps } from '@eventuras/ratio-ui/forms';
 
-export const NumberInput = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => {
-  const { id, name, placeholder, label, description, className, defaultValue, validation, disabled } =
-    props;
+export type NumberInputProps = InputProps & {
+  /**
+   * Render as a numeric text field without spinner arrows — for identifiers
+   * like account numbers, where an accidental step changes the meaning.
+   */
+  noSpinner?: boolean;
+};
+
+export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>((props, ref) => {
+  const {
+    id,
+    name,
+    placeholder,
+    label,
+    description,
+    className,
+    defaultValue,
+    validation,
+    disabled,
+    noSpinner,
+  } = props;
   const inputId = id ?? name;
   const formContext = useFormContext();
 
@@ -30,14 +48,22 @@ export const NumberInput = React.forwardRef<HTMLInputElement, InputProps>((props
 
       <input
         id={inputId}
-        type="number"
+        type={noSpinner ? 'text' : 'number'}
+        inputMode={noSpinner ? 'numeric' : undefined}
         placeholder={placeholder}
         className={inputClassName}
         aria-invalid={hasError}
         disabled={disabled}
         data-testid={props.testId}
         defaultValue={defaultValue}
-        {...register(name, { valueAsNumber: true })}
+        // Scrolling past a focused number input must not change its value.
+        onWheel={e => e.currentTarget.blur()}
+        {...register(
+          name,
+          noSpinner
+            ? { setValueAs: v => (v === '' || v === null ? undefined : Number(v)) }
+            : { valueAsNumber: true }
+        )}
         ref={e => {
           // Assign the ref from forwardRef
           if (typeof ref === 'function') {

--- a/libs/smartform/src/inputs/NumberInput.tsx
+++ b/libs/smartform/src/inputs/NumberInput.tsx
@@ -41,6 +41,15 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
     inputClassName = `${inputClassName} cursor-not-allowed`;
   }
 
+  // Register exactly once, with conversion and validation merged — a second
+  // register() call would overwrite the first one's options.
+  const { ref: registerRef, ...registration } = register(name, {
+    ...(noSpinner
+      ? { setValueAs: v => (v === '' || v === null || v === undefined ? undefined : Number(v)) }
+      : { valueAsNumber: true }),
+    ...validation,
+  });
+
   return (
     <div className="my-6">
       {label && <Label htmlFor={inputId}>{label}</Label>}
@@ -58,22 +67,14 @@ export const NumberInput = React.forwardRef<HTMLInputElement, NumberInputProps>(
         defaultValue={defaultValue}
         // Scrolling past a focused number input must not change its value.
         onWheel={e => e.currentTarget.blur()}
-        {...register(
-          name,
-          noSpinner
-            ? { setValueAs: v => (v === '' || v === null ? undefined : Number(v)) }
-            : { valueAsNumber: true }
-        )}
+        {...registration}
         ref={e => {
-          // Assign the ref from forwardRef
           if (typeof ref === 'function') {
             ref(e);
           } else if (ref) {
             ref.current = e;
           }
-
-          // Also call the register function
-          register(name, validation).ref(e);
+          registerRef(e);
         }}
       />
       {errors?.[name] && (


### PR DESCRIPTION
## What

Customer report ("the hyperactive mouse"): under Products, the number changed whenever the mouse got near the up/down arrows, and the sales-account field's spinner sits directly above the save button — a click a millimeter too high changed the account number (15xx → 12/13) instead of saving.

## Changes

- **smartform `NumberInput`**: scrolling past a focused number input now blurs it instead of stepping the value (applies to all number fields — price, VAT, minimum quantity).
- **New `noSpinner` mode**: renders a numeric text field (`type="text"`, `inputMode="numeric"`, `setValueAs: Number`) without spinner arrows, for identifier-like numbers where an accidental step changes the meaning.
- **ProductModal**: the sales-account field uses `noSpinner`.

## Verification

`tsc --noEmit` clean, eslint 0 errors, smartform builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)