### PR TITLE
feat(api): list business events per event

### DIFF
--- a/.changeset/business-events-event-filter.md
+++ b/.changeset/business-events-event-filter.md
@@ -1,0 +1,6 @@
+---
+'@eventuras/api': minor
+'@eventuras/event-sdk': minor
+---
+
+`GET /v3/business-events` accepts `eventInfoUuid` as an alternative to `subjectType` + `subjectUuid`, returning everything recorded on one event — the event itself, its registrations and their orders — newest first. The event is resolved from the domain tables, so nothing new is stored on the audit records and history is covered. Exactly one selector is required.

--- a/apps/api/docs/eventuras-v3.json
+++ b/apps/api/docs/eventuras-v3.json
@@ -4579,13 +4579,13 @@
         "tags": [
           "BusinessEvents"
         ],
-        "summary": "List business events for a subject in the current organization",
-        "description": "Returns audit/business events scoped to the organization resolved from the Eventuras-Org-Id header, filtered by subjectType + subjectUuid (e.g. order + OrderUuid). Newest first. Requires the caller to be SystemAdmin or an Admin member of the resolved organization.",
+        "summary": "List business events for a subject or an event in the current organization",
+        "description": "Returns audit/business events scoped to the current organization (resolved from the Eventuras-Org-Id header, else the orgId query parameter, else the request hostname), filtered by subjectType + subjectUuid (e.g. order + OrderUuid), or by eventInfoUuid for everything recorded on one event (the event itself, its registrations and their orders). Newest first. Requires the caller to be SystemAdmin or an Admin member of the resolved organization.",
         "parameters": [
           {
             "name": "SubjectType",
             "in": "query",
-            "description": "Subject type to filter on. Free-form string matching the values produced\nby `BusinessEventSubjects.For*` factories (e.g. \"order\", \"registration\", \"user\").",
+            "description": "Subject type to filter on. Free-form string matching the values produced\nby `BusinessEventSubjects.For*` factories (e.g. \"order\", \"registration\", \"user\").\nPair with SubjectUuid.",
             "schema": {
               "type": "string"
             }
@@ -4593,7 +4593,16 @@
           {
             "name": "SubjectUuid",
             "in": "query",
-            "description": "The subject entity's Uuid.",
+            "description": "The subject entity's Uuid. Pair with SubjectType.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "EventInfoUuid",
+            "in": "query",
+            "description": "The event (EventInfo) Uuid: returns every business event recorded on that\nevent — the event itself, its registrations and their orders — instead of one subject.",
             "schema": {
               "type": "string",
               "format": "uuid"

--- a/apps/api/src/Eventuras.Domain/BusinessEventSubject.cs
+++ b/apps/api/src/Eventuras.Domain/BusinessEventSubject.cs
@@ -8,15 +8,20 @@ public sealed record BusinessEventSubject(
 
 public static class BusinessEventSubjects
 {
+    public const string OrderType = "order";
+    public const string RegistrationType = "registration";
+    public const string EventType = "event";
+    public const string UserType = "user";
+
     public static BusinessEventSubject ForOrder(Guid orderId) =>
-        new("order", orderId);
+        new(OrderType, orderId);
 
     public static BusinessEventSubject ForRegistration(Guid registrationId) =>
-        new("registration", registrationId);
+        new(RegistrationType, registrationId);
 
     public static BusinessEventSubject ForEvent(Guid eventInfoUuid) =>
-        new("event", eventInfoUuid);
+        new(EventType, eventInfoUuid);
 
     public static BusinessEventSubject ForUser(Guid userId) =>
-        new("user", userId);
+        new(UserType, userId);
 }

--- a/apps/api/src/Eventuras.Services/BusinessEvents/BusinessEventService.cs
+++ b/apps/api/src/Eventuras.Services/BusinessEvents/BusinessEventService.cs
@@ -72,10 +72,43 @@ public class BusinessEventService : IBusinessEventService
             .Where(e =>
                 e.OrganizationUuid == organizationUuid &&
                 e.SubjectType == subject.Type &&
-                e.SubjectUuid == subject.Uuid)
+                e.SubjectUuid == subject.Uuid);
+
+        return await Paging.CreateAsync(NewestFirst(query), request, cancellationToken);
+    }
+
+    public async Task<Paging<BusinessEvent>> ListEventsForEventAsync(
+        Guid organizationUuid,
+        Guid eventInfoUuid,
+        PagingRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        await _accessControl.CheckListAccessAsync(organizationUuid, cancellationToken);
+
+        // Subjects that belong to the event, resolved as subqueries (IN (...)) so the
+        // audit table needs no event column of its own.
+        var registrationUuids = _dbContext.Registrations
+            .Where(r => r.EventInfo.Uuid == eventInfoUuid)
+            .Select(r => r.Uuid);
+        var orderUuids = _dbContext.Orders
+            .Where(o => o.Registration.EventInfo.Uuid == eventInfoUuid)
+            .Select(o => o.Uuid);
+
+        var query = _dbContext.BusinessEvents
+            .AsNoTracking()
+            .Where(e =>
+                e.OrganizationUuid == organizationUuid &&
+                ((e.SubjectType == BusinessEventSubjects.EventType && e.SubjectUuid == eventInfoUuid) ||
+                 (e.SubjectType == BusinessEventSubjects.RegistrationType && registrationUuids.Contains(e.SubjectUuid)) ||
+                 (e.SubjectType == BusinessEventSubjects.OrderType && orderUuids.Contains(e.SubjectUuid))));
+
+        return await Paging.CreateAsync(NewestFirst(query), request, cancellationToken);
+    }
+
+    private static IOrderedQueryable<BusinessEvent> NewestFirst(IQueryable<BusinessEvent> query) =>
+        query
             .OrderByDescending(e => e.CreatedAt)
             .ThenByDescending(e => e.Uuid);
-
-        return await Paging.CreateAsync(query, request, cancellationToken);
-    }
 }

--- a/apps/api/src/Eventuras.Services/BusinessEvents/IBusinessEventService.cs
+++ b/apps/api/src/Eventuras.Services/BusinessEvents/IBusinessEventService.cs
@@ -23,4 +23,15 @@ public interface IBusinessEventService
         BusinessEventSubject subject,
         PagingRequest request,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    ///     Every event recorded on an EventInfo, across subjects: the event itself, its
+    ///     registrations and their orders. Resolved from the domain tables, so nothing
+    ///     extra is stored on the records. Newest first.
+    /// </summary>
+    Task<Paging<BusinessEvent>> ListEventsForEventAsync(
+        Guid organizationUuid,
+        Guid eventInfoUuid,
+        PagingRequest request,
+        CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/BusinessEvents/BusinessEventsController.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/BusinessEvents/BusinessEventsController.cs
@@ -32,8 +32,8 @@ public class BusinessEventsController : ControllerBase
     }
 
     [HttpGet]
-    [EndpointSummary("List business events for a subject in the current organization")]
-    [EndpointDescription("Returns audit/business events scoped to the organization resolved from the Eventuras-Org-Id header, filtered by subjectType + subjectUuid (e.g. order + OrderUuid). Newest first. Requires the caller to be SystemAdmin or an Admin member of the resolved organization.")]
+    [EndpointSummary("List business events for a subject or an event in the current organization")]
+    [EndpointDescription("Returns audit/business events scoped to the current organization (resolved from the Eventuras-Org-Id header, else the orgId query parameter, else the request hostname), filtered by subjectType + subjectUuid (e.g. order + OrderUuid), or by eventInfoUuid for everything recorded on one event (the event itself, its registrations and their orders). Newest first. Requires the caller to be SystemAdmin or an Admin member of the resolved organization.")]
     [ProducesResponseType(typeof(PageResponseDto<BusinessEventDto>), 200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(403)]
@@ -49,14 +49,21 @@ public class BusinessEventsController : ControllerBase
         var currentOrg = await _currentOrganizationAccessor.RequireCurrentOrganizationAsync(
             cancellationToken: cancellationToken);
 
-        // Org-membership enforcement (SystemAdmin bypass, Admin must be member)
-        // lives inside BusinessEventService.ListEventsAsync — the service throws
-        // NotAccessibleException which the exception filter maps to HTTP 403.
-        var events = await _businessEventService.ListEventsAsync(
-            currentOrg.Uuid,
-            new BusinessEventSubject(query.SubjectType, query.SubjectUuid),
-            new PagingRequest(query.Offset, query.Limit),
-            cancellationToken);
+        // Org-membership enforcement (SystemAdmin bypass, Admin must be member) lives in
+        // the service: both list methods call CheckListAccessAsync, which throws
+        // NotAccessibleException that the exception filter maps to HTTP 403.
+        var paging = new PagingRequest(query.Offset, query.Limit);
+        var events = query.HasSubject
+            ? await _businessEventService.ListEventsAsync(
+                currentOrg.Uuid,
+                new BusinessEventSubject(query.SubjectType!, query.SubjectUuid!.Value),
+                paging,
+                cancellationToken)
+            : await _businessEventService.ListEventsForEventAsync(
+                currentOrg.Uuid,
+                query.EventInfoUuid!.Value,
+                paging,
+                cancellationToken);
 
         return PageResponseDto<BusinessEventDto>.FromPaging(query, events, e => new BusinessEventDto(e));
     }

--- a/apps/api/src/Eventuras.WebApi/Controllers/v3/BusinessEvents/BusinessEventsQueryDto.cs
+++ b/apps/api/src/Eventuras.WebApi/Controllers/v3/BusinessEvents/BusinessEventsQueryDto.cs
@@ -1,21 +1,53 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Eventuras.WebApi.Models;
 
 namespace Eventuras.WebApi.Controllers.v3.BusinessEvents;
 
-public class BusinessEventsQueryDto : PageQueryDto
+/// <summary>
+///     Lists business events either for one subject (<see cref="SubjectType" /> +
+///     <see cref="SubjectUuid" />) or for everything recorded under one event
+///     (<see cref="EventInfoUuid" />). Exactly one of the two selectors is required.
+/// </summary>
+public class BusinessEventsQueryDto : PageQueryDto, IValidatableObject
 {
     /// <summary>
     ///     Subject type to filter on. Free-form string matching the values produced
     ///     by <c>BusinessEventSubjects.For*</c> factories (e.g. "order", "registration", "user").
+    ///     Pair with <see cref="SubjectUuid" />.
     /// </summary>
-    [Required]
-    public string SubjectType { get; set; } = string.Empty;
+    public string? SubjectType { get; set; }
 
-    /// <summary>The subject entity's Uuid.</summary>
-    [Required]
-    public Guid SubjectUuid { get; set; }
+    /// <summary>The subject entity's Uuid. Pair with <see cref="SubjectType" />.</summary>
+    public Guid? SubjectUuid { get; set; }
+
+    /// <summary>
+    ///     The event (EventInfo) Uuid: returns every business event recorded on that
+    ///     event — the event itself, its registrations and their orders — instead of one subject.
+    /// </summary>
+    public Guid? EventInfoUuid { get; set; }
+
+    public bool HasSubject => !string.IsNullOrWhiteSpace(SubjectType) && SubjectUuid.HasValue;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var hasSubjectPart = !string.IsNullOrWhiteSpace(SubjectType) || SubjectUuid.HasValue;
+
+        if (hasSubjectPart && !HasSubject)
+        {
+            yield return new ValidationResult(
+                "subjectType and subjectUuid must be given together.",
+                [nameof(SubjectType), nameof(SubjectUuid)]);
+        }
+
+        if (HasSubject == EventInfoUuid.HasValue)
+        {
+            yield return new ValidationResult(
+                "Specify either subjectType + subjectUuid or eventInfoUuid.",
+                [nameof(SubjectType), nameof(SubjectUuid), nameof(EventInfoUuid)]);
+        }
+    }
 }

