### PR TITLE
feat(web): activity drawer for the pinned event

### DIFF
--- a/.changeset/admin-activity-drawer.md
+++ b/.changeset/admin-activity-drawer.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': minor
+---
+
+The event admin gets an activity drawer: every business event recorded on the pinned event — the event itself, its registrations and their orders — in a drawer that overlays whichever section you are on, opened from the sidebar's "Aktivitet" button or from the overview. Filter by all/event/registration/order, refresh on demand (no live push yet). The overview's "latest notifications" card becomes "latest activity", showing the four newest records with a link into the drawer.

--- a/apps/web/locales/en-US/admin.json
+++ b/apps/web/locales/en-US/admin.json
@@ -1,7 +1,16 @@
 {
   "businessEvents": {
     "empty": "No activity logged yet.",
+    "filterLabel": "Filter activity",
+    "filters": {
+      "all": "All",
+      "event": "Event",
+      "order": "Order",
+      "registration": "Registration"
+    },
     "loadError": "Unable to load activity right now. Please try again later.",
+    "noEvent": "Open an event to see its activity.",
+    "refresh": "Refresh",
     "title": "Activity"
   },
   "certificates": {
@@ -112,7 +121,7 @@
     "overview": {
       "days": "{count, plural, one {# day} other {# days}}",
       "draftOrders": "{count} draft orders",
-      "latestNotifications": "Latest notifications",
+      "latestActivity": "Latest activity",
       "latestRegistrations": "Latest registrations",
       "noDate": "Date not set",
       "noLocation": "Location not set",
@@ -120,6 +129,7 @@
       "registered": "Registered",
       "revenue": "Revenue",
       "seeAll": "See all ({count})",
+      "showAll": "Show all",
       "waitingList": "{count} on the waiting list",
       "when": "When",
       "where": "Where"

--- a/apps/web/locales/nb-NO/admin.json
+++ b/apps/web/locales/nb-NO/admin.json
@@ -1,7 +1,16 @@
 {
   "businessEvents": {
     "empty": "Ingen aktivitet registrert ennå.",
+    "filterLabel": "Filtrer aktivitet",
+    "filters": {
+      "all": "Alle",
+      "event": "Arrangement",
+      "order": "Ordre",
+      "registration": "Påmelding"
+    },
     "loadError": "Kunne ikke laste aktivitetsloggen akkurat nå. Prøv igjen senere.",
+    "noEvent": "Åpne et arrangement for å se aktiviteten.",
+    "refresh": "Oppdater",
     "title": "Aktivitet"
   },
   "certificates": {
@@ -112,7 +121,7 @@
     "overview": {
       "days": "{count, plural, one {# dag} other {# dager}}",
       "draftOrders": "{count} ordre i utkast",
-      "latestNotifications": "Siste meldinger",
+      "latestActivity": "Siste aktivitet",
       "latestRegistrations": "Siste påmeldte",
       "noDate": "Dato ikke satt",
       "noLocation": "Sted ikke satt",
@@ -120,6 +129,7 @@
       "registered": "Påmeldte",
       "revenue": "Omsetning",
       "seeAll": "Se alle ({count})",
+      "showAll": "Vis alt",
       "waitingList": "{count} på venteliste",
       "when": "Når",
       "where": "Sted"

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventAdminSections.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventAdminSections.tsx
@@ -23,6 +23,7 @@ import {
   sectionForTab,
 } from '@/components/admin/shell';
 import {
+  BusinessEventDto,
   EventDto,
   EventFormDto,
   EventStatisticsDto,
@@ -156,6 +157,7 @@ type EventAdminSectionsProps = {
   statistics: EventStatisticsDto;
   eventProducts: ProductDto[];
   notifications: NotificationDto[];
+  activity: BusinessEventDto[];
   organizationId: number;
   defaultTab?: EventAdminTab;
 };
@@ -171,6 +173,7 @@ export default function EventAdminSections({
   statistics,
   eventProducts,
   notifications,
+  activity,
   organizationId,
   defaultTab = DEFAULT_EVENT_ADMIN_TAB,
 }: Readonly<EventAdminSectionsProps>) {
@@ -269,7 +272,7 @@ export default function EventAdminSections({
             eventinfo={eventinfo}
             participants={participants}
             statistics={statistics}
-            notifications={notifications}
+            activity={activity}
           />
         );
       case 'participants':

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventDashboardSection.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventDashboardSection.tsx
@@ -4,8 +4,9 @@ import { useMemo } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
 
 import { formatPrice } from '@eventuras/core/currency';
-import { formatDate, formatDateSpan } from '@eventuras/core/datetime';
+import { formatDateSpan } from '@eventuras/core/datetime';
 import { Badge } from '@eventuras/ratio-ui/core/Badge';
+import { Button } from '@eventuras/ratio-ui/core/Button';
 import { Card } from '@eventuras/ratio-ui/core/Card';
 import { Text } from '@eventuras/ratio-ui/core/Text';
 import { ValueTile } from '@eventuras/ratio-ui/core/ValueTile';
@@ -13,11 +14,12 @@ import { Grid } from '@eventuras/ratio-ui/layout/Grid';
 import { Stack } from '@eventuras/ratio-ui/layout/Stack';
 import { Link } from '@eventuras/ratio-ui-next/Link';
 
+import { ActivityTimeline, useActivityDrawer } from '@/components/admin/activity';
 import { eventAdminHref } from '@/components/admin/shell';
 import {
+  BusinessEventDto,
   EventDto,
   EventStatisticsDto,
-  NotificationDto,
   RegistrationDto,
 } from '@/lib/eventuras-sdk';
 
@@ -29,13 +31,13 @@ import {
 } from '../../registrations/Registration';
 
 const LATEST_REGISTRATIONS = 5;
-const LATEST_NOTIFICATIONS = 4;
 
 type EventDashboardSectionProps = {
   eventinfo: EventDto;
   participants: RegistrationDto[];
   statistics: EventStatisticsDto;
-  notifications: NotificationDto[];
+  /** Newest business events on the event, already limited server-side. */
+  activity: BusinessEventDto[];
 };
 
 /** Whole days from start to end, inclusive; undefined when either date is missing or unparsable. */
@@ -75,8 +77,9 @@ function KeyFact({
 function ListHeading({
   title,
   href,
+  onClick,
   linkLabel,
-}: Readonly<{ title: string; href: string; linkLabel: string }>) {
+}: Readonly<{ title: string; href?: string; onClick?: () => void; linkLabel: string }>) {
   return (
     <div className="flex items-center gap-3">
       <Text
@@ -89,25 +92,32 @@ function ListHeading({
       >
         {title}
       </Text>
-      <Link href={href} className="ml-auto text-sm">
-        {linkLabel}
-      </Link>
+      {href ? (
+        <Link href={href} className="ml-auto text-sm">
+          {linkLabel}
+        </Link>
+      ) : (
+        <Button variant="text" size="sm" className="ml-auto" onClick={onClick}>
+          {linkLabel}
+        </Button>
+      )}
     </div>
   );
 }
 
 /**
  * The event's landing section: key facts, the latest registrations and the
- * latest notifications, each linking on to its full section.
+ * latest activity; the lists link on to the full section or the activity drawer.
  */
 export default function EventDashboardSection({
   eventinfo,
   participants,
   statistics,
-  notifications,
+  activity,
 }: Readonly<EventDashboardSectionProps>) {
   const t = useTranslations();
   const locale = useLocale();
+  const activityDrawer = useActivityDrawer();
   const eventId = eventinfo.id!;
 
   const byStatus = statistics.byStatus;
@@ -130,13 +140,6 @@ export default function EventDashboardSection({
         .sort((a, b) => (b.registrationTime ?? '').localeCompare(a.registrationTime ?? ''))
         .slice(0, LATEST_REGISTRATIONS),
     [participants]
-  );
-  const latestNotifications = useMemo(
-    () =>
-      [...notifications]
-        .sort((a, b) => (b.created ?? '').localeCompare(a.created ?? ''))
-        .slice(0, LATEST_NOTIFICATIONS),
-    [notifications]
   );
 
   const days = durationInDays(eventinfo.dateStart, eventinfo.dateEnd);
@@ -231,35 +234,12 @@ export default function EventDashboardSection({
 
         <Stack gap="sm">
           <ListHeading
-            title={t('admin.events.overview.latestNotifications')}
-            href={eventAdminHref(eventId, 'communication')}
-            linkLabel={t('admin.events.overview.seeAll', { count: notifications.length })}
+            title={t('admin.events.overview.latestActivity')}
+            onClick={activityDrawer.open}
+            linkLabel={t('admin.events.overview.showAll')}
           />
-          <Card border transparent padding="none" testId="dashboard-latest-notifications">
-            {latestNotifications.length === 0 ? (
-              <Text as="p" size="sm" variant="subtle" padding="md">
-                {t('admin.notifications.noNotifications')}
-              </Text>
-            ) : (
-              <ul className="divide-y divide-border-1">
-                {latestNotifications.map(notification => (
-                  <li key={notification.notificationId} className="flex flex-col gap-1 px-4 py-3">
-                    <span className="flex items-center gap-2 font-mono text-xs text-(--text-subtle)">
-                      <span>
-                        {notification.created
-                          ? formatDate(notification.created, { locale, showTime: true })
-                          : ''}
-                      </span>
-                      <span className="text-(--text)">{notification.type}</span>
-                      <span className="ml-auto">{notification.status}</span>
-                    </span>
-                    <span className="line-clamp-2 text-sm text-(--text-muted)">
-                      {notification.message}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            )}
+          <Card border transparent testId="dashboard-latest-activity">
+            <ActivityTimeline events={activity} />
           </Card>
         </Stack>
       </Grid>

--- a/apps/web/src/app/(admin)/admin/events/[id]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/page.tsx
@@ -5,6 +5,7 @@ import { ErrorBlock } from '@eventuras/ratio-ui/blocks/Error';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 
+import { fetchEventActivity } from '@/components/admin/activity/activityActions';
 import { DEFAULT_EVENT_ADMIN_TAB, type EventAdminTab, PinEvent } from '@/components/admin/shell';
 import {
   getV3EventsByEventIdProducts,
@@ -109,6 +110,13 @@ export default async function EventAdminPage({ params, searchParams }: Readonly<
     );
   }
 
+  // The overview shows the newest activity; the drawer loads the full log on demand.
+  const activityRes = eventinfo.uuid ? await fetchEventActivity(eventinfo.uuid, 4) : undefined;
+  if (activityRes && !activityRes.success) {
+    logger.warn({ eventId: id, error: activityRes.error }, 'Failed to load event activity');
+  }
+  const activity = activityRes?.success ? activityRes.data : [];
+
   // Extract notifications data
   const notificationData = notificationsRes?.data as NotificationListResponse | undefined;
   const notifications = notificationData?.data || [];
@@ -133,6 +141,7 @@ export default async function EventAdminPage({ params, searchParams }: Readonly<
           event={{
             id: eventinfo.id!,
             title: eventinfo.title ?? '',
+            uuid: eventinfo.uuid,
             participantCount: registrations?.length,
           }}
         />
@@ -163,6 +172,7 @@ export default async function EventAdminPage({ params, searchParams }: Readonly<
           statistics={statisticsRes.data ?? {}}
           eventProducts={eventProductsRes.data ?? []}
           notifications={notifications}
+          activity={activity}
           organizationId={organizationId ?? 0}
           defaultTab={defaultTab}
         />

--- a/apps/web/src/components/admin/BusinessEventsTimeline.tsx
+++ b/apps/web/src/components/admin/BusinessEventsTimeline.tsx
@@ -9,6 +9,8 @@ import { client } from '@/lib/eventuras-client';
 import { BusinessEventDto, getV3BusinessEvents } from '@/lib/eventuras-sdk';
 import { getOrganizationId } from '@/utils/organization';
 
+import { statusForEventType } from './activity/businessEventPresentation';
+
 const logger = Logger.create({
   namespace: 'web:admin:business-events',
   context: { component: 'BusinessEventsTimeline' },
@@ -91,15 +93,6 @@ function formatTimestamp(instant: string | undefined): string {
   const date = new Date(instant);
   if (Number.isNaN(date.getTime())) return instant;
   return date.toLocaleString();
-}
-
-function statusForEventType(eventType: string | undefined) {
-  if (!eventType) return 'neutral' as const;
-  if (eventType.endsWith('.cancelled') || eventType.endsWith('.refunded'))
-    return 'warning' as const;
-  if (eventType.endsWith('.verified') || eventType.endsWith('.created')) return 'success' as const;
-  if (eventType.endsWith('.invoiced')) return 'info' as const;
-  return 'neutral' as const;
 }
 
 function ActorLabel({ uuid }: { uuid: string }) {

--- a/apps/web/src/components/admin/activity/ActivityDrawer.tsx
+++ b/apps/web/src/components/admin/activity/ActivityDrawer.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import type { ServerActionResult } from '@eventuras/core-nextjs/actions';
+import { Button } from '@eventuras/ratio-ui/core/Button';
+import { Loading } from '@eventuras/ratio-ui/core/Loading';
+import { Text } from '@eventuras/ratio-ui/core/Text';
+import { ToggleButtonGroup } from '@eventuras/ratio-ui/core/ToggleButtonGroup';
+import { Drawer } from '@eventuras/ratio-ui/layout/Drawer';
+import { Stack } from '@eventuras/ratio-ui/layout/Stack';
+
+import type { BusinessEventDto } from '@/lib/eventuras-sdk';
+
+import { fetchEventActivity } from './activityActions';
+import { useActivityDrawer } from './ActivityDrawerProvider';
+import { ActivityTimeline } from './ActivityTimeline';
+import {
+  ACTIVITY_SUBJECTS,
+  type ActivityFilter,
+  matchesActivityFilter,
+} from './businessEventPresentation';
+import { usePinnedEvent } from '../shell/PinnedEvent';
+
+type LoadResult = { key: string; events?: BusinessEventDto[]; error?: string };
+
+type ActivityDrawerProps = {
+  /** Data source; defaults to the server action. Swappable for previews and tests. */
+  loader?: (eventUuid: string) => Promise<ServerActionResult<BusinessEventDto[]>>;
+};
+
+/**
+ * The pinned event's activity log — every business event on the event, its
+ * registrations and orders — in a drawer that overlays whatever section the
+ * admin is on. Loads when opened; "refresh" reloads (no live push yet).
+ */
+export function ActivityDrawer({
+  loader = fetchEventActivity,
+}: Readonly<ActivityDrawerProps> = {}) {
+  const t = useTranslations();
+  const { event } = usePinnedEvent();
+  const { isOpen, close } = useActivityDrawer();
+  const [filter, setFilter] = useState<ActivityFilter>('all');
+  const [reload, setReload] = useState(0);
+  const [result, setResult] = useState<LoadResult | null>(null);
+
+  const uuid = event?.uuid;
+  const key = `${uuid}:${reload}`;
+  const current = result?.key === key ? result : null;
+  const loading = isOpen && !!uuid && !current;
+
+  useEffect(() => {
+    if (!isOpen || !uuid) return;
+    let cancelled = false;
+    loader(uuid)
+      .then(response => {
+        if (cancelled) return;
+        setResult(
+          response.success ? { key, events: response.data } : { key, error: response.error.message }
+        );
+      })
+      .catch((error: unknown) => {
+        if (!cancelled)
+          setResult({ key, error: error instanceof Error ? error.message : String(error) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, uuid, key, loader]);
+
+  const visible = (current?.events ?? []).filter(e => matchesActivityFilter(e, filter));
+
+  return (
+    <Drawer isOpen={isOpen} onClose={close} side="right">
+      <Drawer.Header as="h2">{t('admin.businessEvents.title')}</Drawer.Header>
+      <Drawer.Body>
+        <Stack gap="md">
+          {event && (
+            <Text as="p" family="mono" size="sm" variant="subtle" marginBottom="none">
+              {event.title}
+            </Text>
+          )}
+          <div className="flex flex-wrap items-center gap-3">
+            <ToggleButtonGroup
+              aria-label={t('admin.businessEvents.filterLabel')}
+              size="sm"
+              selectedKeys={[filter]}
+              disallowEmptySelection
+              onSelectionChange={keys => setFilter(([...keys][0] as ActivityFilter) ?? 'all')}
+              options={[
+                { value: 'all', label: t('admin.businessEvents.filters.all') },
+                ...ACTIVITY_SUBJECTS.map(subject => ({
+                  value: subject,
+                  label: t(`admin.businessEvents.filters.${subject}`),
+                })),
+              ]}
+              testId="activity-filter"
+            />
+            <Button
+              variant="text"
+              size="sm"
+              className="ml-auto"
+              loading={loading}
+              onClick={() => setReload(n => n + 1)}
+              testId="activity-refresh"
+            >
+              {t('admin.businessEvents.refresh')}
+            </Button>
+          </div>
+          {!uuid ? (
+            <Text as="p" size="sm" variant="subtle">
+              {t('admin.businessEvents.noEvent')}
+            </Text>
+          ) : loading ? (
+            <Loading />
+          ) : current?.error ? (
+            <Text as="p" size="sm" color="error">
+              {t('admin.businessEvents.loadError')}
+            </Text>
+          ) : (
+            <ActivityTimeline events={visible} testId="activity-timeline" />
+          )}
+        </Stack>
+      </Drawer.Body>
+    </Drawer>
+  );
+}

--- a/apps/web/src/components/admin/activity/ActivityDrawerProvider.tsx
+++ b/apps/web/src/components/admin/activity/ActivityDrawerProvider.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+
+type ActivityDrawerContextValue = {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+};
+
+const ActivityDrawerContext = createContext<ActivityDrawerContextValue | null>(null);
+
+/** Open/closed state of the activity drawer, shared by the sidebar and the pages that open it. */
+export function ActivityDrawerProvider({ children }: Readonly<{ children: ReactNode }>) {
+  const [isOpen, setIsOpen] = useState(false);
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const value = useMemo(() => ({ isOpen, open, close }), [isOpen, open, close]);
+  return <ActivityDrawerContext.Provider value={value}>{children}</ActivityDrawerContext.Provider>;
+}
+
+export function useActivityDrawer(): ActivityDrawerContextValue {
+  const ctx = useContext(ActivityDrawerContext);
+  if (!ctx) throw new Error('useActivityDrawer must be used inside ActivityDrawerProvider');
+  return ctx;
+}

--- a/apps/web/src/components/admin/activity/ActivityTimeline.tsx
+++ b/apps/web/src/components/admin/activity/ActivityTimeline.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useLocale, useTranslations } from 'next-intl';
+
+import { formatDate } from '@eventuras/core/datetime';
+import { Text } from '@eventuras/ratio-ui/core/Text';
+import { Timeline } from '@eventuras/ratio-ui/core/Timeline';
+
+import type { BusinessEventDto } from '@/lib/eventuras-sdk';
+
+import { statusForEventType } from './businessEventPresentation';
+
+type ActivityTimelineProps = {
+  events: BusinessEventDto[];
+  testId?: string;
+};
+
+/** The shared rendering of business events — used by the drawer and the overview. */
+export function ActivityTimeline({ events, testId }: Readonly<ActivityTimelineProps>) {
+  const t = useTranslations();
+  const locale = useLocale();
+
+  if (events.length === 0) {
+    return (
+      <Text as="p" size="sm" variant="subtle" testId={testId}>
+        {t('admin.businessEvents.empty')}
+      </Text>
+    );
+  }
+
+  return (
+    <Timeline testId={testId}>
+      {events.map((event, index) => (
+        <Timeline.Item
+          key={event.uuid ?? `${event.createdAt}-${index}`}
+          timestamp={event.createdAt ? formatDate(event.createdAt, { locale, showTime: true }) : ''}
+          title={event.message ?? event.eventType ?? ''}
+          status={statusForEventType(event.eventType)}
+        >
+          <Text as="span" family="mono" size="xs" variant="subtle">
+            {event.eventType}
+          </Text>
+        </Timeline.Item>
+      ))}
+    </Timeline>
+  );
+}

--- a/apps/web/src/components/admin/activity/activityActions.ts
+++ b/apps/web/src/components/admin/activity/activityActions.ts
@@ -1,0 +1,43 @@
+'use server';
+
+import { actionError, actionSuccess, ServerActionResult } from '@eventuras/core-nextjs/actions';
+import { Logger } from '@eventuras/logger';
+
+import { client } from '@/lib/eventuras-client';
+import { BusinessEventDto, getV3BusinessEvents } from '@/lib/eventuras-sdk';
+import { getOrganizationId } from '@/utils/organization';
+
+const logger = Logger.create({
+  namespace: 'web:admin:activity',
+  context: { module: 'activityActions' },
+});
+
+const MAX_COUNT = 100;
+
+/** Newest business events recorded on an event, across its registrations and orders. */
+export async function fetchEventActivity(
+  eventUuid: string,
+  count = MAX_COUNT
+): Promise<ServerActionResult<BusinessEventDto[]>> {
+  // Server action input is untrusted — keep the page size within bounds.
+  const safeCount = Math.min(Math.max(Math.trunc(count) || 1, 1), MAX_COUNT);
+
+  try {
+    const organizationId = getOrganizationId();
+    const response = await getV3BusinessEvents({
+      client,
+      headers: { 'Eventuras-Org-Id': organizationId },
+      query: { EventInfoUuid: eventUuid, Count: safeCount },
+    });
+
+    if (response.error || !response.data) {
+      logger.error({ eventUuid, error: response.error }, 'Failed to load event activity');
+      return actionError('Failed to load event activity');
+    }
+
+    return actionSuccess(response.data.data ?? []);
+  } catch (error) {
+    logger.error({ eventUuid, error }, 'Failed to load event activity');
+    return actionError('Failed to load event activity');
+  }
+}

--- a/apps/web/src/components/admin/activity/businessEventPresentation.ts
+++ b/apps/web/src/components/admin/activity/businessEventPresentation.ts
@@ -1,0 +1,20 @@
+import type { BusinessEventDto } from '@/lib/eventuras-sdk';
+
+export type BusinessEventStatus = 'neutral' | 'success' | 'warning' | 'info';
+
+/** Timeline tone for a business event, read off the event type's suffix. */
+export function statusForEventType(eventType: string | undefined): BusinessEventStatus {
+  if (!eventType) return 'neutral';
+  if (eventType.endsWith('.cancelled') || eventType.endsWith('.refunded')) return 'warning';
+  if (eventType.endsWith('.verified') || eventType.endsWith('.created')) return 'success';
+  if (eventType.endsWith('.invoiced')) return 'info';
+  return 'neutral';
+}
+
+export const ACTIVITY_SUBJECTS = ['event', 'registration', 'order'] as const;
+export type ActivitySubject = (typeof ACTIVITY_SUBJECTS)[number];
+export type ActivityFilter = 'all' | ActivitySubject;
+
+export function matchesActivityFilter(event: BusinessEventDto, filter: ActivityFilter): boolean {
+  return filter === 'all' || event.subjectType === filter;
+}

--- a/apps/web/src/components/admin/activity/index.ts
+++ b/apps/web/src/components/admin/activity/index.ts
@@ -1,0 +1,9 @@
+export { ActivityDrawer } from './ActivityDrawer';
+export { ActivityDrawerProvider, useActivityDrawer } from './ActivityDrawerProvider';
+export { ActivityTimeline } from './ActivityTimeline';
+export type { ActivityFilter, ActivitySubject } from './businessEventPresentation';
+export {
+  ACTIVITY_SUBJECTS,
+  matchesActivityFilter,
+  statusForEventType,
+} from './businessEventPresentation';

--- a/apps/web/src/components/admin/shell/AdminNav.tsx
+++ b/apps/web/src/components/admin/shell/AdminNav.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 
 import { ActionButton } from '@eventuras/ratio-ui/core/ActionButton';
+import { Button } from '@eventuras/ratio-ui/core/Button';
 import { Chip } from '@eventuras/ratio-ui/core/Chip';
 import { NavTree, type NavTreeItem, type NavTreeProps } from '@eventuras/ratio-ui/core/NavTree';
 import { X } from '@eventuras/ratio-ui/icons';
@@ -19,6 +20,7 @@ import {
   sectionForTab,
 } from './eventAdminSections';
 import { usePinnedEvent } from './PinnedEvent';
+import { useActivityDrawer } from '../activity';
 
 // Plain next/link, not ratio-ui's Link: NavTree owns the row styling and passes style/aria props its LinkProps don't type.
 const NavLink: NonNullable<NavTreeProps['LinkComponent']> = ({ href, ...rest }) => (
@@ -51,6 +53,7 @@ export function AdminNav(props: Readonly<Pick<ComponentProps<typeof NavTree>, 'c
   const searchParams = useSearchParams();
   const router = useRouter();
   const { event, unpin } = usePinnedEvent();
+  const activity = useActivityDrawer();
 
   const closeEvent = () => {
     unpin();
@@ -88,6 +91,20 @@ export function AdminNav(props: Readonly<Pick<ComponentProps<typeof NavTree>, 'c
               </Chip>
             ) : undefined,
         })),
+        {
+          id: 'pinned-event-activity',
+          content: (
+            <Button
+              variant="outline"
+              size="sm"
+              block
+              onClick={activity.open}
+              testId="admin-nav-activity"
+            >
+              {t('admin.businessEvents.title')}
+            </Button>
+          ),
+        },
       ]
     : undefined;
 

--- a/apps/web/src/components/admin/shell/AdminShell.tsx
+++ b/apps/web/src/components/admin/shell/AdminShell.tsx
@@ -11,6 +11,7 @@ import { Link } from '@eventuras/ratio-ui-next/Link';
 
 import { AdminNav } from './AdminNav';
 import { PinnedEventProvider } from './PinnedEvent';
+import { ActivityDrawer, ActivityDrawerProvider } from '../activity';
 
 export interface AdminShellProps {
   children: ReactNode;
@@ -43,31 +44,35 @@ export function AdminShell({ children, title, menuLabel }: Readonly<AdminShellPr
 
   return (
     <PinnedEventProvider>
-      <div className="flex items-start">
-        <Sidebar aria-label={title} width={256} className="hidden lg:flex" testId="admin-sidebar">
-          <Sidebar.Header>{header}</Sidebar.Header>
-          <Sidebar.Body>
-            <AdminNav />
-          </Sidebar.Body>
-        </Sidebar>
+      <ActivityDrawerProvider>
+        <div className="flex items-start">
+          <Sidebar aria-label={title} width={256} className="hidden lg:flex" testId="admin-sidebar">
+            <Sidebar.Header>{header}</Sidebar.Header>
+            <Sidebar.Body>
+              <AdminNav />
+            </Sidebar.Body>
+          </Sidebar>
 
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-3 border-b border-border-1 px-3 py-2 lg:hidden">
-            <ActionButton round ariaLabel={menuLabel} onPress={() => setOpenedAt(location)}>
-              <MenuIcon size={18} />
-            </ActionButton>
-            {header}
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-3 border-b border-border-1 px-3 py-2 lg:hidden">
+              <ActionButton round ariaLabel={menuLabel} onPress={() => setOpenedAt(location)}>
+                <MenuIcon size={18} />
+              </ActionButton>
+              {header}
+            </div>
+            <main id="main-content">{children}</main>
           </div>
-          <main id="main-content">{children}</main>
         </div>
-      </div>
 
-      <Drawer isOpen={drawerOpen} onClose={() => setOpenedAt(null)} side="left">
-        <Drawer.Header as="h2">{title}</Drawer.Header>
-        <Drawer.Body>
-          <AdminNav />
-        </Drawer.Body>
-      </Drawer>
+        <Drawer isOpen={drawerOpen} onClose={() => setOpenedAt(null)} side="left">
+          <Drawer.Header as="h2">{title}</Drawer.Header>
+          <Drawer.Body>
+            <AdminNav />
+          </Drawer.Body>
+        </Drawer>
+
+        <ActivityDrawer />
+      </ActivityDrawerProvider>
     </PinnedEventProvider>
   );
 }

--- a/apps/web/src/components/admin/shell/PinnedEvent.tsx
+++ b/apps/web/src/components/admin/shell/PinnedEvent.tsx
@@ -12,6 +12,8 @@ import {
 export type PinnedEvent = {
   id: number;
   title: string;
+  /** Stable identifier, used to fetch the event's activity. */
+  uuid?: string;
   participantCount?: number;
 };
 
@@ -59,6 +61,7 @@ function parse(raw: string | null): PinnedEvent | null {
     return {
       id: parsed.id,
       title: parsed.title,
+      uuid: typeof parsed.uuid === 'string' ? parsed.uuid : undefined,
       participantCount:
         typeof parsed.participantCount === 'number' ? parsed.participantCount : undefined,
     };
@@ -92,9 +95,9 @@ export function usePinnedEvent(): PinnedEventContextValue {
 /** Rendered by the event admin page to pin that event in the sidebar. */
 export function PinEvent({ event }: Readonly<{ event: PinnedEvent }>) {
   const { pin } = usePinnedEvent();
-  const { id, title, participantCount } = event;
+  const { id, title, uuid, participantCount } = event;
   useEffect(() => {
-    pin({ id, title, participantCount });
-  }, [pin, id, title, participantCount]);
+    pin({ id, title, uuid, participantCount });
+  }, [pin, id, title, uuid, participantCount]);
   return null;
 }


### PR DESCRIPTION
## Summary

The admin activity drawer from the admin IA prototype, on top of #1831 and #1832. Every business event recorded on the pinned event — the event itself, its registrations and their orders — in a drawer that overlays whichever section the admin is on.

- **`components/admin/activity/`** — `ActivityDrawer` (ratio-ui `Drawer`, right side): event title, filter chips all/event/registration/order (`ToggleButtonGroup`), "Oppdater", and a `Timeline` with time, message and event type. Loads `GET /v3/business-events?eventInfoUuid=…` (100 newest) through the `fetchEventActivity` server action when opened; filtering is client-side. No live push yet. Takes an injectable `loader` for previews/tests.
- `ActivityDrawerProvider`/`useActivityDrawer` share the open state; `ActivityTimeline` is the rendering shared with the overview. `statusForEventType` moves out of `BusinessEventsTimeline` into a shared helper (that component now imports it).
- **Sidebar:** "Aktivitet" button under the pinned event. `PinnedEvent` now carries the event `uuid` (validated from sessionStorage like the rest).
- **Overview:** "Siste meldinger" becomes "Siste aktivitet" — the four newest records (fetched server-side via the same action) with "Vis alt" opening the drawer. Notifications are still under Kommunikasjon.
- New `admin.businessEvents.*` / `admin.events.overview.*` strings (nb-NO, en-US); `latestNotifications` removed.

Known gap, next PR: the actor is only a uuid on the record (`actorUserUuid`), so no "who" is shown yet. Plan is an `actorName` on `BusinessEventDto` in the API, then the drawer and the existing timelines show it.

Messages ("Status changed from Verified to Attended") come from the backend and are English for now.

## Screenshots

Overview card, drawer, and the drawer filtered to orders — with dummy data via the `loader` prop on a temporary page (not in the PR). The real request path is not browser-verified locally (auth), only typechecked.

## Test plan

- [ ] Open an event → Oversikt shows "Siste aktivitet" with the newest records; "Vis alt" opens the drawer
- [ ] Sidebar "Aktivitet" opens the drawer on any section (e.g. Brukere while the event is pinned)
- [ ] Change a registration status → "Oppdater" shows it; filters narrow the list; empty filter shows the empty text
- [ ] Without a pinned event the drawer shows the "open an event" hint
- [ ] Registration/order detail pages' timelines unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
