### PR TITLE
fix(web): use utilities that exist in ratio-ui.css for the pinned event title

### DIFF
--- a/apps/web/src/components/admin/shell/AdminNav.tsx
+++ b/apps/web/src/components/admin/shell/AdminNav.tsx
@@ -63,7 +63,7 @@ export function AdminNav(props: Readonly<Pick<ComponentProps<typeof NavTree>, 'c
           id: 'pinned-event',
           content: (
             <div className="flex items-start gap-2 py-0.5">
-              <span className="min-w-0 flex-1 font-mono text-xs leading-snug text-(--text-muted) wrap-break-word">
+              <span className="min-w-0 flex-1 font-mono text-xs leading-tight text-(--text-muted) break-words">
                 {event.title}
               </span>
               <ActionButton


### PR DESCRIPTION
## Summary

Follow-up to #1827. `apps/web` has no Tailwind build of its own — every utility comes from the prebuilt `@eventuras/ratio-ui/ratio-ui.css`, which only contains classes ratio-ui itself uses (plus its small safelist). `wrap-break-word` and `leading-snug` on the pinned event title are valid Tailwind v4 but absent from that file, so they did nothing; `break-words` and `leading-tight` are present. Copilot's review comment on #1827 was right in effect — my reply there was wrong about the cause.

One-line change, no behaviour beyond long event titles now wrapping in the sidebar.

## Test plan

- [ ] Pin an event with a long title → it wraps inside the sidebar instead of overflowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
