### PR TITLE
feat(web): redesign the public event detail page

### DIFF
--- a/.changeset/event-detail-ratio-ui-primitives.md
+++ b/.changeset/event-detail-ratio-ui-primitives.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Adopt the ratio-ui 2.19 detail-page primitives on the public event page: Heading `size` for the editorial serif scale, `DescriptionList` `facts`/`meta` variants for the key-facts strip and registration-card rows, `AsideLayout` for the sticky registration rail (which also fixes the aside being capped at `max-w-sm` on tablets), and `Text` for the lead. Shared `getEventFacts` helper replaces the duplicated date/location/deadline building.

--- a/.changeset/event-detail-redesign.md
+++ b/.changeset/event-detail-redesign.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': minor
+---
+
+Redesign the public event detail page: editorial hero with eyebrow, serif title and lead, a key-facts strip, and a sticky registration card in a right-hand column from lg. Empty content sections no longer render headings, and the registrations-open status label now reads as a status ("Påmelding åpen") instead of a call to action.

--- a/.changeset/standalone-swc-helpers-tracing.md
+++ b/.changeset/standalone-swc-helpers-tracing.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+Fix the standalone server crashing on startup with `Cannot find module '@swc/helpers/esm/_interop_require_default.js'`. Since next 16.3.1 (which pins `@swc/helpers` 0.5.23), Node >= 22.10 resolves the helper through the new `module-sync` export condition to the esm files, while Next's output file tracing follows the `require` condition and ships only the cjs files. Force the whole package into the trace via `outputFileTracingIncludes` until vercel/next.js#90567 is fixed upstream.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,9 @@
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -103,11 +103,17 @@
   "events": {
     "description": "Description",
     "detailspage": {
+      "facts": {
+        "date": "Date",
+        "deadline": "Registration deadline",
+        "location": "Location"
+      },
       "notfound": {
         "back": "Show me the front page",
         "description": "We do not know where to look.",
         "title": "Sorry, not found."
-      }
+      },
+      "registration": "Registration"
     },
     "event": "Event",
     "event-not-found": "Event not found",
@@ -120,7 +126,7 @@
         "finished": "Finished",
         "planned": "Planned",
         "registrationsClosed": "Registrations now closed",
-        "registrationsOpen": "Register now",
+        "registrationsOpen": "Registration open",
         "unknown": "Unknown",
         "waitingList": "Waitinglist"
       }

--- a/apps/web/locales/nb-NO/common.json
+++ b/apps/web/locales/nb-NO/common.json
@@ -103,11 +103,17 @@
   "events": {
     "description": "Beskrivelse",
     "detailspage": {
+      "facts": {
+        "date": "Dato",
+        "deadline": "Påmeldingsfrist",
+        "location": "Sted"
+      },
       "notfound": {
         "back": "Til forsiden",
         "description": "Vi finner ikke dette arrangementet",
         "title": "Beklager, kunne ikke finne siden"
-      }
+      },
+      "registration": "Påmelding"
     },
     "event": "Arrangement",
     "event-not-found": "Arrangementet ble ikke funnet",
@@ -120,7 +126,7 @@
         "finished": "Ferdig",
         "planned": "Planlagt",
         "registrationsClosed": "Stengt for påmelding",
