### PR TITLE
feat(web): event overview dashboard as the admin landing section

### DIFF
--- a/.changeset/admin-event-overview.md
+++ b/.changeset/admin-event-overview.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': minor
+---
+
+The event admin gets an overview section (now the default when opening an event): key facts — registered/max with waiting list, dates with duration, venue, revenue with draft-order count — plus the five latest registrations with status and order total, and the four latest notifications, each linking on to its full section. Order revenue maths is shared with the economy section via `computeOrderStatistics`, which now also counts refunded orders (shown as its own tile in the economy section) and leaves cancelled and refunded orders out of the revenue total.

--- a/apps/web/locales/en-US/admin.json
+++ b/apps/web/locales/en-US/admin.json
@@ -49,6 +49,7 @@
       "cancelledOrders": "Cancelled",
       "draftOrders": "Draft",
       "invoicedOrders": "Invoiced",
+      "refundedOrders": "Refunded",
       "totalOrders": "Total Orders",
       "totalRevenue": "Total Revenue",
       "verifiedOrders": "Verified"
@@ -102,8 +103,24 @@
     "labes": {
       "create": "Add event"
     },
+    "overview": {
+      "days": "{count, plural, one {# day} other {# days}}",
+      "draftOrders": "{count} draft orders",
+      "latestNotifications": "Latest notifications",
+      "latestRegistrations": "Latest registrations",
+      "noDate": "Date not set",
+      "noLocation": "Location not set",
+      "noRegistrations": "No registrations yet",
+      "registered": "Registered",
+      "revenue": "Revenue",
+      "seeAll": "See all ({count})",
+      "waitingList": "{count} on the waiting list",
+      "when": "When",
+      "where": "Where"
+    },
     "sections": {
-      "edit": "Edit"
+      "edit": "Edit",
+      "overview": "Overview"
     },
     "tabs": {
       "advanced": "Advanced",

--- a/apps/web/locales/nb-NO/admin.json
+++ b/apps/web/locales/nb-NO/admin.json
@@ -49,6 +49,7 @@
       "cancelledOrders": "Kansellert",
       "draftOrders": "Utkast",
       "invoicedOrders": "Fakturert",
+      "refundedOrders": "Tilbakebetalt",
       "totalOrders": "Totale ordre",
       "totalRevenue": "Total inntekt",
       "verifiedOrders": "Verifisert"
@@ -102,8 +103,24 @@
     "labes": {
       "create": "Nytt arrangement"
     },
+    "overview": {
+      "days": "{count, plural, one {# dag} other {# dager}}",
+      "draftOrders": "{count} ordre i utkast",
+      "latestNotifications": "Siste meldinger",
+      "latestRegistrations": "Siste påmeldte",
+      "noDate": "Dato ikke satt",
+      "noLocation": "Sted ikke satt",
+      "noRegistrations": "Ingen påmeldte ennå",
+      "registered": "Påmeldte",
+      "revenue": "Omsetning",
+      "seeAll": "Se alle ({count})",
+      "waitingList": "{count} på venteliste",
+      "when": "Når",
+      "where": "Sted"
+    },
     "sections": {
-      "edit": "Rediger"
+      "edit": "Rediger",
+      "overview": "Oversikt"
     },
     "tabs": {
       "advanced": "Avansert",

--- a/apps/web/src/app/(admin)/admin/events/[id]/EconomySection.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EconomySection.tsx
@@ -13,19 +13,11 @@ import { Stack } from '@eventuras/ratio-ui/layout/Stack';
 
 import { RegistrationDto, RegistrationStatus } from '@/lib/eventuras-sdk';
 
+import { computeOrderStatistics } from './orderStatistics';
 import Registration from '../../registrations/Registration';
 
 type EconomySectionProps = {
   participants: RegistrationDto[];
-};
-
-type OrderStatistics = {
-  totalOrders: number;
-  totalRevenue: number;
-  draftOrders: number;
-  verifiedOrders: number;
-  invoicedOrders: number;
-  cancelledOrders: number;
 };
 
 // Define the order for status groups
@@ -45,55 +37,7 @@ const STATUS_GROUP_CONFIG: {
 const EconomySection: React.FC<EconomySectionProps> = ({ participants }) => {
   const t = useTranslations();
 
-  // Calculate statistics from all registrations
-  const statistics = useMemo((): OrderStatistics => {
-    const stats: OrderStatistics = {
-      totalOrders: 0,
-      totalRevenue: 0,
-      draftOrders: 0,
-      verifiedOrders: 0,
-      invoicedOrders: 0,
-      cancelledOrders: 0,
-    };
-
-    for (const registration of participants) {
-      const orders = registration.orders || [];
-      const isRegistrationCancelled = registration.status === 'Cancelled';
-
-      for (const order of orders) {
-        stats.totalOrders++;
-
-        // Only count revenue from non-cancelled registrations
-        if (!isRegistrationCancelled) {
-          const orderTotal =
-            order.items?.reduce(
-              (sum: number, item: { quantity?: number; product?: { price?: number } }) =>
-                sum + (item.quantity ?? 0) * (item.product?.price ?? 0),
-              0
-            ) ?? 0;
-          stats.totalRevenue += orderTotal;
-        }
-
-        // Count by status
-        switch (order.status) {
-          case 'Draft':
-            stats.draftOrders++;
-            break;
-          case 'Verified':
-            stats.verifiedOrders++;
-            break;
-          case 'Invoiced':
-            stats.invoicedOrders++;
-            break;
-          case 'Cancelled':
-            stats.cancelledOrders++;
-            break;
-        }
-      }
-    }
-
-    return stats;
-  }, [participants]);
+  const statistics = useMemo(() => computeOrderStatistics(participants), [participants]);
 
   // Group participants by registration status
   const groupedParticipants = useMemo(() => {
@@ -136,7 +80,7 @@ const EconomySection: React.FC<EconomySectionProps> = ({ participants }) => {
       </Grid>
 
       {/* Order status breakdown */}
-      <Grid cols={{ sm: 2, md: 4 }}>
+      <Grid cols={{ sm: 2, md: 3 }}>
         <Card transparent border className="text-center">
           <ValueTile
             number={statistics.draftOrders}
@@ -162,6 +106,13 @@ const EconomySection: React.FC<EconomySectionProps> = ({ participants }) => {
           <ValueTile
             number={statistics.cancelledOrders}
             label={t('admin.economy.statistics.cancelledOrders')}
+            className="items-center"
+          />
+        </Card>
+        <Card transparent border className="text-center">
+          <ValueTile
+            number={statistics.refundedOrders}
+            label={t('admin.economy.statistics.refundedOrders')}
             className="items-center"
           />
         </Card>

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventAdminSections.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventAdminSections.tsx
@@ -34,6 +34,7 @@ import slugify from '@/utils/slugify';
 
 import CommunicationSection from './CommunicationSection';
 import EconomySection from './EconomySection';
+import EventDashboardSection from './EventDashboardSection';
 import {
   AdvancedSection,
   CertificateSection,
@@ -247,9 +248,7 @@ export default function EventAdminSections({
     return <div className="p-4">Loading...</div>;
   }
 
-  const sectionTitle = isEditSection
-    ? t('admin.events.sections.edit')
-    : t(`admin.events.tabs.${section.tab}`);
+  const sectionTitle = t(section.labelKey);
 
   const editTabs: { id: EventEditTab; content: ReactNode; actions?: ReactNode }[] = [
     { id: 'overview', content: <OverviewSection organizationId={organizationId} /> },
@@ -265,6 +264,15 @@ export default function EventAdminSections({
 
   const renderSection = () => {
     switch (section.key) {
+      case 'dashboard':
+        return (
+          <EventDashboardSection
+            eventinfo={eventinfo}
+            participants={participants}
+            statistics={statistics}
+            notifications={notifications}
+          />
+        );
       case 'participants':
         return (
           <ParticipantsSection

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventDashboardSection.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventDashboardSection.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useLocale, useTranslations } from 'next-intl';
+
+import { formatPrice } from '@eventuras/core/currency';
+import { formatDate, formatDateSpan } from '@eventuras/core/datetime';
+import { Badge } from '@eventuras/ratio-ui/core/Badge';
+import { Card } from '@eventuras/ratio-ui/core/Card';
+import { Text } from '@eventuras/ratio-ui/core/Text';
+import { ValueTile } from '@eventuras/ratio-ui/core/ValueTile';
+import { Grid } from '@eventuras/ratio-ui/layout/Grid';
+import { Stack } from '@eventuras/ratio-ui/layout/Stack';
+import { Link } from '@eventuras/ratio-ui-next/Link';
+
+import { eventAdminHref } from '@/components/admin/shell';
+import {
+  EventDto,
+  EventStatisticsDto,
+  NotificationDto,
+  RegistrationDto,
+} from '@/lib/eventuras-sdk';
+
+import { computeOrderStatistics, registrationTotal } from './orderStatistics';
+import {
+  formatRegistrationTime,
+  getStatusBadgeStatus,
+  getStatusLabels,
+} from '../../registrations/Registration';
+
+const LATEST_REGISTRATIONS = 5;
+const LATEST_NOTIFICATIONS = 4;
+
+type EventDashboardSectionProps = {
+  eventinfo: EventDto;
+  participants: RegistrationDto[];
+  statistics: EventStatisticsDto;
+  notifications: NotificationDto[];
+};
+
+/** Whole days from start to end, inclusive; undefined when either date is missing or unparsable. */
+function durationInDays(start?: string | null, end?: string | null): number | undefined {
+  if (!start || !end) return undefined;
+  const ms = Date.parse(end) - Date.parse(start);
+  if (Number.isNaN(ms) || ms < 0) return undefined;
+  return Math.round(ms / 86_400_000) + 1;
+}
+
+function KeyFact({
+  label,
+  value,
+  note,
+  testId,
+}: Readonly<{ label: string; value: string; note?: string; testId: string }>) {
+  return (
+    <Card border transparent testId={testId}>
+      <Text
+        as="p"
+        family="mono"
+        size="xs"
+        variant="subtle"
+        transform="uppercase"
+        marginBottom="none"
+      >
+        {label}
+      </Text>
+      <ValueTile>
+        <ValueTile.Value className="text-2xl">{value}</ValueTile.Value>
+        {note && <ValueTile.Caption>{note}</ValueTile.Caption>}
+      </ValueTile>
+    </Card>
+  );
+}
+
+function ListHeading({
+  title,
+  href,
+  linkLabel,
+}: Readonly<{ title: string; href: string; linkLabel: string }>) {
+  return (
+    <div className="flex items-center gap-3">
+      <Text
+        as="span"
+        family="mono"
+        size="xs"
+        variant="muted"
+        transform="uppercase"
+        weight="semibold"
+      >
+        {title}
+      </Text>
+      <Link href={href} className="ml-auto text-sm">
+        {linkLabel}
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * The event's landing section: key facts, the latest registrations and the
+ * latest notifications, each linking on to its full section.
+ */
+export default function EventDashboardSection({
+  eventinfo,
+  participants,
+  statistics,
+  notifications,
+}: Readonly<EventDashboardSectionProps>) {
+  const t = useTranslations();
+  const locale = useLocale();
+  const eventId = eventinfo.id!;
+
+  const byStatus = statistics.byStatus;
+  const activeCount = byStatus
+    ? (byStatus.draft ?? 0) +
+      (byStatus.verified ?? 0) +
+      (byStatus.attended ?? 0) +
+      (byStatus.finished ?? 0) +
+      (byStatus.notAttended ?? 0)
+    : participants.filter(p => p.status !== 'Cancelled' && p.status !== 'WaitingList').length;
+  const waitingListCount =
+    byStatus?.waitingList ?? participants.filter(p => p.status === 'WaitingList').length;
+
+  const orders = useMemo(() => computeOrderStatistics(participants), [participants]);
+  const statusLabels = useMemo(() => getStatusLabels(t), [t]);
+
+  const latestRegistrations = useMemo(
+    () =>
+      [...participants]
+        .sort((a, b) => (b.registrationTime ?? '').localeCompare(a.registrationTime ?? ''))
+        .slice(0, LATEST_REGISTRATIONS),
+    [participants]
+  );
+  const latestNotifications = useMemo(
+    () =>
+      [...notifications]
+        .sort((a, b) => (b.created ?? '').localeCompare(a.created ?? ''))
+        .slice(0, LATEST_NOTIFICATIONS),
+    [notifications]
+  );
+
+  const days = durationInDays(eventinfo.dateStart, eventinfo.dateEnd);
+  const place = eventinfo.location || eventinfo.city || undefined;
+
+  return (
+    <Stack gap="xl">
+      <Grid cols={{ sm: 2, md: 4 }}>
+        <KeyFact
+          testId="dashboard-registered"
+          label={t('admin.events.overview.registered')}
+          value={
+            eventinfo.maxParticipants
+              ? `${activeCount}/${eventinfo.maxParticipants}`
+              : String(activeCount)
+          }
+          note={
+            waitingListCount > 0
+              ? t('admin.events.overview.waitingList', { count: waitingListCount })
+              : undefined
+          }
+        />
+        <KeyFact
+          testId="dashboard-when"
+          label={t('admin.events.overview.when')}
+          value={
+            eventinfo.dateStart
+              ? formatDateSpan(eventinfo.dateStart, eventinfo.dateEnd, { locale })
+              : t('admin.events.overview.noDate')
+          }
+          note={days ? t('admin.events.overview.days', { count: days }) : undefined}
+        />
+        <KeyFact
+          testId="dashboard-where"
+          label={t('admin.events.overview.where')}
+          value={place ?? t('admin.events.overview.noLocation')}
+          note={eventinfo.location && eventinfo.city ? eventinfo.city : undefined}
+        />
+        <KeyFact
+          testId="dashboard-revenue"
+          label={t('admin.events.overview.revenue')}
+          value={formatPrice(orders.totalRevenue)}
+          note={
+            orders.draftOrders > 0
+              ? t('admin.events.overview.draftOrders', { count: orders.draftOrders })
+              : undefined
+          }
+        />
+      </Grid>
+
+      <Grid cols={{ sm: 1, md: 2 }}>
+        <Stack gap="sm">
+          <ListHeading
+            title={t('admin.events.overview.latestRegistrations')}
+            href={eventAdminHref(eventId, 'participants')}
+            linkLabel={t('admin.events.overview.seeAll', { count: participants.length })}
+          />
+          <Card border transparent padding="none" testId="dashboard-latest-registrations">
+            {latestRegistrations.length === 0 ? (
+              <Text as="p" size="sm" variant="subtle" padding="md">
+                {t('admin.events.overview.noRegistrations')}
+              </Text>
+            ) : (
+              <ul className="divide-y divide-border-1">
+                {latestRegistrations.map(registration => (
+                  <li
+                    key={registration.registrationId}
+                    className="flex items-center gap-3 px-4 py-3 text-sm"
+                  >
+                    <span className="flex min-w-0 flex-1 flex-col">
+                      <span className="truncate font-semibold">{registration.user?.name}</span>
+                      <span className="truncate font-mono text-xs text-(--text-subtle)">
+                        {formatRegistrationTime(registration.registrationTime, locale)}
+                      </span>
+                    </span>
+                    <Badge
+                      variant="subtle"
+                      status={getStatusBadgeStatus(registration.status ?? '')}
+                    >
+                      {statusLabels.find(s => s.value === registration.status)?.label ??
+                        registration.status}
+                    </Badge>
+                    <span className="shrink-0 text-right font-mono text-xs text-(--text-muted)">
+                      {formatPrice(registrationTotal(registration))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </Stack>
+
+        <Stack gap="sm">
+          <ListHeading
+            title={t('admin.events.overview.latestNotifications')}
+            href={eventAdminHref(eventId, 'communication')}
+            linkLabel={t('admin.events.overview.seeAll', { count: notifications.length })}
+          />
+          <Card border transparent padding="none" testId="dashboard-latest-notifications">
+            {latestNotifications.length === 0 ? (
+              <Text as="p" size="sm" variant="subtle" padding="md">
+                {t('admin.notifications.noNotifications')}
+              </Text>
+            ) : (
+              <ul className="divide-y divide-border-1">
+                {latestNotifications.map(notification => (
+                  <li key={notification.notificationId} className="flex flex-col gap-1 px-4 py-3">
+                    <span className="flex items-center gap-2 font-mono text-xs text-(--text-subtle)">
+                      <span>
+                        {notification.created
+                          ? formatDate(notification.created, { locale, showTime: true })
+                          : ''}
+                      </span>
+                      <span className="text-(--text)">{notification.type}</span>
+                      <span className="ml-auto">{notification.status}</span>
+                    </span>
+                    <span className="line-clamp-2 text-sm text-(--text-muted)">
+                      {notification.message}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </Stack>
+      </Grid>
+    </Stack>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/events/[id]/orderStatistics.ts
+++ b/apps/web/src/app/(admin)/admin/events/[id]/orderStatistics.ts
@@ -1,0 +1,80 @@
+import type { OrderDto, RegistrationDto } from '@/lib/eventuras-sdk';
+
+export type OrderStatistics = {
+  totalOrders: number;
+  totalRevenue: number;
+  draftOrders: number;
+  verifiedOrders: number;
+  invoicedOrders: number;
+  cancelledOrders: number;
+  refundedOrders: number;
+};
+
+export function orderTotal(order: OrderDto): number {
+  return (
+    order.items?.reduce(
+      (sum, item) => sum + (item.quantity ?? 0) * (item.product?.price ?? 0),
+      0
+    ) ?? 0
+  );
+}
+
+/** Cancelled and refunded orders carry no revenue. */
+function countsAsRevenue(order: OrderDto): boolean {
+  return order.status !== 'Cancelled' && order.status !== 'Refunded';
+}
+
+/** Sum of a registration's orders, leaving out cancelled and refunded ones. */
+export function registrationTotal(registration: RegistrationDto): number {
+  return (registration.orders ?? [])
+    .filter(countsAsRevenue)
+    .reduce((sum, order) => sum + orderTotal(order), 0);
+}
+
+/**
+ * Order counts by status and revenue across registrations. Revenue skips
+ * cancelled registrations and cancelled/refunded orders; the status counters
+ * cover every `OrderStatus`, so they add up to `totalOrders`.
+ */
+export function computeOrderStatistics(registrations: RegistrationDto[]): OrderStatistics {
+  const stats: OrderStatistics = {
+    totalOrders: 0,
+    totalRevenue: 0,
+    draftOrders: 0,
+    verifiedOrders: 0,
+    invoicedOrders: 0,
+    cancelledOrders: 0,
+    refundedOrders: 0,
+  };
+
+  for (const registration of registrations) {
+    const isRegistrationCancelled = registration.status === 'Cancelled';
+
+    for (const order of registration.orders ?? []) {
+      stats.totalOrders++;
+      if (!isRegistrationCancelled && countsAsRevenue(order)) {
+        stats.totalRevenue += orderTotal(order);
+      }
+
+      switch (order.status) {
+        case 'Draft':
+          stats.draftOrders++;
+          break;
+        case 'Verified':
+          stats.verifiedOrders++;
+          break;
+        case 'Invoiced':
+          stats.invoicedOrders++;
+          break;
+        case 'Cancelled':
+          stats.cancelledOrders++;
+          break;
+        case 'Refunded':
+          stats.refundedOrders++;
+          break;
+      }
+    }
+  }
+
+  return stats;
+}

--- a/apps/web/src/app/(admin)/admin/events/[id]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/page.tsx
@@ -5,7 +5,7 @@ import { ErrorBlock } from '@eventuras/ratio-ui/blocks/Error';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 
-import { type EventAdminTab, PinEvent } from '@/components/admin/shell';
+import { DEFAULT_EVENT_ADMIN_TAB, type EventAdminTab, PinEvent } from '@/components/admin/shell';
 import {
   getV3EventsByEventIdProducts,
   getV3EventsByEventIdStatistics,
@@ -39,9 +39,9 @@ export default async function EventAdminPage({ params, searchParams }: Readonly<
   const { id } = await params;
   const search = await searchParams;
 
-  // A newly created event opens in the editor; otherwise the participant list.
+  // A newly created event opens in the editor; otherwise the overview.
   const isNewlyCreated = search.newlyCreated === 'true';
-  const defaultTab: EventAdminTab = isNewlyCreated ? 'overview' : 'participants';
+  const defaultTab: EventAdminTab = isNewlyCreated ? 'overview' : DEFAULT_EVENT_ADMIN_TAB;
 
   const organizationId = getOrganizationId();
 

--- a/apps/web/src/components/admin/shell/AdminNav.tsx
+++ b/apps/web/src/components/admin/shell/AdminNav.tsx
@@ -79,10 +79,7 @@ export function AdminNav(props: Readonly<Pick<ComponentProps<typeof NavTree>, 'c
           ),
         },
         ...EVENT_ADMIN_SECTIONS.map<NavTreeItem>(section => ({
-          title:
-            section.key === 'edit'
-              ? t('admin.events.sections.edit')
-              : t(`admin.events.tabs.${section.tab}`),
+          title: t(section.labelKey),
           href: eventAdminHref(event.id, section.tab),
           trailing:
             section.key === 'participants' && event.participantCount !== undefined ? (

--- a/apps/web/src/components/admin/shell/eventAdminSections.ts
+++ b/apps/web/src/components/admin/shell/eventAdminSections.ts
@@ -14,27 +14,30 @@ export const EVENT_EDIT_TABS = [
 export type EventEditTab = (typeof EVENT_EDIT_TABS)[number];
 
 export type EventAdminTab =
-  EventEditTab | 'participants' | 'communication' | 'products' | 'economy' | 'export';
+  EventEditTab | 'dashboard' | 'participants' | 'communication' | 'products' | 'economy' | 'export';
 
 export type EventAdminSectionKey =
-  'participants' | 'communication' | 'products' | 'economy' | 'edit' | 'export';
+  'dashboard' | 'participants' | 'communication' | 'products' | 'economy' | 'edit' | 'export';
 
 export type EventAdminSection = {
   key: EventAdminSectionKey;
   /** The tab the sidebar links to. */
   tab: EventAdminTab;
+  /** Translation key for the section's label. */
+  labelKey: string;
 };
 
 export const EVENT_ADMIN_SECTIONS: readonly EventAdminSection[] = [
-  { key: 'participants', tab: 'participants' },
-  { key: 'communication', tab: 'communication' },
-  { key: 'products', tab: 'products' },
-  { key: 'economy', tab: 'economy' },
-  { key: 'edit', tab: 'overview' },
-  { key: 'export', tab: 'export' },
+  { key: 'dashboard', tab: 'dashboard', labelKey: 'admin.events.sections.overview' },
+  { key: 'participants', tab: 'participants', labelKey: 'admin.events.tabs.participants' },
+  { key: 'communication', tab: 'communication', labelKey: 'admin.events.tabs.communication' },
+  { key: 'products', tab: 'products', labelKey: 'admin.events.tabs.products' },
+  { key: 'economy', tab: 'economy', labelKey: 'admin.events.tabs.economy' },
+  { key: 'edit', tab: 'overview', labelKey: 'admin.events.sections.edit' },
+  { key: 'export', tab: 'export', labelKey: 'admin.events.tabs.export' },
 ];
 
-export const DEFAULT_EVENT_ADMIN_TAB: EventAdminTab = 'participants';
+export const DEFAULT_EVENT_ADMIN_TAB: EventAdminTab = 'dashboard';
 
 export function isEventEditTab(tab: string): tab is EventEditTab {
   return (EVENT_EDIT_TABS as readonly string[]).includes(tab);


### PR DESCRIPTION
## Summary

Step 2 of the admin IA prototype ([Claude Design: Eventuras admin navigation options](https://claude.ai/design/p/a8f166f0-17b4-46c3-83c9-af0afea41a5c)), on top of #1827. Opening an event now lands on an **Oversikt** section instead of the participant list (a newly created event still opens in the editor).

- **`EventDashboardSection`** — key facts as `ValueTile` cards (registered/max + waiting list, date span + duration, venue + city, revenue + draft-order count), the five latest registrations (status `Badge`, order total) linking to Deltakere, and the four latest notifications linking to Kommunikasjon. Empty states for both lists.
- **`orderStatistics.ts`** — the revenue/order-count maths extracted from `EconomySection` so both sections compute the same numbers (−58 lines there).
- Section model gains a `labelKey` so the sidebar and the page heading share one lookup; `dashboard` is the new default tab.
- New `admin.events.overview.*` strings (nb-NO / en-US, ICU plural for days).
- Includes the same one-line class fix as #1828 (`break-words`/`leading-tight`) — it disappears on rebase once that merges.

Note for reviewers: `apps/web` has no Tailwind build of its own; utilities come from the prebuilt `ratio-ui.css`. Every class used here was checked against that file (arbitrary grid templates are not available, hence flex rows).

## Screenshots

Light and dark, from a temporary preview page with dummy data (not in the PR) — see the PR conversation for the real-data test plan.

## Test plan

- [ ] Open an event → lands on Oversikt; sidebar highlights Oversikt
- [ ] Key facts match Deltakere/Økonomi numbers (registered count, revenue, draft orders)
- [ ] Event without dates/location/max shows the "not set" fallbacks and no `x/undefined`
- [ ] "Se alle" links land on Deltakere / Kommunikasjon
- [ ] Event with no registrations / no notifications shows the empty states
- [ ] `?newlyCreated=true` still opens the editor; e2e `001-admin-event-create-registration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
