### PR TITLE
fix(scribo): scope the editor stylesheet to the editor

### DIFF
--- a/.changeset/scribo-scoped-css.md
+++ b/.changeset/scribo-scoped-css.md
@@ -1,0 +1,6 @@
+---
+'@eventuras/scribo': patch
+'@eventuras/web': patch
+---
+
+The markdown editor's stylesheet no longer styles bare `ul` and `pre` elements globally — the rules are scoped to the editor. Unscoped, they overrode the design system's list reset on any page that loaded the editor, which is why the admin sidebar grew bullet points and indentation on event pages.

--- a/libs/scribo/src/MarkdownEditor.css
+++ b/libs/scribo/src/MarkdownEditor.css
@@ -115,13 +115,13 @@
   border-left-color: #555;
 }
 
-ul {
+.editor ul {
   list-style-type: disc;
   padding: 10px 0 !important;
   padding-left: 20px !important;
 }
 
-pre {
+.editor-shell pre {
   line-height: 1.1;
   background: #222;
   color: #fff;
@@ -132,12 +132,12 @@ pre {
   max-height: 400px;
 }
 
-pre::-webkit-scrollbar {
+.editor-shell pre::-webkit-scrollbar {
   background: transparent;
   width: 10px;
 }
 
-pre::-webkit-scrollbar-thumb {
+.editor-shell pre::-webkit-scrollbar-thumb {
   background: #999;
 }
 


### PR DESCRIPTION
## Summary

Fixes the bullet points and indentation that appeared in the admin sidebar on event pages in production.

**Cause:** `MarkdownEditor.css` in `@eventuras/scribo` styles bare `ul` (`list-style-type: disc` + `padding !important`) and `pre` elements. Those rules are unlayered, so they beat ratio-ui's `@layer base` reset (`ol, ul, menu { list-style: none }`) on any page that loads the editor — the event admin page does, via the editor sections. That's why the sidebar's NavTree grew bullets and 20px indents, while pages without the editor looked fine.

**Fix:** the rules are scoped to `.editor` / `.editor-shell` (the editor's own roots). The editor's lists and code blocks render exactly as before; nothing else on the page is touched.

Verified with a page rendering the admin sidebar and the markdown editor together: sidebar computed `list-style: none / padding 0`, editor list `disc / 20px`.

## Test plan

- [ ] `/admin/events/{id}` → sidebar has no bullets or extra indentation
- [ ] Rediger → Beskrivelse: bullet lists inside the editor still render with discs and indentation
- [ ] Code blocks in the editor unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