--- a/apps/api/tests/Eventuras.Services.Tests/BusinessEvents/BusinessEventServiceTests.cs
+++ b/apps/api/tests/Eventuras.Services.Tests/BusinessEvents/BusinessEventServiceTests.cs
@@ -189,4 +189,53 @@ public class BusinessEventServiceTests
             new[] { "order.invoice.created", "order.status.changed" },
             result.Data.Select(e => e.EventType).ToArray());
     }
+
+    [Fact]
+    public async Task ListEventsForEventAsync_Returns_Events_Across_Subjects_For_The_Event()
+    {
+        using var db = CreateDbContext();
+        var service = CreateService(db);
+        var organizationUuid = Guid.NewGuid();
+
+        var eventInfo = new EventInfo { EventInfoId = 1, OrganizationId = 1, Title = "Mine", Slug = "mine" };
+        var otherEvent = new EventInfo { EventInfoId = 2, OrganizationId = 1, Title = "Other", Slug = "other" };
+        var registration = new Registration { RegistrationId = 1, EventInfoId = 1 };
+        var otherRegistration = new Registration { RegistrationId = 2, EventInfoId = 2 };
+        var order = new Order { OrderId = 1, RegistrationId = 1 };
+        var otherOrder = new Order { OrderId = 2, RegistrationId = 2 };
+        db.EventInfos.AddRange(eventInfo, otherEvent);
+        db.Registrations.AddRange(registration, otherRegistration);
+        db.Orders.AddRange(order, otherOrder);
+
+        BusinessEvent Row(Instant at, string message, BusinessEventSubject subject, Guid? org = null) => new()
+        {
+            CreatedAt = at,
+            EventType = subject.Type + ".status.changed",
+            Message = message,
+            SubjectType = subject.Type,
+            SubjectUuid = subject.Uuid,
+            OrganizationUuid = org ?? organizationUuid
+        };
+
+        db.BusinessEvents.AddRange(
+            Row(Instant.FromUtc(2026, 4, 19, 10, 0), "Registration on the event", BusinessEventSubjects.ForRegistration(registration.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 11, 0), "Order on the event", BusinessEventSubjects.ForOrder(order.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 12, 0), "The event itself", BusinessEventSubjects.ForEvent(eventInfo.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 13, 0), "Other event's registration", BusinessEventSubjects.ForRegistration(otherRegistration.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 14, 0), "Other event's order", BusinessEventSubjects.ForOrder(otherOrder.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 15, 0), "Other event itself", BusinessEventSubjects.ForEvent(otherEvent.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 16, 0), "Same event, other org", BusinessEventSubjects.ForRegistration(registration.Uuid), Guid.NewGuid()),
+            Row(Instant.FromUtc(2026, 4, 19, 17, 0), "Unrelated user", BusinessEventSubjects.ForUser(Guid.NewGuid())));
+        await db.SaveChangesAsync();
+
+        var result = await service.ListEventsForEventAsync(
+            organizationUuid,
+            eventInfo.Uuid,
+            new PagingRequest(offset: 0, limit: 10));
+
+        Assert.Equal(3, result.TotalRecords);
+        Assert.Equal(
+            new[] { "The event itself", "Order on the event", "Registration on the event" },
+            result.Data.Select(e => e.Message).ToArray());
+    }
 }