-        "registrationsOpen": "Registrer deg nå",
+        "registrationsOpen": "Påmelding åpen",
         "unknown": "Ukjent",
         "waitingList": "Venteliste"
       }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,14 @@ const pkg = JSON.parse(readFileSync(path.resolve(__dirname, 'package.json'), 'ut
 const nextConfig: NextConfig = {
   output: 'standalone',
 
+  // next requires @swc/helpers via its `module-sync` export condition on
+  // Node >= 22.10, but file tracing resolves the `require` condition and only
+  // ships the cjs files — crashing the standalone server on startup
+  // (vercel/next.js#90567). Force the whole (tiny) package into the trace.
+  outputFileTracingIncludes: {
+    '/**': ['../../node_modules/.pnpm/@swc+helpers@*/node_modules/@swc/helpers/**'],
+  },
+
   env: {
     BUILD_GIT_SHA: process.env.GIT_SHA ?? 'unknown',
     BUILD_TIME: new Date().toISOString(),

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,7 +34,7 @@
     "@eventuras/logger": "^0.8.1",
     "@eventuras/markdown": "^0.15.0",
     "@eventuras/markdown-plugin-happening": "workspace:*",
-    "@eventuras/ratio-ui": "^2.18.0",
+    "@eventuras/ratio-ui": "^2.19.0",
     "@eventuras/ratio-ui-next": "^0.2.0",
     "@eventuras/scribo": "workspace:*",
     "@eventuras/smartform": "workspace:*",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "analyze": "ANALYZE=true next build",
     "build": "next build",
     "dev": "next dev",
+    "dev:staging": "set -a && . ./.env.staging && set +a && next dev",
     "generate:config-types": "tsx scripts/generate-config-types.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix && prettier . --write",

--- a/apps/web/src/app/(public)/events/EventDetails.tsx
+++ b/apps/web/src/app/(public)/events/EventDetails.tsx
@@ -15,6 +15,7 @@ import {
 } from '@eventuras/markdown-plugin-happening';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import { NavList } from '@eventuras/ratio-ui/core/NavList';
+import { AsideLayout } from '@eventuras/ratio-ui/layout/AsideLayout';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 import { Link } from '@eventuras/ratio-ui-next/Link';
@@ -61,11 +62,11 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
     <Section className="pb-24">
       {sections.length > 0 && <NavList items={sections} LinkComponent={Link} sticky />}
       <Container size="xl">
-        <div className="lg:flex gap-8 items-start pt-8">
-          <div className="min-w-0 flex-1">
+        <AsideLayout className="pt-8">
+          <AsideLayout.Main>
             {sections.map(section => (
               <section key={section.id} id={section.id} className="mb-10">
-                <Heading as="h2" className="font-serif font-medium text-2xl tracking-tight m-0">
+                <Heading as="h2" size="md">
                   {section.title}
                 </Heading>
                 <div className="mt-4">
@@ -82,9 +83,13 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
                 </div>
               </section>
             ))}
-          </div>
-          {aside && <aside className="w-full max-w-sm shrink-0 lg:sticky lg:top-16">{aside}</aside>}
-        </div>
+          </AsideLayout.Main>
+          {aside && (
+            <AsideLayout.Aside width="lg" top={64}>
+              {aside}
+            </AsideLayout.Aside>
+          )}
+        </AsideLayout>
       </Container>
     </Section>
   );

--- a/apps/web/src/app/(public)/events/EventDetails.tsx
+++ b/apps/web/src/app/(public)/events/EventDetails.tsx
@@ -23,13 +23,15 @@ import { EventDto } from '@/lib/eventuras-public-sdk';
 
 type EventProps = {
   eventinfo: EventDto;
-  bgClassNames?: string;
+  /** Rendered in a sticky right-hand column on wide screens, e.g. the registration card. */
+  aside?: React.ReactNode;
 };
+
 /**
  * Renders event details with top sticky navigation for sections.
  * @param props - See {@link EventProps}.
  */
-const EventDetails: React.FC<EventProps> = ({ eventinfo }) => {
+const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
   const t = useTranslations();
   if (!eventinfo) return <div>{t('common.events.event-not-found')}</div>;
   const sections = [
@@ -51,27 +53,39 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo }) => {
       title: t('common.events.practicalinformation'),
       content: eventinfo.practicalInformation,
     },
-  ];
+  ].filter(section => section.content);
+
+  if (sections.length === 0 && !aside) return null;
+
   return (
     <Section className="pb-24">
-      <NavList items={sections} LinkComponent={Link} sticky />
-      {sections.map(section => (
-        <Section key={section.id} id={section.id}>
-          <Container>
-            <Heading as="h2">{section.title}</Heading>
-            <MarkdownContent
-              markdown={section.content!}
-              allowExternalLinks={true}
-              remarkPlugins={[remarkSchedule, remarkCallout]}
-              customComponents={{ ...scheduleComponents, ...calloutComponents }}
-              sanitizeSchemaExtension={mergeSanitizeSchemas(
-                scheduleSanitizeSchema,
-                calloutSanitizeSchema
-              )}
-            />
-          </Container>
-        </Section>
-      ))}
+      {sections.length > 0 && <NavList items={sections} LinkComponent={Link} sticky />}
+      <Container size="xl">
+        <div className="lg:flex gap-8 items-start pt-8">
+          <div className="min-w-0 flex-1">
+            {sections.map(section => (
+              <section key={section.id} id={section.id} className="mb-10">
+                <Heading as="h2" className="font-serif font-medium text-2xl tracking-tight m-0">
+                  {section.title}
+                </Heading>
+                <div className="mt-4">
+                  <MarkdownContent
+                    markdown={section.content}
+                    allowExternalLinks={true}
+                    remarkPlugins={[remarkSchedule, remarkCallout]}
+                    customComponents={{ ...scheduleComponents, ...calloutComponents }}
+                    sanitizeSchemaExtension={mergeSanitizeSchemas(
+                      scheduleSanitizeSchema,
+                      calloutSanitizeSchema
+                    )}
+                  />
+                </div>
+              </section>
+            ))}
+          </div>
+          {aside && <aside className="w-full max-w-sm shrink-0 lg:sticky lg:top-16">{aside}</aside>}
+        </div>
+      </Container>
     </Section>
   );
 };

