### PR TITLE
fix(web): give the event overview cards the elevated card background

### DIFF
--- a/.changeset/dashboard-card-contrast.md
+++ b/.changeset/dashboard-card-contrast.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+The event overview's cards use the elevated card background instead of a transparent fill, so key facts and the latest-registrations/activity lists stand out from the page surface in both themes.

--- a/apps/web/src/app/(admin)/admin/events/[id]/EventDashboardSection.tsx
+++ b/apps/web/src/app/(admin)/admin/events/[id]/EventDashboardSection.tsx
@@ -55,7 +55,7 @@ function KeyFact({
   testId,
 }: Readonly<{ label: string; value: string; note?: string; testId: string }>) {
   return (
-    <Card border transparent testId={testId}>
+    <Card testId={testId}>
       <Text
         as="p"
         family="mono"
@@ -197,7 +197,7 @@ export default function EventDashboardSection({
             href={eventAdminHref(eventId, 'participants')}
             linkLabel={t('admin.events.overview.seeAll', { count: participants.length })}
           />
-          <Card border transparent padding="none" testId="dashboard-latest-registrations">
+          <Card padding="none" testId="dashboard-latest-registrations">
             {latestRegistrations.length === 0 ? (
               <Text as="p" size="sm" variant="subtle" padding="md">
                 {t('admin.events.overview.noRegistrations')}
@@ -238,7 +238,7 @@ export default function EventDashboardSection({
             onClick={activityDrawer.open}
             linkLabel={t('admin.events.overview.showAll')}
           />
-          <Card border transparent testId="dashboard-latest-activity">
+          <Card testId="dashboard-latest-activity">
             <ActivityTimeline events={activity} />
           </Card>
         </Stack>


### PR DESCRIPTION
## Summary

Small contrast fix for the event overview: the key-facts tiles and the latest-registrations/latest-activity cards were `Card border transparent`, leaving only a hairline against the page surface. They now use plain `Card` — the elevated `--card` background plus ratio-ui's subtle card shadow — so they read clearly in both light and dark.

The alternative (a lighter content area behind everything but the menu) is really the prototype's dark sidebar rail; that belongs to a later ratio-ui step rather than a local background override.

## Test plan

- [ ] Event → Oversikt: tiles and lists stand out from the background in light and dark
- [ ] Økonomi-section tiles (still transparent by design) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
