### PR TITLE
feat(api): expose the event uuid on EventDto

### DIFF
--- a/.changeset/event-dto-uuid.md
+++ b/.changeset/event-dto-uuid.md
@@ -1,0 +1,6 @@
+---
+'@eventuras/api': minor
+'@eventuras/event-sdk': minor
+---
+
+`EventDto` now carries the event's `uuid`, so clients can address an event by its stable identifier — needed to query business events for an event.

--- a/apps/api/docs/eventuras-v3.json
+++ b/apps/api/docs/eventuras-v3.json
@@ -5089,6 +5089,10 @@
             "type": "integer",
             "format": "int32"
           },
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          },
           "type": {
             "$ref": "#/components/schemas/EventInfoType"
           },

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventDto.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/Events/EventDto.cs
@@ -16,6 +16,7 @@ public class EventDto
     public EventDto(EventInfo e)
     {
         Id = e.EventInfoId;
+        Uuid = e.Uuid;
         Type = e.Type;
         Status = e.Status;
         Title = e.Title;
@@ -48,6 +49,7 @@ public class EventDto
     }
 
     public int Id { get; set; }
+    public Guid Uuid { get; set; }
     public EventInfo.EventInfoType Type { get; set; }
     public EventInfo.EventInfoStatus Status { get; set; }
     public string Title { get; set; }

--- a/apps/api/tests/Eventuras.WebApi.Tests/JsonElementExtensions.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/JsonElementExtensions.cs
@@ -90,6 +90,7 @@ public static class JsonElementExtensions
     public static void CheckEvent(this JsonElement token, EventInfo eventInfo)
     {
         Assert.Equal(eventInfo.EventInfoId, token.GetValue<int>("id"));
+        Assert.Equal(eventInfo.Uuid.ToString(), token.GetValue<string>("uuid"));
         Assert.Equal(eventInfo.Type.ToString(), token.GetValue<string>("type"));
         Assert.Equal(eventInfo.Title, token.GetValue<string>("title"));
         Assert.Equal(eventInfo.Slug, token.GetValue<string>("slug"));

--- a/libs/event-sdk/src/client-next/types.gen.ts
+++ b/libs/event-sdk/src/client-next/types.gen.ts
@@ -101,6 +101,7 @@ export type EventCollectionDto = {
 
 export type EventDto = {
     id?: number;
+    uuid?: string;
     type?: EventInfoType;
     status?: EventInfoStatus;
     title?: null | string;


### PR DESCRIPTION
## Summary

First of a few small PRs towards the admin activity drawer (prototype: [Claude Design](https://claude.ai/design/p/a8f166f0-17b4-46c3-83c9-af0afea41a5c)). `BusinessEvent`s are addressed by subject uuid, but the v3 `EventDto` only exposed the integer id — so the web app can't ask for an event's business events at all.

- **API:** `Uuid` on `EventDto`, set from `EventInfo.Uuid` (same pattern as `RegistrationDto`/`OrderDto`). The `CheckEvent` test helper asserts `uuid`, so every endpoint returning events is covered.
- **OpenAPI spec:** the one property added by hand (same shape as `RegistrationDto.uuid`) — I couldn't fetch the spec from a running API with this change without starting the API against the local DB. Should be a no-op diff the next time `pnpm openapi:update` runs.
- **event-sdk:** regenerated from the spec → `uuid?: string` on `EventDto`. `apps/web` typechecks against it.

Next PRs: `EventInfoUuid` on `BusinessEvent` + an event filter on `/v3/business-events`; then the drawer in web (polling, no live push for now).

## Test plan

- [x] `EventsControllerTests` + `RegistrationsControllerTest*`: 204 passed, 1 skipped (pre-existing)
- [x] `dotnet format --verify-no-changes` on the changed files
- [x] `apps/web` `tsc --noEmit` against the regenerated SDK
- [ ] `GET /v3/events/{id}` returns `uuid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