--- a/apps/web/src/app/(public)/events/EventRegistrationButton.tsx
+++ b/apps/web/src/app/(public)/events/EventRegistrationButton.tsx
@@ -3,35 +3,16 @@ import { getTranslations } from 'next-intl/server';
 import { Badge } from '@eventuras/ratio-ui/core/Badge';
 import { Link } from '@eventuras/ratio-ui-next/Link';
 
+import { eventStatusLabel } from '@/app/(public)/events/eventStatusLabel';
 import { EventDto, EventInfoStatus } from '@/lib/eventuras-public-sdk';
 export type EventRegistrationButtonProps = {
   event: EventDto;
 };
-export default async function EventRegistrationButton({ event }: Readonly<EventRegistrationButtonProps>) {
+export default async function EventRegistrationButton({
+  event,
+}: Readonly<EventRegistrationButtonProps>) {
   const t = await getTranslations();
   const canRegister = event.status === EventInfoStatus.REGISTRATIONS_OPEN;
-  const getStatusText = (status: EventInfoStatus): string => {
-    switch (status) {
-      case EventInfoStatus.DRAFT:
-        return t('common.events.labels.status.draft');
-      case EventInfoStatus.PLANNED:
-        return t('common.events.labels.status.planned');
-      case EventInfoStatus.REGISTRATIONS_OPEN:
-        return t('common.events.labels.status.registrationsOpen');
-      case EventInfoStatus.WAITING_LIST:
-        return t('common.events.labels.status.waitingList');
-      case EventInfoStatus.REGISTRATIONS_CLOSED:
-        return t('common.events.labels.status.registrationsClosed');
-      case EventInfoStatus.FINISHED:
-        return t('common.events.labels.status.finished');
-      case EventInfoStatus.ARCHIVED:
-        return t('common.events.labels.status.archived');
-      case EventInfoStatus.CANCELLED:
-        return t('common.events.labels.status.cancelled');
-      default:
-        return t('common.events.labels.status.unknown');
-    }
-  };
   if (canRegister) {
     return (
       <Link
@@ -44,6 +25,6 @@ export default async function EventRegistrationButton({ event }: Readonly<EventR
       </Link>
     );
   } else {
-    return <Badge block>{getStatusText(event.status!)}</Badge>;
+    return <Badge block>{eventStatusLabel(t, event.status)}</Badge>;
   }
 }

--- a/apps/web/src/app/(public)/events/EventRegistrationCard.tsx
+++ b/apps/web/src/app/(public)/events/EventRegistrationCard.tsx
@@ -1,11 +1,12 @@
 import { getLocale, getTranslations } from 'next-intl/server';
 
-import { formatDateSpan } from '@eventuras/core/datetime';
 import { Badge } from '@eventuras/ratio-ui/core/Badge';
 import { Card } from '@eventuras/ratio-ui/core/Card';
+import { DescriptionList } from '@eventuras/ratio-ui/core/DescriptionList';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
 import type { Status } from '@eventuras/ratio-ui/tokens';
 
+import { getEventFacts } from '@/app/(public)/events/eventFacts';
 import EventRegistrationButton from '@/app/(public)/events/EventRegistrationButton';
 import { eventStatusLabel } from '@/app/(public)/events/eventStatusLabel';
 import { EventDto, EventInfoStatus } from '@/lib/eventuras-public-sdk';
@@ -21,13 +22,6 @@ const badgeStatusByEventStatus: Partial<Record<EventInfoStatus, Status>> = {
   [EventInfoStatus.CANCELLED]: 'error',
 };
 
-const MetaRow = ({ label, value }: { label: string; value: string }) => (
-  <div className="flex justify-between gap-4">
-    <dt className="font-mono text-xs uppercase tracking-widest text-(--text-subtle)">{label}</dt>
-    <dd className="text-sm text-(--text) text-right m-0">{value}</dd>
-  </div>
-);
-
 /**
  * Sticky aside card for the event detail page — status chip, key facts,
  * and the registration CTA when registrations are open.
@@ -39,19 +33,12 @@ export default async function EventRegistrationCard({
   const locale = await getLocale();
 
   const canRegister = event.status === EventInfoStatus.REGISTRATIONS_OPEN;
-
-  const dates = formatDateSpan(event.dateStart as string, event.dateEnd as string, { locale });
-  const place = [event.location, event.city].filter(Boolean).join(', ');
-  const deadline = event.lastRegistrationDate
-    ? new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
-        new Date(event.lastRegistrationDate as string)
-      )
-    : '';
+  const facts = getEventFacts(event, t, locale);
 
   return (
     <Card padding="md" testId="event-registration-card">
       <div className="flex items-baseline justify-between gap-4">
-        <Heading as="h2" className="font-serif font-medium text-xl tracking-tight m-0">
+        <Heading as="h2" size="sm">
           {t('common.events.detailspage.registration')}
         </Heading>
         {event.status && (
@@ -61,14 +48,14 @@ export default async function EventRegistrationCard({
         )}
       </div>
 
-      {(dates || place || deadline) && (
-        <dl className="mt-4 mb-4 border-t border-b border-(--border-1) py-3 flex flex-col gap-2">
-          {dates && <MetaRow label={t('common.events.detailspage.facts.date')} value={dates} />}
-          {place && <MetaRow label={t('common.events.detailspage.facts.location')} value={place} />}
-          {deadline && (
-            <MetaRow label={t('common.events.detailspage.facts.deadline')} value={deadline} />
-          )}
-        </dl>
+      {facts.length > 0 && (
+        <DescriptionList variant="meta" className="mt-4 mb-4">
+          {facts.map(fact => (
+            <DescriptionList.Description key={fact.label} term={fact.label}>
+              {fact.value}
+            </DescriptionList.Description>
+          ))}
+        </DescriptionList>
       )}
 
       {canRegister && <EventRegistrationButton event={event} />}

--- a/apps/web/src/app/(public)/events/EventRegistrationCard.tsx
+++ b/apps/web/src/app/(public)/events/EventRegistrationCard.tsx
@@ -1,0 +1,77 @@
+import { getLocale, getTranslations } from 'next-intl/server';
+
+import { formatDateSpan } from '@eventuras/core/datetime';
+import { Badge } from '@eventuras/ratio-ui/core/Badge';
+import { Card } from '@eventuras/ratio-ui/core/Card';
+import { Heading } from '@eventuras/ratio-ui/core/Heading';
+import type { Status } from '@eventuras/ratio-ui/tokens';
+
+import EventRegistrationButton from '@/app/(public)/events/EventRegistrationButton';
+import { eventStatusLabel } from '@/app/(public)/events/eventStatusLabel';
+import { EventDto, EventInfoStatus } from '@/lib/eventuras-public-sdk';
+
+export type EventRegistrationCardProps = {
+  event: EventDto;
+};
+
+const badgeStatusByEventStatus: Partial<Record<EventInfoStatus, Status>> = {
+  [EventInfoStatus.REGISTRATIONS_OPEN]: 'success',
+  [EventInfoStatus.WAITING_LIST]: 'warning',
+  [EventInfoStatus.PLANNED]: 'info',
+  [EventInfoStatus.CANCELLED]: 'error',
+};
+
+const MetaRow = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex justify-between gap-4">
+    <dt className="font-mono text-xs uppercase tracking-widest text-(--text-subtle)">{label}</dt>
+    <dd className="text-sm text-(--text) text-right m-0">{value}</dd>
+  </div>
+);
+
+/**
+ * Sticky aside card for the event detail page — status chip, key facts,
+ * and the registration CTA when registrations are open.
+ */
+export default async function EventRegistrationCard({
+  event,
+}: Readonly<EventRegistrationCardProps>) {
+  const t = await getTranslations();
+  const locale = await getLocale();
+
+  const canRegister = event.status === EventInfoStatus.REGISTRATIONS_OPEN;
+
+  const dates = formatDateSpan(event.dateStart as string, event.dateEnd as string, { locale });
+  const place = [event.location, event.city].filter(Boolean).join(', ');
+  const deadline = event.lastRegistrationDate
+    ? new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
+        new Date(event.lastRegistrationDate as string)
+      )
+    : '';
+
+  return (
+    <Card padding="md" testId="event-registration-card">
+      <div className="flex items-baseline justify-between gap-4">
+        <Heading as="h2" className="font-serif font-medium text-xl tracking-tight m-0">
+          {t('common.events.detailspage.registration')}
+        </Heading>
+        {event.status && (
+          <Badge variant="subtle" status={badgeStatusByEventStatus[event.status] ?? 'neutral'}>
+            {eventStatusLabel(t, event.status)}
+          </Badge>
+        )}
+      </div>
+
+      {(dates || place || deadline) && (
+        <dl className="mt-4 mb-4 border-t border-b border-(--border-1) py-3 flex flex-col gap-2">
+          {dates && <MetaRow label={t('common.events.detailspage.facts.date')} value={dates} />}
+          {place && <MetaRow label={t('common.events.detailspage.facts.location')} value={place} />}
+          {deadline && (
+            <MetaRow label={t('common.events.detailspage.facts.deadline')} value={deadline} />
+          )}
+        </dl>
+      )}
+
+      {canRegister && <EventRegistrationButton event={event} />}
+    </Card>
+  );
+}

--- a/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
@@ -3,15 +3,17 @@ import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { getLocale, getTranslations } from 'next-intl/server';
 
-import { formatDateSpan } from '@eventuras/core/datetime';
 import { Logger } from '@eventuras/logger';
 import { MarkdownContent } from '@eventuras/markdown';
 import { Card } from '@eventuras/ratio-ui/core/Card';
+import { DescriptionList } from '@eventuras/ratio-ui/core/DescriptionList';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
+import { Text } from '@eventuras/ratio-ui/core/Text';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 
 import EventDetails from '@/app/(public)/events/EventDetails';
+import { getEventFacts } from '@/app/(public)/events/eventFacts';
 import EventRegistrationButton from '@/app/(public)/events/EventRegistrationButton';
 import EventRegistrationCard from '@/app/(public)/events/EventRegistrationCard';
 import { getPublicClient } from '@/lib/eventuras-public-client';
@@ -138,15 +140,7 @@ export default async function EventDetailsPage({ params }: Readonly<EventDetails
   const t = await getTranslations();
   const locale = await getLocale();
 
-  const dates = eventinfo.dateStart
-    ? formatDateSpan(eventinfo.dateStart as string, eventinfo.dateEnd as string, { locale })
-    : '';
-  const place = [eventinfo.location, eventinfo.city].filter(Boolean).join(', ');
-  const deadline = eventinfo.lastRegistrationDate
-    ? new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
-        new Date(eventinfo.lastRegistrationDate as string)
-      )
-    : '';
+  const facts = getEventFacts(eventinfo, t, locale);
   const year = eventinfo.dateStart
     ? String(new Date(eventinfo.dateStart as string).getFullYear())
     : '';
@@ -154,28 +148,21 @@ export default async function EventDetailsPage({ params }: Readonly<EventDetails
     .filter(Boolean)
     .join(' · ');
 
-  const facts = [
-    { label: t('common.events.detailspage.facts.date'), value: dates },
-    { label: t('common.events.detailspage.facts.location'), value: place },
-    { label: t('common.events.detailspage.facts.deadline'), value: deadline },
-  ].filter(fact => fact.value);
-
   return (
     <>
       <Section paddingY="lg" className="pb-8">
         <Container size="xl">
           <Heading.Group>
             {eyebrow && <Heading.Eyebrow tone="accent">{eyebrow}</Heading.Eyebrow>}
-            <Heading
-              as="h1"
-              className="font-serif font-medium text-3xl md:text-4xl leading-tight tracking-tight m-0"
-            >
+            <Heading as="h1" size="lg">
               {eventinfo.title ?? 'Mysterious Event'}
             </Heading>
           </Heading.Group>
 
           {eventinfo.headline && (
-            <p className="mt-4 text-xl text-(--text-muted) max-w-prose">{eventinfo.headline}</p>
+            <Text as="p" size="xl" variant="muted" className="mt-4 max-w-prose">
+              {eventinfo.headline}
+            </Text>
           )}
 
           {eventinfo.description && (
@@ -185,18 +172,13 @@ export default async function EventDetailsPage({ params }: Readonly<EventDetails
           )}
 
           {facts.length > 0 && (
-            <dl className="grid grid-cols-2 md:grid-cols-4 gap-6 border-t border-b border-(--border-1) py-6 mt-8">
+            <DescriptionList variant="facts" className="mt-8">
               {facts.map(fact => (
-                <div key={fact.label}>
-                  <dt className="font-mono text-xs uppercase tracking-widest text-(--text-subtle)">
-                    {fact.label}
-                  </dt>
-                  <dd className="font-serif text-lg leading-tight text-(--text) mt-1">
-                    {fact.value}
-                  </dd>
-                </div>
+                <DescriptionList.Description key={fact.label} term={fact.label}>
+                  {fact.value}
+                </DescriptionList.Description>
               ))}
-            </dl>
+            </DescriptionList>
           )}
 
           {eventinfo.featuredImageUrl && (

--- a/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
@@ -1,19 +1,19 @@
 import { Suspense } from 'react';
 import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
+import { getLocale, getTranslations } from 'next-intl/server';
 
 import { formatDateSpan } from '@eventuras/core/datetime';
 import { Logger } from '@eventuras/logger';
 import { MarkdownContent } from '@eventuras/markdown';
 import { Card } from '@eventuras/ratio-ui/core/Card';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
-import { Calendar, MapPin } from '@eventuras/ratio-ui/icons';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
 
 import EventDetails from '@/app/(public)/events/EventDetails';
 import EventRegistrationButton from '@/app/(public)/events/EventRegistrationButton';
-import { appConfig } from '@/config.server';
+import EventRegistrationCard from '@/app/(public)/events/EventRegistrationCard';
 import { getPublicClient } from '@/lib/eventuras-public-client';
 import { EventInfoStatus, getV3EventsById } from '@/lib/eventuras-public-sdk';
 
@@ -135,57 +135,87 @@ export default async function EventDetailsPage({ params }: Readonly<EventDetails
     redirect(`/events/${eventinfo.id}/${encodeURI(eventinfo.slug)}`);
   }
 
+  const t = await getTranslations();
+  const locale = await getLocale();
+
+  const dates = eventinfo.dateStart
+    ? formatDateSpan(eventinfo.dateStart as string, eventinfo.dateEnd as string, { locale })
+    : '';
+  const place = [eventinfo.location, eventinfo.city].filter(Boolean).join(', ');
+  const deadline = eventinfo.lastRegistrationDate
+    ? new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
+        new Date(eventinfo.lastRegistrationDate as string)
+      )
+    : '';
+  const year = eventinfo.dateStart
+    ? String(new Date(eventinfo.dateStart as string).getFullYear())
+    : '';
+  const eyebrow = [eventinfo.category, [eventinfo.city, year].filter(Boolean).join(' ')]
+    .filter(Boolean)
+    .join(' · ');
+
+  const facts = [
+    { label: t('common.events.detailspage.facts.date'), value: dates },
+    { label: t('common.events.detailspage.facts.location'), value: place },
+    { label: t('common.events.detailspage.facts.deadline'), value: deadline },
+  ].filter(fact => fact.value);
+
   return (
     <>
-      <Section className="pb-8">
-        <Container>
+      <Section paddingY="lg" className="pb-8">
+        <Container size="xl">
+          <Heading.Group>
+            {eyebrow && <Heading.Eyebrow tone="accent">{eyebrow}</Heading.Eyebrow>}
+            <Heading
+              as="h1"
+              className="font-serif font-medium text-3xl md:text-4xl leading-tight tracking-tight m-0"
+            >
+              {eventinfo.title ?? 'Mysterious Event'}
+            </Heading>
+          </Heading.Group>
+
+          {eventinfo.headline && (
+            <p className="mt-4 text-xl text-(--text-muted) max-w-prose">{eventinfo.headline}</p>
+          )}
+
+          {eventinfo.description && (
+            <div className="mt-4 max-w-prose">
+              <MarkdownContent markdown={eventinfo.description} />
+            </div>
+          )}
+
+          {facts.length > 0 && (
+            <dl className="grid grid-cols-2 md:grid-cols-4 gap-6 border-t border-b border-(--border-1) py-6 mt-8">
+              {facts.map(fact => (
+                <div key={fact.label}>
+                  <dt className="font-mono text-xs uppercase tracking-widest text-(--text-subtle)">
+                    {fact.label}
+                  </dt>
+                  <dd className="font-serif text-lg leading-tight text-(--text) mt-1">
+                    {fact.value}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          )}
+
           {eventinfo.featuredImageUrl && (
             <Card
-              className="min-h-[33vh] mx-auto"
+              className="h-64 rounded-xl mt-8"
               backgroundImageUrl={eventinfo.featuredImageUrl}
             />
           )}
 
-          <Heading as="h1" paddingY="xs">
-            {eventinfo.title ?? 'Mysterious Event'}
-          </Heading>
-
-          {eventinfo.headline && (
-            <Heading as="h2" paddingY="xs" className="text-xl font-semibold text-gray-700">
-              &mdash; {eventinfo.headline}
-            </Heading>
-          )}
-
-          <div className="py-3">
-            <MarkdownContent markdown={eventinfo.description} />
+          <div className="lg:hidden mt-6">
+            <Suspense fallback={<div>Loading registration options...</div>}>
+              <EventRegistrationButton event={eventinfo} />
+            </Suspense>
           </div>
-
-          {eventinfo.dateStart && (
-            <div className="flex items-center gap-2 py-0">
-              <Calendar className="h-5 w-5 mb-5 text-gray-600" />
-              <span>
-                {formatDateSpan(eventinfo.dateStart as string, eventinfo.dateEnd as string, {
-                  locale: appConfig.env.DEFAULT_LOCALE as string,
-                })}
-              </span>
-            </div>
-          )}
-
-          {eventinfo.city && (
-            <div className="flex items-center gap-2 py-0 mb-4">
-              <MapPin className="h-5 w-5 text-gray-600" />
-              <span>{eventinfo.city}</span>
-            </div>
-          )}
-
-          <Suspense fallback={<div>Loading registration options...</div>}>
-            <EventRegistrationButton event={eventinfo} />
-          </Suspense>
         </Container>
       </Section>
 
       <Suspense fallback={<div>Loading event details...</div>}>
-        <EventDetails eventinfo={eventinfo} />
+        <EventDetails eventinfo={eventinfo} aside={<EventRegistrationCard event={eventinfo} />} />
       </Suspense>
     </>
   );

--- a/apps/web/src/app/(public)/events/eventFacts.ts
+++ b/apps/web/src/app/(public)/events/eventFacts.ts
@@ -1,0 +1,25 @@
+import { formatDateSpan } from '@eventuras/core/datetime';
+
+import type { Translator } from '@/app/(public)/events/eventStatusLabel';
+import { EventDto } from '@/lib/eventuras-public-sdk';
+
+export type EventFact = { label: string; value: string };
+
+/** Date/location/deadline facts shown on the detail page and the registration card. */
+export function getEventFacts(event: EventDto, t: Translator, locale: string): EventFact[] {
+  const dates = event.dateStart
+    ? formatDateSpan(event.dateStart as string, event.dateEnd as string, { locale })
+    : '';
+  const place = [event.location, event.city].filter(Boolean).join(', ');
+  const deadline = event.lastRegistrationDate
+    ? new Intl.DateTimeFormat(locale, { dateStyle: 'medium' }).format(
+        new Date(event.lastRegistrationDate as string)
+      )
+    : '';
+
+  return [
+    { label: t('common.events.detailspage.facts.date'), value: dates },
+    { label: t('common.events.detailspage.facts.location'), value: place },
+    { label: t('common.events.detailspage.facts.deadline'), value: deadline },
+  ].filter(fact => fact.value);
+}

--- a/apps/web/src/app/(public)/events/eventStatusLabel.ts
+++ b/apps/web/src/app/(public)/events/eventStatusLabel.ts
@@ -2,7 +2,7 @@ import type { getTranslations } from 'next-intl/server';
 
 import { EventInfoStatus } from '@/lib/eventuras-public-sdk';
 
-type Translator = Awaited<ReturnType<typeof getTranslations>>;
+export type Translator = Awaited<ReturnType<typeof getTranslations>>;
 
 /** Localized label for an event status, e.g. "Påmelding åpen". */
 export function eventStatusLabel(t: Translator, status?: EventInfoStatus | null): string {

--- a/apps/web/src/app/(public)/events/eventStatusLabel.ts
+++ b/apps/web/src/app/(public)/events/eventStatusLabel.ts
@@ -1,0 +1,29 @@
+import type { getTranslations } from 'next-intl/server';
+
+import { EventInfoStatus } from '@/lib/eventuras-public-sdk';
+
+type Translator = Awaited<ReturnType<typeof getTranslations>>;
+
+/** Localized label for an event status, e.g. "Påmelding åpen". */
+export function eventStatusLabel(t: Translator, status?: EventInfoStatus | null): string {
+  switch (status) {
+    case EventInfoStatus.DRAFT:
+      return t('common.events.labels.status.draft');
+    case EventInfoStatus.PLANNED:
+      return t('common.events.labels.status.planned');
+    case EventInfoStatus.REGISTRATIONS_OPEN:
+      return t('common.events.labels.status.registrationsOpen');
+    case EventInfoStatus.WAITING_LIST:
+      return t('common.events.labels.status.waitingList');
+    case EventInfoStatus.REGISTRATIONS_CLOSED:
+      return t('common.events.labels.status.registrationsClosed');
+    case EventInfoStatus.FINISHED:
+      return t('common.events.labels.status.finished');
+    case EventInfoStatus.ARCHIVED:
+      return t('common.events.labels.status.archived');
+    case EventInfoStatus.CANCELLED:
+      return t('common.events.labels.status.cancelled');
+    default:
+      return t('common.events.labels.status.unknown');
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,7 +107,7 @@ importers:
         version: 0.1.3(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))(react@19.2.8)
       '@eventuras/datatable':
         specifier: ^0.6.0
-        version: 0.6.0(@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/match-sorter-utils@8.19.4)(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/table-core@8.21.3)(lucide-react@1.31.0(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.6.0(@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/match-sorter-utils@8.19.4)(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/table-core@8.21.3)(lucide-react@1.31.0(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@eventuras/event-sdk':
         specifier: workspace:^
         version: link:../../libs/event-sdk
@@ -119,16 +119,16 @@ importers:
         version: 0.8.1(@opentelemetry/api-logs@0.220.0)(@opentelemetry/api@1.9.1)(@opentelemetry/instrumentation-pino@0.66.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-logs@0.220.0(@opentelemetry/api@1.9.1))
       '@eventuras/markdown':
         specifier: ^0.15.0
-        version: 0.15.0(@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 0.15.0(@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@eventuras/markdown-plugin-happening':
         specifier: workspace:*
         version: link:../../libs/markdown-plugin-happening
       '@eventuras/ratio-ui':
-        specifier: ^2.18.0
-        version: 2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: ^2.19.0
+        version: 2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@eventuras/ratio-ui-next':
         specifier: ^0.2.0
-        version: 0.2.0(@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))
+        version: 0.2.0(@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))
       '@eventuras/scribo':
         specifier: workspace:*
         version: link:../../libs/scribo
@@ -1245,6 +1245,12 @@ packages:
 
   '@eventuras/ratio-ui@2.18.0':
     resolution: {integrity: sha512-vvCuPrITdR/sPyZAOndcjtVLShSxOocHZI+Kshrpzk44X804/HVKVWzgHAzuHwfMgRM/yqblG3PlCzSt1d3QXQ==}
+    peerDependencies:
+      react: ^19.0.0
+      react-dom: ^19.0.0
+
+  '@eventuras/ratio-ui@2.19.0':
+    resolution: {integrity: sha512-LPqUXysjRjvw54XKRYUfPtmU3OfI3UKN/Jv3L52CQSD7gvY7kBpoMOfZhM+7M6StXgsUTVgqSQuovrZwREh6kw==}
     peerDependencies:
       react: ^19.0.0
       react-dom: ^19.0.0
@@ -6714,9 +6720,9 @@ snapshots:
 
   '@eventuras/core@0.4.0': {}
 
-  '@eventuras/datatable@0.6.0(@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/match-sorter-utils@8.19.4)(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/table-core@8.21.3)(lucide-react@1.31.0(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@eventuras/datatable@0.6.0(@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/match-sorter-utils@8.19.4)(@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/table-core@8.21.3)(lucide-react@1.31.0(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@eventuras/ratio-ui': 2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@eventuras/ratio-ui': 2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/match-sorter-utils': 8.19.4
       '@tanstack/react-table': 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/table-core': 8.21.3
@@ -6838,9 +6844,9 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@eventuras/markdown@0.15.0(@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@eventuras/markdown@0.15.0(@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@eventuras/ratio-ui': 2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@eventuras/ratio-ui': 2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-markdown: 10.1.0(@types/react@19.2.18)(react@19.2.8)
@@ -6851,9 +6857,9 @@ snapshots:
       - '@types/react'
       - supports-color
 
-  '@eventuras/ratio-ui-next@0.2.0(@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))':
+  '@eventuras/ratio-ui-next@0.2.0(@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(next@16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4))':
     dependencies:
-      '@eventuras/ratio-ui': 2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@eventuras/ratio-ui': 2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next: 16.3.1(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.77.4)
 
   '@eventuras/ratio-ui@2.17.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
@@ -6867,6 +6873,16 @@ snapshots:
       tailwind-merge: 3.6.0
 
   '@eventuras/ratio-ui@2.18.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      clsx: 2.1.1
+      lucide-react: 1.31.0(react@19.2.8)
+      react: 19.2.8
+      react-aria-components: 1.20.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-dom: 19.2.8(react@19.2.8)
+      react-stately: 3.49.0(react@19.2.8)
+      tailwind-merge: 3.6.0
+
+  '@eventuras/ratio-ui@2.19.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       clsx: 2.1.1
       lucide-react: 1.31.0(react@19.2.8)


### PR DESCRIPTION
Editorial hero (eyebrow, serif title, lead), key-facts strip, and a sticky registration card in a right-hand aside from lg; content sections render next to it in the existing markdown pipeline. Empty sections no longer emit headings, and the registrations-open status label now reads as a status ("Påmelding åpen") instead of a CTA.

Also adds a dev:staging script that sources BACKEND_URL from an untracked .env.staging, so the frontend can be pointed at the staging API without checking any URL into the repo.