### PR TITLE
feat(web): sticky two-row navigation on the event detail page

### DIFF
--- a/.changeset/event-detail-section-nav.md
+++ b/.changeset/event-detail-section-nav.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': minor
+---
+
+Sticky two-row navigation on the event detail page: the public site navbar now sticks to the top with a surface background and hairline, and a section nav sits directly under it with mono overline links (Informasjon · Program · Praktisk · Påmelding) that highlight the section in view. Anchors land clear of both bars, and the sticky registration card sits below them on wide screens.

--- a/apps/web/locales/en-US/common.json
+++ b/apps/web/locales/en-US/common.json
@@ -113,7 +113,8 @@
         "description": "We do not know where to look.",
         "title": "Sorry, not found."
       },
-      "registration": "Registration"
+      "registration": "Registration",
+      "sectionNav": "On this page"
     },
     "event": "Event",
     "event-not-found": "Event not found",

--- a/apps/web/locales/nb-NO/common.json
+++ b/apps/web/locales/nb-NO/common.json
@@ -113,7 +113,8 @@
         "description": "Vi finner ikke dette arrangementet",
         "title": "Beklager, kunne ikke finne siden"
       },
-      "registration": "Påmelding"
+      "registration": "Påmelding",
+      "sectionNav": "Innhold"
     },
     "event": "Arrangement",
     "event-not-found": "Arrangementet ble ikke funnet",

--- a/apps/web/src/app/(public)/events/EventDetails.tsx
+++ b/apps/web/src/app/(public)/events/EventDetails.tsx
@@ -14,13 +14,19 @@ import {
   scheduleSanitizeSchema,
 } from '@eventuras/markdown-plugin-happening';
 import { Heading } from '@eventuras/ratio-ui/core/Heading';
-import { NavList } from '@eventuras/ratio-ui/core/NavList';
 import { AsideLayout } from '@eventuras/ratio-ui/layout/AsideLayout';
 import { Container } from '@eventuras/ratio-ui/layout/Container';
 import { Section } from '@eventuras/ratio-ui/layout/Section';
-import { Link } from '@eventuras/ratio-ui-next/Link';
 
+import EventSectionNav from '@/app/(public)/events/EventSectionNav';
 import { EventDto } from '@/lib/eventuras-public-sdk';