--- a/apps/api/tests/Eventuras.WebApi.Tests/Controllers/BusinessEvents/BusinessEventsControllerTest.cs
+++ b/apps/api/tests/Eventuras.WebApi.Tests/Controllers/BusinessEvents/BusinessEventsControllerTest.cs
@@ -156,6 +156,63 @@ public class BusinessEventsControllerTest : IClassFixture<CustomWebApiApplicatio
     }
 
     [Fact]
+    public async Task List_Should_Return_Events_For_An_Event_Across_Subjects()
+    {
+        using var scope = _factory.Services.NewTestScope();
+        using var org = await scope.CreateOrganizationAsync();
+        using var user = await scope.CreateUserAsync();
+        using var eventInfo = await scope.CreateEventAsync(organization: org.Entity);
+        using var otherEvent = await scope.CreateEventAsync(organization: org.Entity);
+        using var registration = await scope.CreateRegistrationAsync(eventInfo.Entity, user.Entity);
+        using var otherRegistration = await scope.CreateRegistrationAsync(otherEvent.Entity, user.Entity);
+        using var order = await scope.CreateOrderAsync(registration.Entity, user: user.Entity);
+
+        BusinessEvent Row(Instant at, string message, BusinessEventSubject subject) => new()
+        {
+            CreatedAt = at,
+            EventType = subject.Type + ".status.changed",
+            Message = message,
+            SubjectType = subject.Type,
+            SubjectUuid = subject.Uuid,
+            OrganizationUuid = org.Entity.Uuid
+        };
+
+        scope.Db.BusinessEvents.AddRange(
+            Row(Instant.FromUtc(2026, 4, 19, 10, 0), "Registration", BusinessEventSubjects.ForRegistration(registration.Entity.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 11, 0), "Order", BusinessEventSubjects.ForOrder(order.Entity.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 12, 0), "Event", BusinessEventSubjects.ForEvent(eventInfo.Entity.Uuid)),
+            Row(Instant.FromUtc(2026, 4, 19, 13, 0), "Other event", BusinessEventSubjects.ForRegistration(otherRegistration.Entity.Uuid)));
+        await scope.Db.SaveChangesAsync();
+
+        var client = _factory.CreateClient().AuthenticatedAsSystemAdmin();
+
+        var response = await client.GetAsync(
+            $"/v3/business-events?orgId={org.Entity.OrganizationId}&eventInfoUuid={eventInfo.Entity.Uuid}");
+
+        var body = await response.CheckOk().Content.ReadFromJsonAsync<PageResponseDto<BusinessEventDto>>(JsonOptions);
+        Assert.NotNull(body);
+        Assert.Equal(3, body!.Total);
+        Assert.Equal(new[] { "Event", "Order", "Registration" }, body.Data.Select(e => e.Message).ToArray());
+    }
+
+    [Theory]
+    [InlineData("subjectType=order")]
+    [InlineData("subjectUuid=7d5c0a5e-0000-4000-8000-000000000001")]
+    [InlineData("subjectType=order&subjectUuid=7d5c0a5e-0000-4000-8000-000000000001&eventInfoUuid=7d5c0a5e-0000-4000-8000-000000000002")]
+    public async Task List_Should_Reject_Incomplete_Or_Mixed_Selectors(string selectors)
+    {
+        using var scope = _factory.Services.NewTestScope();
+        using var org = await scope.CreateOrganizationAsync();
+
+        var client = _factory.CreateClient().AuthenticatedAsSystemAdmin();
+
+        var response = await client.GetAsync(
+            $"/v3/business-events?orgId={org.Entity.OrganizationId}&{selectors}");
+
+        Assert.Equal(System.Net.HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
     public async Task List_Should_Require_Subject_Parameters()
     {
         using var scope = _factory.Services.NewTestScope();

--- a/libs/event-sdk/src/client-next/sdk.gen.ts
+++ b/libs/event-sdk/src/client-next/sdk.gen.ts
@@ -407,8 +407,8 @@ export const putV3EventsByEventIdCollectionsByCollectionId = <ThrowOnError exten
 export const getV3CertificatesById = <ThrowOnError extends boolean = false>(options: Options<GetV3CertificatesByIdData, ThrowOnError>): RequestResult<GetV3CertificatesByIdResponses, unknown, ThrowOnError> => (options.client ?? client).get<GetV3CertificatesByIdResponses, unknown, ThrowOnError>({ url: '/v3/certificates/{id}', ...options });
 
 /**
- * List business events for a subject in the current organization
+ * List business events for a subject or an event in the current organization
  *
- * Returns audit/business events scoped to the organization resolved from the Eventuras-Org-Id header, filtered by subjectType + subjectUuid (e.g. order + OrderUuid). Newest first. Requires the caller to be SystemAdmin or an Admin member of the resolved organization.
+ * Returns audit/business events scoped to the current organization (resolved from the Eventuras-Org-Id header, else the orgId query parameter, else the request hostname), filtered by subjectType + subjectUuid (e.g. order + OrderUuid), or by eventInfoUuid for everything recorded on one event (the event itself, its registrations and their orders). Newest first. Requires the caller to be SystemAdmin or an Admin member of the resolved organization.
  */
 export const getV3BusinessEvents = <ThrowOnError extends boolean = false>(options?: Options<GetV3BusinessEventsData, ThrowOnError>): RequestResult<GetV3BusinessEventsResponses, GetV3BusinessEventsErrors, ThrowOnError> => (options?.client ?? client).get<GetV3BusinessEventsResponses, GetV3BusinessEventsErrors, ThrowOnError>({ url: '/v3/business-events', ...options });

--- a/libs/event-sdk/src/client-next/types.gen.ts
+++ b/libs/event-sdk/src/client-next/types.gen.ts
@@ -2739,12 +2739,18 @@ export type GetV3BusinessEventsData = {
         /**
          * Subject type to filter on. Free-form string matching the values produced
          * by `BusinessEventSubjects.For*` factories (e.g. "order", "registration", "user").
+         * Pair with SubjectUuid.
          */
         SubjectType?: string;
         /**
-         * The subject entity's Uuid.
+         * The subject entity's Uuid. Pair with SubjectType.
          */
         SubjectUuid?: string;
+        /**
+         * The event (EventInfo) Uuid: returns every business event recorded on that
+         * event — the event itself, its registrations and their orders — instead of one subject.
+         */
+        EventInfoUuid?: string;
         Page?: number;
         Count?: number;
         Limit?: number;


### PR DESCRIPTION
## Summary

Second backend step for the admin activity drawer (after #1831). Business events were addressed by subject only, so "everything that happened on this event" could not be asked for in one call.

- **API:** `GET /v3/business-events` accepts `eventInfoUuid` as an alternative to `subjectType` + `subjectUuid`, returning the event's own records plus those of its registrations and their orders, newest first. The query DTO validates that exactly one selector is given and the subject pair is complete. `BusinessEventDto` is unchanged.
- **Service:** `ListEventsForEventAsync(org, eventInfoUuid, paging)` resolves the event from the domain tables with `IN (...)` subqueries (registrations by `EventInfo.Uuid`, orders via their registration) — no schema change, no new column, and history is covered. The existing `ListEventsAsync` is untouched.
- `BusinessEventSubjects` gets named type constants (`EventType`, `RegistrationType`, `OrderType`, `UserType`) instead of repeating the strings.
- **Spec/SDK:** OpenAPI spec updated by hand (parameter + descriptions); event-sdk regenerated; `apps/web` typechecks.

_Reworked from an earlier version of this PR that stored an `EventInfoUuid` column on `BusinessEvent` with a migration and touched every `AddEvent` call site — dropped in favour of resolving the event at query time. The column can come later if deleted subjects or query cost make it worth it._

## Tests

- New: service test with real `EventInfo`/`Registration`/`Order` rows (other event, other org and an unrelated `user` event excluded; newest first); controller test built with the `Create*Async` helpers; a `Theory` rejecting incomplete or mixed selectors.
- `BusinessEventServiceTests`: 11 passed. `BusinessEventsControllerTest` + `MigrationsScriptTests`: 12 passed.
- `dotnet format --verify-no-changes` clean on the changed files.

## Test plan

- [ ] Change a registration status on an event → `GET /v3/business-events?eventInfoUuid={event.uuid}` returns it alongside the event's own status changes and its orders' events
- [ ] `?subjectType=order&subjectUuid=…` still works as before
- [ ] `?subjectType=order` alone, or subject + `eventInfoUuid` together → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)
