### PR TITLE
feat(web): admin sidebar shell with pinned event navigation

### DIFF
--- a/.changeset/admin-sidebar-shell.md
+++ b/.changeset/admin-sidebar-shell.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': minor
+---
+
+Admin gets a sidebar shell (ratio-ui `Sidebar` + `NavTree`) with the top-level areas — events, users, orders, registrations, collections, organizations, system — and a drawer with the same navigation on small screens. Opening an event pins it in the sidebar with its sections (participants, communication, products, economy, edit, export); the pin stays while moving between areas and is cleared with the close button. The event admin page now renders one section at a time from `?tab=`; only the five editor tabs keep a tab strip, inside the edit section. First step towards the admin IA prototype; the overview dashboard, export dialog and activity drawer come later.

--- a/apps/web/locales/en-US/admin.json
+++ b/apps/web/locales/en-US/admin.json
@@ -102,6 +102,9 @@
     "labes": {
       "create": "Add event"
     },
+    "sections": {
+      "edit": "Edit"
+    },
     "tabs": {
       "advanced": "Advanced",
       "certificate": "Certificate",
@@ -123,6 +126,12 @@
     "previewCertificate": "Preview certificate",
     "sendCertificates": "Send certificates",
     "users": "Users"
+  },
+  "nav": {
+    "ariaLabel": "Admin navigation",
+    "closeEvent": "Close event",
+    "events": "Events",
+    "system": "System"
   },
   "notifications": {
     "noNotifications": "No notifications yet..."

--- a/apps/web/locales/nb-NO/admin.json
+++ b/apps/web/locales/nb-NO/admin.json
@@ -102,6 +102,9 @@
     "labes": {
       "create": "Nytt arrangement"
     },
+    "sections": {
+      "edit": "Rediger"
+    },
     "tabs": {
       "advanced": "Avansert",
       "certificate": "Kursbevis",
@@ -119,10 +122,16 @@
     "collections": "Samlinger",
     "invoice": "Faktura",
     "orders": "Ordre",
-    "registrations": "Registeringer",
+    "registrations": "Registreringer",
     "previewCertificate": "Forhåndsvis kursbevis",
     "sendCertificates": "Send kursbevis",
     "users": "Brukere"
+  },
+  "nav": {
+    "ariaLabel": "Admin-navigasjon",
+    "closeEvent": "Lukk arrangementet",
+    "events": "Arrangementer",
+    "system": "System"
   },
   "notifications": {
     "noNotifications": "Ingen varslinger ennå..."

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventAdminSections.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventAdminSections.tsx
@@ -8,11 +8,20 @@ import { useTranslations } from 'next-intl';
 import { Logger } from '@eventuras/logger';
 import { Button } from '@eventuras/ratio-ui/core/Button';
 import { ErrorBoundary } from '@eventuras/ratio-ui/core/ErrorBoundary';
+import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Tabs } from '@eventuras/ratio-ui/core/Tabs';
+import { Text } from '@eventuras/ratio-ui/core/Text';
 import { ActionBar } from '@eventuras/ratio-ui/layout/ActionBar';
 import { useToast } from '@eventuras/ratio-ui/toast';
 import { Form, useFormContext } from '@eventuras/smartform';
 
+import {
+  DEFAULT_EVENT_ADMIN_TAB,
+  type EventAdminTab,
+  type EventEditTab,
+  isEventAdminTab,
+  sectionForTab,
+} from '@/components/admin/shell';
 import {
   EventDto,
   EventFormDto,
@@ -38,8 +47,8 @@ import EventProductsEditor from './products/EventProductsEditor';
 import { updateEvent } from '../actions';
 import { AdminCertificatesActionsMenu } from '../AdminCertificatesActionsMenu';
 
-// Isolates a tab's content so a crash there doesn't propagate to the page boundary.
-const TabErrorBoundary = ({ tabId, children }: { tabId: string; children: ReactNode }) => (
+// Isolates a section's content so a crash there doesn't propagate to the page boundary.
+const SectionErrorBoundary = ({ tabId, children }: { tabId: string; children: ReactNode }) => (
   <ErrorBoundary
     onError={(error, info) => {
       const logger = Logger.create({
@@ -141,35 +150,30 @@ const SaveActionBar = ({
   );
 };
 
-type EventPageTabsProps = {
+type EventAdminSectionsProps = {
   eventinfo: EventDto;
   participants: RegistrationDto[];
   statistics: EventStatisticsDto;
   eventProducts: ProductDto[];
   notifications: NotificationDto[];
   organizationId: number;
-  defaultTab?:
-    | 'participants'
-    | 'overview'
-    | 'dates'
-    | 'descriptions'
-    | 'certificate'
-    | 'advanced'
-    | 'communication'
-    | 'products'
-    | 'economy'
-    | 'export';
+  defaultTab?: EventAdminTab;
 };
 
-export default function EventPageTabs({
+/**
+ * Renders the section of the event admin page selected by `?tab=`. The admin
+ * sidebar is the section navigation; only the five editor tabs keep a tab
+ * strip, inside the "edit" section.
+ */
+export default function EventAdminSections({
   eventinfo,
   participants,
   statistics,
   eventProducts,
   notifications,
   organizationId,
-  defaultTab = 'participants',
-}: Readonly<EventPageTabsProps>) {
+  defaultTab = DEFAULT_EVENT_ADMIN_TAB,
+}: Readonly<EventAdminSectionsProps>) {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -179,7 +183,7 @@ export default function EventPageTabs({
 
   const logger = Logger.create({
     namespace: 'web:admin:events',
-    context: { component: 'EventPageTabs', eventId: eventinfo.id },
+    context: { component: 'EventAdminSections', eventId: eventinfo.id },
   });
 
   // Ensure component is mounted before rendering form
@@ -188,9 +192,11 @@ export default function EventPageTabs({
   }, []);
 
   // Get current tab from URL or use default
-  const currentTab = searchParams.get('tab') || defaultTab;
+  const tabParam = searchParams.get('tab');
+  const currentTab: EventAdminTab = isEventAdminTab(tabParam) ? tabParam : defaultTab;
+  const section = sectionForTab(currentTab);
 
-  const handleTabChange = (newTab: string) => {
+  const handleEditTabChange = (newTab: string) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('tab', newTab);
     router.push(`${pathname}?${params.toString()}`, { scroll: false });
@@ -234,14 +240,68 @@ export default function EventPageTabs({
     [eventinfo.id, logger, toast]
   );
 
-  const isEditTab = ['overview', 'dates', 'descriptions', 'certificate', 'advanced'].includes(
-    currentTab
-  );
+  const isEditSection = section.key === 'edit';
 
   // Don't render until mounted to avoid hydration/context issues
   if (!isMounted) {
     return <div className="p-4">Loading...</div>;
   }
+
+  const sectionTitle = isEditSection
+    ? t('admin.events.sections.edit')
+    : t(`admin.events.tabs.${section.tab}`);
+
+  const editTabs: { id: EventEditTab; content: ReactNode; actions?: ReactNode }[] = [
+    { id: 'overview', content: <OverviewSection organizationId={organizationId} /> },
+    { id: 'dates', content: <DatesLocationSection /> },
+    { id: 'descriptions', content: <DescriptionsSection /> },
+    {
+      id: 'certificate',
+      content: <CertificateSection />,
+      actions: <AdminCertificatesActionsMenu eventinfo={eventinfo} />,
+    },
+    { id: 'advanced', content: <AdvancedSection eventId={eventinfo.id} /> },
+  ];
+
+  const renderSection = () => {
+    switch (section.key) {
+      case 'participants':
+        return (
+          <ParticipantsSection
+            eventInfo={eventinfo}
+            participants={participants}
+            statistics={statistics}
+            eventProducts={eventProducts}
+          />
+        );
+      case 'communication':
+        return <CommunicationSection eventinfo={eventinfo} notifications={notifications} />;
+      case 'products':
+        return <EventProductsEditor eventInfo={eventinfo} products={eventProducts} />;
+      case 'economy':
+        return <EconomySection participants={participants} />;
+      case 'export':
+        return <ExportSection eventId={eventinfo.id!} />;
+      case 'edit':
+        return (
+          <Tabs selectedKey={currentTab} onSelectionChange={handleEditTabChange}>
+            {editTabs.map(tab => (
+              <Tabs.Item
+                key={tab.id}
+                id={tab.id}
+                title={t(`admin.events.tabs.${tab.id}`)}
+                testId={`tab-${tab.id}`}
+              >
+                <SectionErrorBoundary tabId={tab.id}>
+                  {tab.content}
+                  <SaveActionBar onSave={handleAutoSave}>{tab.actions}</SaveActionBar>
+                </SectionErrorBoundary>
+              </Tabs.Item>
+            ))}
+          </Tabs>
+        );
+    }
+  };
 
   return (
     <Form
@@ -252,97 +312,25 @@ export default function EventPageTabs({
         // No-op: auto-save handles all updates
       }}
     >
-      {isEditTab && <AutoSaveHandler onAutoSave={handleAutoSave} />}
+      {isEditSection && <AutoSaveHandler onAutoSave={handleAutoSave} />}
 
-      <Tabs selectedKey={currentTab} onSelectionChange={handleTabChange}>
-        <Tabs.Item
-          id="participants"
-          title={t('admin.events.tabs.participants')}
-          testId="tab-participants"
+      <Heading.Group className="mb-6">
+        <Text
+          as="p"
+          family="mono"
+          size="sm"
+          variant="subtle"
+          marginBottom="none"
+          testId="event-admin-eyebrow"
         >
-          <TabErrorBoundary tabId="participants">
-            <ParticipantsSection
-              eventInfo={eventinfo}
-              participants={participants}
-              statistics={statistics}
-              eventProducts={eventProducts}
-            />
-          </TabErrorBoundary>
-        </Tabs.Item>
+          {eventinfo.title}
+        </Text>
+        <Heading as="h1" marginTop="none" testId="event-admin-section-title">
+          {sectionTitle}
+        </Heading>
+      </Heading.Group>
 
-        <Tabs.Item id="overview" title={t('admin.events.tabs.overview')} testId="tab-overview">
-          <TabErrorBoundary tabId="overview">
-            <OverviewSection organizationId={organizationId} />
-            <SaveActionBar onSave={handleAutoSave} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item id="dates" title={t('admin.events.tabs.dates')} testId="tab-dates">
-          <TabErrorBoundary tabId="dates">
-            <DatesLocationSection />
-            <SaveActionBar onSave={handleAutoSave} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item
-          id="descriptions"
-          title={t('admin.events.tabs.descriptions')}
-          testId="tab-descriptions"
-        >
-          <TabErrorBoundary tabId="descriptions">
-            <DescriptionsSection />
-            <SaveActionBar onSave={handleAutoSave} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item
-          id="certificate"
-          title={t('admin.events.tabs.certificate')}
-          testId="tab-certificate"
-        >
-          <TabErrorBoundary tabId="certificate">
-            <CertificateSection />
-            <SaveActionBar onSave={handleAutoSave}>
-              <AdminCertificatesActionsMenu eventinfo={eventinfo} />
-            </SaveActionBar>
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item
-          id="communication"
-          title={t('admin.events.tabs.communication')}
-          testId="tab-communication"
-        >
-          <TabErrorBoundary tabId="communication">
-            <CommunicationSection eventinfo={eventinfo} notifications={notifications} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item id="products" title={t('admin.events.tabs.products')} testId="tab-products">
-          <TabErrorBoundary tabId="products">
-            <EventProductsEditor eventInfo={eventinfo} products={eventProducts} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item id="advanced" title={t('admin.events.tabs.advanced')} testId="tab-advanced">
-          <TabErrorBoundary tabId="advanced">
-            <AdvancedSection eventId={eventinfo.id} />
-            <SaveActionBar onSave={handleAutoSave} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item id="economy" title={t('admin.events.tabs.economy')} testId="tab-economy">
-          <TabErrorBoundary tabId="economy">
-            <EconomySection participants={participants} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-
-        <Tabs.Item id="export" title={t('admin.events.tabs.export')} testId="tab-export">
-          <TabErrorBoundary tabId="export">
-            <ExportSection eventId={eventinfo.id!} />
-          </TabErrorBoundary>
-        </Tabs.Item>
-      </Tabs>
+      <SectionErrorBoundary tabId={section.key}>{renderSection()}</SectionErrorBoundary>
     </Form>
   );
 }

--- a/apps/web/src/app/(admin)/admin/events/[id]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/page.tsx
@@ -2,10 +2,10 @@ import { notFound } from 'next/navigation';
 
 import { Logger } from '@eventuras/logger';
 import { ErrorBlock } from '@eventuras/ratio-ui/blocks/Error';
-import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 
+import { type EventAdminTab, PinEvent } from '@/components/admin/shell';
 import {
   getV3EventsByEventIdProducts,
   getV3EventsByEventIdStatistics,
@@ -16,7 +16,7 @@ import {
 } from '@/lib/eventuras-sdk';
 import { getOrganizationId } from '@/utils/organization';
 
-import EventPageTabs from './EventPageTabs';
+import EventAdminSections from './EventAdminSections';
 
 const logger = Logger.create({
   namespace: 'web:admin:events',
@@ -39,9 +39,9 @@ export default async function EventAdminPage({ params, searchParams }: Readonly<
   const { id } = await params;
   const search = await searchParams;
 
-  // Determine default tab based on query params
+  // A newly created event opens in the editor; otherwise the participant list.
   const isNewlyCreated = search.newlyCreated === 'true';
-  const defaultTab = isNewlyCreated ? 'overview' : 'participants';
+  const defaultTab: EventAdminTab = isNewlyCreated ? 'overview' : 'participants';
 
   const organizationId = getOrganizationId();
 
@@ -123,58 +123,50 @@ export default async function EventAdminPage({ params, searchParams }: Readonly<
     !eventProductsRes ||
     !statisticsRes
   );
+  // Undefined while registrations failed to load, so the sidebar omits the count rather than showing 0.
+  const registrations = registrationsRes?.data?.data;
+
   return (
-    <>
-      <Section>
-        <Container>
-          <Heading as="h1">{eventinfo.title}</Heading>
-          {hasPartialErrors && (
-            <div className="mt-4">
-              <ErrorBlock type="generic" status="warning">
-                <ErrorBlock.Title>Some Data Could Not Be Loaded</ErrorBlock.Title>
-                <ErrorBlock.Description>
-                  The event information loaded successfully, but some additional data is temporarily
-                  unavailable:
-                </ErrorBlock.Description>
-                <ErrorBlock.Details>
-                  <ul className="text-sm list-disc list-inside space-y-1">
-                    {(!registrationsRes || !!registrationsRes?.error) && (
-                      <li>Participant registrations</li>
-                    )}
-                    {(!eventProductsRes || !!eventProductsRes?.error) && <li>Event products</li>}
-                    {(!statisticsRes || !!statisticsRes?.error) && <li>Event statistics</li>}
-                    {!!notificationsRes?.error && <li>Notifications</li>}
-                  </ul>
-                </ErrorBlock.Details>
-              </ErrorBlock>
-            </div>
-          )}
-        </Container>
-      </Section>
-      <Section>
-        <Container>
-          <EventPageTabs
-            eventinfo={eventinfo}
-            participants={registrationsRes.data?.data ?? []}
-            statistics={statisticsRes.data ?? {}}
-            eventProducts={eventProductsRes.data ?? []}
-            notifications={notifications}
-            organizationId={organizationId ?? 0}
-            defaultTab={
-              defaultTab as
-                | 'participants'
-                | 'overview'
-                | 'dates'
-                | 'descriptions'
-                | 'certificate'
-                | 'advanced'
-                | 'communication'
-                | 'products'
-                | 'economy'
-            }
-          />
-        </Container>
-      </Section>
-    </>
+    <Section>
+      <Container>
+        <PinEvent
+          event={{
+            id: eventinfo.id!,
+            title: eventinfo.title ?? '',
+            participantCount: registrations?.length,
+          }}
+        />
+        {hasPartialErrors && (
+          <div className="mb-6">
+            <ErrorBlock type="generic" status="warning">
+              <ErrorBlock.Title>Some Data Could Not Be Loaded</ErrorBlock.Title>
+              <ErrorBlock.Description>
+                The event information loaded successfully, but some additional data is temporarily
+                unavailable:
+              </ErrorBlock.Description>
+              <ErrorBlock.Details>
+                <ul className="text-sm list-disc list-inside space-y-1">
+                  {(!registrationsRes || !!registrationsRes?.error) && (
+                    <li>Participant registrations</li>
+                  )}
+                  {(!eventProductsRes || !!eventProductsRes?.error) && <li>Event products</li>}
+                  {(!statisticsRes || !!statisticsRes?.error) && <li>Event statistics</li>}
+                  {!!notificationsRes?.error && <li>Notifications</li>}
+                </ul>
+              </ErrorBlock.Details>
+            </ErrorBlock>
+          </div>
+        )}
+        <EventAdminSections
+          eventinfo={eventinfo}
+          participants={registrations ?? []}
+          statistics={statisticsRes.data ?? {}}
+          eventProducts={eventProductsRes.data ?? []}
+          notifications={notifications}
+          organizationId={organizationId ?? 0}
+          defaultTab={defaultTab}
+        />
+      </Container>
+    </Section>
   );
 }

--- a/apps/web/src/app/(admin)/layout.tsx
+++ b/apps/web/src/app/(admin)/layout.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react';
+import { getTranslations } from 'next-intl/server';
 
 import { Unauthorized } from '@eventuras/ratio-ui/blocks/Unauthorized';
 
-import SiteFooter from '@/components/eventuras/SiteFooter';
+import { AdminShell } from '@/components/admin/shell';
 import SiteNavbar from '@/components/eventuras/SiteNavbar';
 import { checkAuthorization } from '@/utils/auth/checkAuthorization';
 
@@ -12,7 +13,7 @@ export const dynamic = 'force-dynamic';
 /**
  * (admin) Route Group Layout
  * For admin area: /admin/*
- * Includes navbar and footer with container-wrapped content
+ * Site navbar on top, then the admin shell: sidebar navigation beside the page content.
  * Requires admin authentication - all routes under /admin/* require 'Admin' role
  * Individual pages can add stricter role requirements if needed
  */
@@ -24,13 +25,14 @@ export default async function AdminLayout({ children }: Readonly<{ children: Rea
     return <Unauthorized />;
   }
 
+  const t = await getTranslations();
+
   return (
     <>
       <SiteNavbar />
-
-      <main id="main-content">{children}</main>
-
-      <SiteFooter />
+      <AdminShell title={t('admin.title')} menuLabel={t('common.labels.menu')}>
+        {children}
+      </AdminShell>
     </>
   );
 }

--- a/apps/web/src/components/admin/shell/AdminNav.tsx
+++ b/apps/web/src/components/admin/shell/AdminNav.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import type { ComponentProps } from 'react';
+import NextLink from 'next/link';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+
+import { ActionButton } from '@eventuras/ratio-ui/core/ActionButton';
+import { Chip } from '@eventuras/ratio-ui/core/Chip';
+import { NavTree, type NavTreeItem, type NavTreeProps } from '@eventuras/ratio-ui/core/NavTree';
+import { X } from '@eventuras/ratio-ui/icons';
+
+import {
+  DEFAULT_EVENT_ADMIN_TAB,
+  EVENT_ADMIN_SECTIONS,
+  eventAdminHref,
+  type EventAdminTab,
+  isEventAdminTab,
+  sectionForTab,
+} from './eventAdminSections';
+import { usePinnedEvent } from './PinnedEvent';
+
+// Plain next/link, not ratio-ui's Link: NavTree owns the row styling and passes style/aria props its LinkProps don't type.
+const NavLink: NonNullable<NavTreeProps['LinkComponent']> = ({ href, ...rest }) => (
+  <NextLink href={href} {...rest} />
+);
+
+const EVENT_PATH = /^\/admin\/events\/(\d+)(?:\/|$)/;
+
+/**
+ * Resolves the path NavTree should treat as current: the event section when
+ * inside the pinned event (its product subpages count as the products
+ * section), otherwise the top-level admin area (`/admin/users/42` → `/admin/users`).
+ */
+function currentNavPath(pathname: string, tab: string | null, pinnedEventId: number | undefined) {
+  const eventMatch = EVENT_PATH.exec(pathname);
+  if (eventMatch && pinnedEventId !== undefined && Number(eventMatch[1]) === pinnedEventId) {
+    const subpage = pathname.slice(eventMatch[0].length);
+    let current: EventAdminTab = DEFAULT_EVENT_ADMIN_TAB;
+    if (subpage.startsWith('products')) current = 'products';
+    else if (isEventAdminTab(tab)) current = tab;
+    return eventAdminHref(pinnedEventId, sectionForTab(current).tab);
+  }
+  const [, admin, area] = pathname.split('/');
+  return area ? `/${admin}/${area}` : `/${admin}`;
+}
+
+export function AdminNav(props: Readonly<Pick<ComponentProps<typeof NavTree>, 'className'>>) {
+  const t = useTranslations();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { event, unpin } = usePinnedEvent();
+
+  const closeEvent = () => {
+    unpin();
+    if (event && EVENT_PATH.exec(pathname)?.[1] === String(event.id)) router.push('/admin/events');
+  };
+
+  const eventChildren: NavTreeItem[] | undefined = event
+    ? [
+        {
+          id: 'pinned-event',
+          content: (
+            <div className="flex items-start gap-2 py-0.5">
+              <span className="min-w-0 flex-1 font-mono text-xs leading-snug text-(--text-muted) wrap-break-word">
+                {event.title}
+              </span>
+              <ActionButton
+                size="sm"
+                variant="ghost"
+                ariaLabel={t('admin.nav.closeEvent')}
+                onPress={closeEvent}
+                testId="admin-nav-close-event"
+              >
+                <X size={14} />
+              </ActionButton>
+            </div>
+          ),
+        },
+        ...EVENT_ADMIN_SECTIONS.map<NavTreeItem>(section => ({
+          title:
+            section.key === 'edit'
+              ? t('admin.events.sections.edit')
+              : t(`admin.events.tabs.${section.tab}`),
+          href: eventAdminHref(event.id, section.tab),
+          trailing:
+            section.key === 'participants' && event.participantCount !== undefined ? (
+              <Chip variant="outline" className="font-mono text-[11px]">
+                {event.participantCount}
+              </Chip>
+            ) : undefined,
+        })),
+      ]
+    : undefined;
+
+  return (
+    <NavTree
+      aria-label={t('admin.nav.ariaLabel')}
+      className={props.className}
+      LinkComponent={NavLink}
+      currentPath={currentNavPath(pathname, searchParams.get('tab'), event?.id)}
+      groups={[
+        {
+          items: [
+            {
+              title: t('admin.nav.events'),
+              href: '/admin/events',
+              children: eventChildren,
+              defaultOpen: !!event,
+            },
+            { title: t('admin.labels.users'), href: '/admin/users' },
+            { title: t('admin.labels.orders'), href: '/admin/orders' },
+            { title: t('admin.labels.registrations'), href: '/admin/registrations' },
+            { title: t('admin.labels.collections'), href: '/admin/collections' },
+          ],
+        },
+        {
+          items: [
+            { title: t('admin.organizations.page.title'), href: '/admin/organizations' },
+            { title: t('admin.nav.system'), href: '/admin/system' },
+          ],
+        },
+      ]}
+    />
+  );
+}

--- a/apps/web/src/components/admin/shell/AdminShell.tsx
+++ b/apps/web/src/components/admin/shell/AdminShell.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { type ReactNode, useState } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+import { ActionButton } from '@eventuras/ratio-ui/core/ActionButton';
+import { MenuIcon } from '@eventuras/ratio-ui/icons';
+import { Drawer } from '@eventuras/ratio-ui/layout/Drawer';
+import { Sidebar } from '@eventuras/ratio-ui/layout/Sidebar';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+import { AdminNav } from './AdminNav';
+import { PinnedEventProvider } from './PinnedEvent';
+
+export interface AdminShellProps {
+  children: ReactNode;
+  /** Sidebar header text, e.g. "Admin". */
+  title: string;
+  menuLabel: string;
+}
+
+/**
+ * The admin chrome: a sticky sidebar with the admin navigation on large
+ * screens, the same navigation in a left drawer below that. The page content
+ * renders beside it. The sidebar sticks to the viewport top once the site
+ * navbar scrolls away, so it needs no offset.
+ */
+export function AdminShell({ children, title, menuLabel }: Readonly<AdminShellProps>) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // The drawer stays open only for the URL it was opened on, so it closes
+  // itself once a navigation from inside it lands.
+  const location = `${pathname}?${searchParams.toString()}`;
+  const [openedAt, setOpenedAt] = useState<string | null>(null);
+  const drawerOpen = openedAt === location;
+
+  const header = (
+    <Link href="/admin" className="block px-3 font-serif text-lg font-semibold no-underline">
+      {title}
+    </Link>
+  );
+
+  return (
+    <PinnedEventProvider>
+      <div className="flex items-start">
+        <Sidebar aria-label={title} width={256} className="hidden lg:flex" testId="admin-sidebar">
+          <Sidebar.Header>{header}</Sidebar.Header>
+          <Sidebar.Body>
+            <AdminNav />
+          </Sidebar.Body>
+        </Sidebar>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3 border-b border-border-1 px-3 py-2 lg:hidden">
+            <ActionButton round ariaLabel={menuLabel} onPress={() => setOpenedAt(location)}>
+              <MenuIcon size={18} />
+            </ActionButton>
+            {header}
+          </div>
+          <main id="main-content">{children}</main>
+        </div>
+      </div>
+
+      <Drawer isOpen={drawerOpen} onClose={() => setOpenedAt(null)} side="left">
+        <Drawer.Header as="h2">{title}</Drawer.Header>
+        <Drawer.Body>
+          <AdminNav />
+        </Drawer.Body>
+      </Drawer>
+    </PinnedEventProvider>
+  );
+}

--- a/apps/web/src/components/admin/shell/PinnedEvent.tsx
+++ b/apps/web/src/components/admin/shell/PinnedEvent.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+  useSyncExternalStore,
+} from 'react';
+
+export type PinnedEvent = {
+  id: number;
+  title: string;
+  participantCount?: number;
+};
+
+type PinnedEventContextValue = {
+  event: PinnedEvent | null;
+  pin: (event: PinnedEvent) => void;
+  unpin: () => void;
+};
+
+const PinnedEventContext = createContext<PinnedEventContextValue | null>(null);
+
+// A tiny sessionStorage-backed store so the pinned event survives reloads
+// and hydrates without a server/client mismatch.
+const STORAGE_KEY = 'eventuras.admin.pinnedEvent';
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function readSnapshot(): string | null {
+  try {
+    return window.sessionStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function write(value: string | null) {
+  try {
+    if (value === null) window.sessionStorage.removeItem(STORAGE_KEY);
+    else window.sessionStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    // Storage unavailable; the event page re-pins on its next visit.
+  }
+  listeners.forEach(listener => listener());
+}
+
+function parse(raw: string | null): PinnedEvent | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<PinnedEvent>;
+    if (typeof parsed.id !== 'number' || typeof parsed.title !== 'string') return null;
+    return {
+      id: parsed.id,
+      title: parsed.title,
+      participantCount:
+        typeof parsed.participantCount === 'number' ? parsed.participantCount : undefined,
+    };
+  } catch {
+    return null;
+  }
+}
+
+const pin = (event: PinnedEvent) => write(JSON.stringify(event));
+const unpin = () => write(null);
+
+/**
+ * The event the admin is currently working in. It stays in the sidebar when
+ * they move to users, orders etc., so the sidebar never "forgets" the event.
+ * Cleared with the sidebar's close button.
+ */
+export function PinnedEventProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const raw = useSyncExternalStore(subscribe, readSnapshot, () => null);
+  const event = useMemo(() => parse(raw), [raw]);
+  const value = useMemo(() => ({ event, pin, unpin }), [event]);
+
+  return <PinnedEventContext.Provider value={value}>{children}</PinnedEventContext.Provider>;
+}
+
+export function usePinnedEvent(): PinnedEventContextValue {
+  const ctx = useContext(PinnedEventContext);
+  if (!ctx) throw new Error('usePinnedEvent must be used inside PinnedEventProvider');
+  return ctx;
+}
+
+/** Rendered by the event admin page to pin that event in the sidebar. */
+export function PinEvent({ event }: Readonly<{ event: PinnedEvent }>) {
+  const { pin } = usePinnedEvent();
+  const { id, title, participantCount } = event;
+  useEffect(() => {
+    pin({ id, title, participantCount });
+  }, [pin, id, title, participantCount]);
+  return null;
+}

--- a/apps/web/src/components/admin/shell/eventAdminSections.ts
+++ b/apps/web/src/components/admin/shell/eventAdminSections.ts
@@ -1,0 +1,56 @@
+/**
+ * The event admin page is one route, `/admin/events/[id]?tab=…`. The sidebar
+ * groups those tabs into sections; `edit` spans the five editor tabs, which
+ * stay as a tab strip inside the section.
+ */
+export const EVENT_EDIT_TABS = [
+  'overview',
+  'dates',
+  'descriptions',
+  'certificate',
+  'advanced',
+] as const;
+
+export type EventEditTab = (typeof EVENT_EDIT_TABS)[number];
+
+export type EventAdminTab =
+  EventEditTab | 'participants' | 'communication' | 'products' | 'economy' | 'export';
+
+export type EventAdminSectionKey =
+  'participants' | 'communication' | 'products' | 'economy' | 'edit' | 'export';
+
+export type EventAdminSection = {
+  key: EventAdminSectionKey;
+  /** The tab the sidebar links to. */
+  tab: EventAdminTab;
+};
+
+export const EVENT_ADMIN_SECTIONS: readonly EventAdminSection[] = [
+  { key: 'participants', tab: 'participants' },
+  { key: 'communication', tab: 'communication' },
+  { key: 'products', tab: 'products' },
+  { key: 'economy', tab: 'economy' },
+  { key: 'edit', tab: 'overview' },
+  { key: 'export', tab: 'export' },
+];
+
+export const DEFAULT_EVENT_ADMIN_TAB: EventAdminTab = 'participants';
+
+export function isEventEditTab(tab: string): tab is EventEditTab {
+  return (EVENT_EDIT_TABS as readonly string[]).includes(tab);
+}
+
+export function isEventAdminTab(tab: string | null | undefined): tab is EventAdminTab {
+  return !!tab && (isEventEditTab(tab) || EVENT_ADMIN_SECTIONS.some(s => s.tab === tab));
+}
+
+/** Section a tab belongs to — the editor tabs all resolve to `edit`. */
+export function sectionForTab(tab: EventAdminTab): EventAdminSection {
+  if (isEventEditTab(tab)) return EVENT_ADMIN_SECTIONS.find(s => s.key === 'edit')!;
+  return EVENT_ADMIN_SECTIONS.find(s => s.tab === tab)!;
+}
+
+export function eventAdminHref(eventId: number, tab?: EventAdminTab): string {
+  const base = `/admin/events/${eventId}`;
+  return tab ? `${base}?tab=${tab}` : base;
+}

--- a/apps/web/src/components/admin/shell/index.ts
+++ b/apps/web/src/components/admin/shell/index.ts
@@ -1,0 +1,3 @@
+export { AdminShell } from './AdminShell';
+export * from './eventAdminSections';
+export { PinEvent, PinnedEventProvider, usePinnedEvent } from './PinnedEvent';


### PR DESCRIPTION
## Summary

First step towards the admin IA prototype ([Claude Design: Eventuras admin navigation options](https://claude.ai/design/p/a8f166f0-17b4-46c3-83c9-af0afea41a5c)). This PR only does the "skinne" — the sidebar shell and the pinned-event navigation — built on what ratio-ui already ships (`Sidebar`, `NavTree`, `Drawer`). Dashboard, export dialog, activity drawer and the dark sidebar rail come in later steps.

- **Admin shell** (`components/admin/shell/`): sticky `Sidebar` + `NavTree` on large screens with Events / Users / Orders / Registrations / Collections and Organizations / System; the same nav in a left `Drawer` behind a burger on small screens.
- **Pinned event**: opening an event pins it in the sidebar with its sections (participants, communication, products, economy, edit, export). The pin stays while moving between areas (sessionStorage-backed via `useSyncExternalStore`) and is cleared with the ✕. Product subpages highlight "Products".
- **Event page**: renders one section from `?tab=`, with the event title as mono eyebrow over the section `h1`. Only the five editor tabs keep a `Tabs` strip, inside the edit section — the `tab-overview`/`tab-dates`/… test ids are unchanged, so the e2e event-creation helper keeps working. `EventPageTabs` → `EventAdminSections`.
- Admin layout drops the site footer (the prototype has none); new `admin.nav.*` / `admin.events.sections.edit` strings in nb-NO and en-US, and the "Registeringer" typo fixed.

## Screenshots

Light/dark desktop and the mobile drawer were checked against a temporary preview page (not in the PR); the real admin area could not be driven locally because the local API rejects the local Keycloak token. The active-item highlight is therefore unverified in a browser — please check it in the test plan.

## Test plan

- [ ] `/admin` — sidebar shows, no pinned event
- [ ] Open an event → it appears under Arrangementer with sections; Deltakere has the count chip
- [ ] Click Brukere → event stays pinned; ✕ clears it (and returns to `/admin/events` if you're on the event)
- [ ] Reload on `/admin/users` → pin survives
- [ ] Rediger → editor tabs + autosave work as before; `?newlyCreated=true` lands on Oversikt
- [ ] `/admin/events/{id}/products/{productId}` highlights Produkter
- [ ] Narrow viewport → burger opens the drawer; navigating closes it
- [ ] e2e `001-admin-event-create-registration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