+
+// Sticky stack in ratio-ui spacing units (0.25rem on a fluid root font size):
+// the site navbar (`h-16`), the section nav under it (`h-12`), then a gap.
+const SITE_NAV_UNITS = 16;
+const SECTION_NAV_UNITS = 12;
+const GAP_UNITS = 6;
+const units = (n: number) => `calc(var(--spacing) * ${n})`;
 
 type EventProps = {
   eventinfo: EventDto;
@@ -29,7 +35,7 @@ type EventProps = {
 };
 
 /**
- * Renders event details with top sticky navigation for sections.
+ * Renders event details with a sticky section nav under the site navbar.
  * @param props - See {@link EventProps}.
  */
 const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
@@ -38,19 +44,16 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
   const sections = [
     {
       id: 'more-information',
-      href: '#more-information',
       title: t('common.events.moreinformation'),
       content: eventinfo.moreInformation,
     },
     {
       id: 'program',
-      href: '#program',
       title: t('common.events.program'),
       content: eventinfo.program,
     },
     {
       id: 'practical-information',
-      href: '#practical-information',
       title: t('common.events.practicalinformation'),
       content: eventinfo.practicalInformation,
     },
@@ -58,14 +61,34 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
 
   if (sections.length === 0 && !aside) return null;
 
+  const registrationLabel = t('common.events.detailspage.registration');
+  const hasNav = sections.length > 0;
+  const navItems = [
+    ...sections.map(({ id, title }) => ({ id, title })),
+    ...(aside ? [{ id: 'registration', title: registrationLabel }] : []),
+  ];
+  const stickyUnits = SITE_NAV_UNITS + (hasNav ? SECTION_NAV_UNITS : 0) + GAP_UNITS;
+  const stickyTop = units(stickyUnits);
+
   return (
     <Section className="pb-24">
-      {sections.length > 0 && <NavList items={sections} LinkComponent={Link} sticky />}
+      {hasNav && (
+        <EventSectionNav
+          sections={navItems}
+          top={units(SITE_NAV_UNITS)}
+          ariaLabel={t('common.events.detailspage.sectionNav')}
+        />
+      )}
       <Container size="xl">
-        <AsideLayout className="pt-8">
+        <AsideLayout className="pt-10">
           <AsideLayout.Main>
             {sections.map(section => (
-              <section key={section.id} id={section.id} className="mb-10">
+              <section
+                key={section.id}
+                id={section.id}
+                className="mb-10"
+                style={{ scrollMarginTop: stickyTop }}
+              >
                 <Heading as="h2" size="md">
                   {section.title}
                 </Heading>
@@ -85,9 +108,16 @@ const EventDetails: React.FC<EventProps> = ({ eventinfo, aside }) => {
             ))}
           </AsideLayout.Main>
           {aside && (
-            <AsideLayout.Aside width="lg" top={64}>
+            // AsideLayout.Aside only takes a px `top`; the sticky stack is rem-based, so
+            // mirror its classes here until ratio-ui accepts a CSS length.
+            <aside
+              id="registration"
+              aria-label={registrationLabel}
+              className="mt-8 lg:mt-0 lg:shrink-0 lg:sticky lg:w-96"
+              style={{ top: stickyTop, scrollMarginTop: stickyTop }}
+            >
               {aside}
-            </AsideLayout.Aside>
+            </aside>
           )}
         </AsideLayout>
       </Container>

--- a/apps/web/src/app/(public)/events/EventSectionNav.tsx
+++ b/apps/web/src/app/(public)/events/EventSectionNav.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useLayoutEffect, useRef, useState } from 'react';
+
+import { Container } from '@eventuras/ratio-ui/layout/Container';
+
+import { useActiveSection } from '@/app/(public)/events/useActiveSection';
+
+export type EventSectionNavSection = { id: string; title: string };
+
+export type EventSectionNavProps = {
+  sections: EventSectionNavSection[];
+  /** CSS `top` for the sticky bar — the height of the site navbar above it. */
+  top: string;
+  ariaLabel: string;
+};
+
+const linkClasses =
+  'font-mono text-[11px] font-semibold uppercase tracking-widest whitespace-nowrap no-underline transition-colors';
+
+/**
+ * Sticky in-page section nav under the site navbar — mono overline links with
+ * the current section highlighted. 12 spacing units tall (`h-12`).
+ */
+export default function EventSectionNav({
+  sections,
+  top,
+  ariaLabel,
+}: Readonly<EventSectionNavProps>) {
+  const ref = useRef<HTMLElement>(null);
+  const [offset, setOffset] = useState(0);
+  const activeId = useActiveSection(
+    sections.map(section => section.id),
+    offset
+  );
+
+  // Scroll-spy wants the bar's bottom edge in px; `top` is rem-based, so measure.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () => setOffset(Number.parseFloat(getComputedStyle(el).top) + el.offsetHeight);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    window.addEventListener('resize', measure);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', measure);
+    };
+  }, []);
+
+  return (
+    <nav
+      ref={ref}
+      aria-label={ariaLabel}
+      className="sticky z-10 bg-surface border-b border-border-1"
+      style={{ top }}
+    >
+      <Container size="xl" className="flex h-12 items-center gap-6 overflow-x-auto">
+        {sections.map(section => {
+          const current = activeId === section.id;
+          return (
+            <a
+              key={section.id}
+              href={`#${section.id}`}
+              aria-current={current ? 'location' : undefined}
+              className={`${linkClasses} ${
+                current ? 'text-(--text)' : 'text-(--text-subtle) hover:text-(--text)'
+              }`}
+            >
+              {section.title}
+            </a>
+          );
+        })}
+      </Container>
+    </nav>
+  );
+}

--- a/apps/web/src/app/(public)/events/useActiveSection.ts
+++ b/apps/web/src/app/(public)/events/useActiveSection.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Scroll-spy for in-page navigation: the id of the section currently under a
+ * sticky bar of `offset` px. Sections count as visible between the bar and the
+ * upper half of the viewport; at the bottom of the page the last id wins, so a
+ * short final section can still become active.
+ */
+export function useActiveSection(ids: string[], offset: number): string | undefined {
+  const [activeId, setActiveId] = useState<string>();
+  const idsKey = ids.join('|');
+
+  useEffect(() => {
+    const sectionIds = idsKey.split('|').filter(Boolean);
+    const elements = sectionIds
+      .map(id => document.getElementById(id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (elements.length === 0) return;
+
+    const visible = new Set<string>();
+    let current: string | undefined;
+    const update = () => {
+      const atBottom =
+        window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 2;
+      const next = atBottom ? sectionIds.at(-1) : sectionIds.find(id => visible.has(id));
+      if (next && next !== current) {
+        current = next;
+        setActiveId(next);
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) visible.add(entry.target.id);
+          else visible.delete(entry.target.id);
+        }
+        update();
+      },
+      { rootMargin: `-${offset}px 0px -50% 0px` }
+    );
+    elements.forEach(el => observer.observe(el));
+    window.addEventListener('scroll', update, { passive: true });
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('scroll', update);
+    };
+  }, [idsKey, offset]);
+
+  return activeId;
+}

--- a/apps/web/src/app/(public)/layout.tsx
+++ b/apps/web/src/app/(public)/layout.tsx
@@ -11,7 +11,7 @@ import SiteNavbar from '@/components/eventuras/SiteNavbar';
 export default function PublicLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <>
-      <SiteNavbar />
+      <SiteNavbar sticky />
 
       <main id="main-content">{children}</main>
 

--- a/apps/web/src/components/eventuras/SiteNavbarClient.tsx
+++ b/apps/web/src/components/eventuras/SiteNavbarClient.tsx
@@ -11,6 +11,10 @@ const BG_COLOR_BY_VARIANT: Record<Exclude<SiteNavbarVariant, 'dark'>, string> = 
   primary: 'bg-primary w-full py-1',
   transparent: 'bg-transparent w-full py-1',
 };
+// A sticky bar needs a surface behind it, and a known height (h-16 = 16 spacing
+// units) so page-level sticky elements (e.g. the event section nav) can sit right under it.
+const STICKY_TRANSPARENT_BG = 'bg-surface border-b border-border-1 w-full';
+const STICKY_CLASSES = 'h-16 flex items-center';
 
 export interface SiteNavbarClientProps {
   brand: string;
@@ -38,7 +42,14 @@ export default function SiteNavbarClient({
     <Navbar
       {...(isDark
         ? { dark: true, overlay: true, glass: true }
-        : { bgColor: BG_COLOR_BY_VARIANT[variant], sticky })}
+        : {
+            bgColor:
+              sticky && variant === 'transparent'
+                ? STICKY_TRANSPARENT_BG
+                : BG_COLOR_BY_VARIANT[variant],
+            sticky,
+            className: sticky ? STICKY_CLASSES : undefined,
+          })}
     >
       <Navbar.Brand>
         <Link href="/" className="text-lg tracking-tight whitespace-nowrap no-underline">

--- a/tests/e2e/specs/web/public/005-public-event-section-nav.spec.ts
+++ b/tests/e2e/specs/web/public/005-public-event-section-nav.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Validates the sticky two-row navigation on the public event detail page:
+ * - the section nav sticks directly under the site navbar while scrolling
+ * - clicking a section link lands the section below the sticky bars
+ * - scroll-spy marks the section in view with aria-current="location"
+ *
+ * The event is created via API with content in every section, plus filler in
+ * the last one so the program section can scroll all the way up under the bars.
+ */
+
+import { Logger } from '@eventuras/logger';
+import { expect, test } from '@playwright/test';
+
+import { adminApi } from '../../shared/api-helpers';
+import { generateTestEventData } from '../../shared/testEventData';
+
+const logger = Logger.create({ namespace: 'e2e:section-nav' });
+
+test.describe.configure({ mode: 'serial' });
+const eventName = `Section Nav Test Event - ${Math.floor(Date.now() / 1000 / 10)}`;
+let eventId: string;
+
+const filler = Array.from(
+  { length: 30 },
+  (_, i) => `Paragraph ${i + 1}: filler text so the page is long enough to scroll.`
+).join('\n\n');
+
+test.use({ storageState: 'tmp/auth/admin.json' });
+
+test.describe('section navigation on public event page', () => {
+  test('create event with content in every section via API', async () => {
+    const eventData = generateTestEventData(eventName);
+    logger.debug({ title: eventData.title }, 'Creating event via API');
+
+    const created = await adminApi.post<{ id: number }>('/v3/events', {
+      title: eventData.title,
+      slug: `section-nav-test-${Math.floor(Date.now() / 1000)}`,
+      headline: eventData.headline,
+      category: eventData.category,
+      description: eventData.description,
+      program: eventData.program,
+      practicalInformation: `${eventData.practicalInformation}\n\n${filler}`,
+      moreInformation: eventData.moreInformation,
+      status: 'RegistrationsOpen',
+      maxParticipants: eventData.maxParticipants,
+      city: eventData.city,
+      location: eventData.location,
+      organizationId: 1,
+    });
+
+    eventId = created.id.toString();
+    logger.debug({ eventId }, 'Event created via API');
+  });
+
+  test('section nav sticks under the site navbar and highlights the section in view', async ({
+    page,
+  }) => {
+    await page.goto(`/events/${eventId}`);
+    await page.waitForLoadState('load');
+
+    const siteNav = page.locator('nav').first();
+    const sectionNav = page.locator('nav', { has: page.locator('a[href="#program"]') });
+    await expect(sectionNav).toBeVisible();
+
+    logger.debug('Checking section links...');
+    const hrefs = await sectionNav
+      .locator('a')
+      .evaluateAll(links => links.map(link => link.getAttribute('href')));
+    expect(hrefs).toEqual([
+      '#more-information',
+      '#program',
+      '#practical-information',
+      '#registration',
+    ]);
+
+    logger.debug('Clicking the program link...');
+    await sectionNav.locator('a[href="#program"]').click();
+    const program = page.locator('#program');
+    await expect(program).toBeInViewport();
+    await expect(sectionNav.locator('a[href="#program"]')).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    await expect(sectionNav.locator('a[href="#more-information"]')).not.toHaveAttribute(
+      'aria-current',
+      /.+/
+    );
+
+    logger.debug('Checking the sticky stack...');
+    expect(await page.evaluate(() => globalThis.scrollY)).toBeGreaterThan(0);
+    const siteBox = await siteNav.boundingBox();
+    const navBox = await sectionNav.boundingBox();
+    const programBox = await program.boundingBox();
+    expect(siteBox?.y).toBe(0);
+    expect(navBox?.y).toBeCloseTo(siteBox!.y + siteBox!.height, 0);
+    expect(programBox!.y).toBeGreaterThanOrEqual(navBox!.y + navBox!.height);
+
+    logger.debug('Scrolling on to practical information...');
+    await page.evaluate(() => document.querySelector('#practical-information')?.scrollIntoView());
+    await expect(sectionNav.locator('a[href="#practical-information"]')).toHaveAttribute(
+      'aria-current',
+      'location'
+    );
+    const navBoxAfter = await sectionNav.boundingBox();
+    expect(navBoxAfter?.y).toBeCloseTo(siteBox!.y + siteBox!.height, 0);
+
+    logger.debug('Section nav is sticky and tracks the section in view');
+  });
+});


### PR DESCRIPTION
## What

Next step of the public event detail page redesign: the two-row sticky navigation.

- **Site navbar** on the `(public)` layout is now sticky, with a surface background, a hairline and a fixed `h-16` so page-level sticky elements can sit directly under it.
- **Section nav** (`EventSectionNav`) sticks right under the navbar: mono overline links (Informasjon · Program · Praktisk · Påmelding) with scroll-spy highlighting via a small `useActiveSection` hook. "Påmelding" anchors to the registration card. Replaces the old `NavList`.
- Anchors and the sticky registration card land clear of both bars.

## Why the offsets look the way they do

ratio-ui's root font size is fluid (`clamp(1rem, …, 1.13rem)`) and scales with the user's default font size, so `h-16` is 64px on a phone, ~71px at 1280px, and more for users with a larger base font. Every offset is therefore expressed in spacing units (`calc(var(--spacing) * n)`) rather than px — the section nav's `top`, the sections' `scroll-margin-top`, and the aside's sticky `top`. `AsideLayout.Aside` only accepts a px `top`, so the aside mirrors its utilities locally until ratio-ui accepts a CSS length; a brief for ratio-ui covering this (`top: number | string`, a `SectionNav` primitive, the scroll-spy hook, `Navbar` `aria-label`/light `glass`) is written separately.

## Verified

- eslint, prettier and `tsc --noEmit` clean.
- Playwright against staging (event 503) at 390px and 1280px: the two bars sit flush at both widths, anchors land 6 units under the section nav, the aside is sticky under both bars from `lg`, scroll-spy tracks the section in view and falls back to the last section at the bottom of the page.
- New E2E spec `tests/e2e/specs/web/public/005-public-event-section-nav.spec.ts`: section links, sticky stack geometry, anchor landing below the bars, and `aria-current` following the section in view.

Note: this makes the header sticky on all `(public)` pages (events list, collections). Admin, user and front page layouts are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
