### PR TITLE
fix(web): unique registration test ids, build identity in healthz, image smoke test

### DIFF
--- a/.changeset/event-page-testids-and-healthz-build.md
+++ b/.changeset/event-page-testids-and-healthz-build.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': patch
+---
+
+The registration CTA in the event hero now has its own test id (`event-registration-button-hero`) so `event-registration-button` uniquely identifies the one in the registration card, and `/api/healthz` reports `gitSha` and `imageTag` so a deploy gate can verify which build is serving without authenticating.

--- a/.github/workflows/web-docker.yml
+++ b/.github/workflows/web-docker.yml
@@ -96,6 +96,62 @@ jobs:
             org.opencontainers.image.revision=${{ steps.ver.outputs.sha }}
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
 
+      - name: Build amd64 image for smoke test
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: apps/web/Dockerfile
+          platforms: linux/amd64
+          load: true
+          tags: eventuras-web:smoke
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          secrets: |
+            TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
+            TURBO_TEAM=${{ secrets.TURBO_TEAM }}
+          build-args: |
+            GIT_SHA=${{ steps.ver.outputs.sha }}
+
+      # A standalone build missing a runtime dependency (next@16.3.1 without the
+      # @swc/helpers esm files, 2026-08-26) only fails when the server starts —
+      # in the cluster that is a CrashLoopBackOff nobody notices. Boot the image
+      # and require /api/healthz to answer with this build's sha before pushing.
+      - name: Smoke test — image starts and serves /api/healthz
+        env:
+          EXPECTED_SHA: ${{ steps.ver.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Placeholder config: app-config validates these at startup, but
+          # /api/healthz contacts nothing, so the values only need to parse.
+          docker run -d --name web-smoke -p 3000:3000 \
+            -e APPLICATION_URL=http://localhost:3000 \
+            -e LOGOUT_URL_REDIRECT=http://localhost:3000 \
+            -e DEFAULT_LOCALE=nb-NO \
+            -e ORGANIZATION_ID=1 \
+            -e BACKEND_URL=https://smoke.invalid \
+            -e OIDC_ISSUER=https://smoke.invalid/realms/smoke \
+            -e OIDC_CLIENT_ID=smoke \
+            -e OIDC_CLIENT_SECRET=smoke \
+            -e SESSION_SECRET=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+            eventuras-web:smoke
+          trap 'docker rm -f web-smoke >/dev/null 2>&1 || true' EXIT
+          for _ in $(seq 1 30); do
+            if BODY=$(curl -fsS http://localhost:3000/api/healthz 2>/dev/null); then
+              echo "healthz: ${BODY}"
+              SHA=$(jq -r '.gitSha // empty' <<<"${BODY}")
+              if [[ "${SHA}" != "${EXPECTED_SHA}" ]]; then
+                echo "::error::/api/healthz reports gitSha '${SHA}', expected '${EXPECTED_SHA}'"
+                docker logs web-smoke || true
+                exit 1
+              fi
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::web image did not answer /api/healthz within 30s"
+          docker logs web-smoke || true
+          exit 1
+
       - name: Login to Docker Hub
         if: inputs.push
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/apps/web/src/app/(public)/events/EventRegistrationButton.tsx
+++ b/apps/web/src/app/(public)/events/EventRegistrationButton.tsx
@@ -7,20 +7,18 @@ import { eventStatusLabel } from '@/app/(public)/events/eventStatusLabel';
 import { EventDto, EventInfoStatus } from '@/lib/eventuras-public-sdk';
 export type EventRegistrationButtonProps = {
   event: EventDto;
+  /** Override when the page renders more than one CTA, so test IDs stay unique. */
+  testId?: string;
 };
 export default async function EventRegistrationButton({
   event,
+  testId = 'event-registration-button',
 }: Readonly<EventRegistrationButtonProps>) {
   const t = await getTranslations();
   const canRegister = event.status === EventInfoStatus.REGISTRATIONS_OPEN;
   if (canRegister) {
     return (
-      <Link
-        href={`/user/events/${event.id}`}
-        variant="button-primary"
-        block
-        testId="event-registration-button"
-      >
+      <Link href={`/user/events/${event.id}`} variant="button-primary" block testId={testId}>
         {t('common.buttons.register-cta')}
       </Link>
     );

--- a/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
+++ b/apps/web/src/app/(public)/events/[id]/[slug]/page.tsx
@@ -190,7 +190,7 @@ export default async function EventDetailsPage({ params }: Readonly<EventDetails
 
           <div className="lg:hidden mt-6">
             <Suspense fallback={<div>Loading registration options...</div>}>
-              <EventRegistrationButton event={eventinfo} />
+              <EventRegistrationButton event={eventinfo} testId="event-registration-button-hero" />
             </Suspense>
           </div>
         </Container>

--- a/apps/web/src/app/api/healthz/route.ts
+++ b/apps/web/src/app/api/healthz/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from 'next/server';
 
 /**
- * Health check endpoint for Kubernetes liveness and readiness probes.
+ * Health check endpoint for Kubernetes liveness and readiness probes, and for
+ * the CD gate to verify which build is actually serving. Unauthenticated: a git
+ * SHA and image tag are not sensitive.
  * GET /api/healthz
  */
 export async function GET() {
@@ -9,6 +11,8 @@ export async function GET() {
     {
       status: 'ok',
       timestamp: new Date().toISOString(),
+      gitSha: process.env.BUILD_GIT_SHA ?? 'unknown',
+      imageTag: process.env.IMAGE_TAG ?? 'unknown',
     },
     { status: 200 }
   );

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -15,7 +15,12 @@
         "OIDC_API_AUDIENCE",
         "OIDC_ROLES_CLAIM",
         "SESSION_SECRET",
-        "NODE_ENV"
+        "NODE_ENV",
+        "GIT_SHA",
+        "BUILD_GIT_SHA",
+        "BUILD_VERSION",
+        "BUILD_TIME",
+        "IMAGE_TAG"
       ],
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## Why

Prod CD has been blocked on a red E2E gate since the event-detail-page redesign (infra brief, 2026-08-28). Two failures were reported on `main-162d84f`; one is a real bug in the app, the other was the gate testing the wrong pod.

## What

**E2E §1a — duplicate `data-testid="event-registration-button"`** (real, introduced by `da22979`)
The event page renders the registration CTA twice: in the hero (`lg:hidden`, mobile) and in the registration card. `tests/e2e/specs/web/helpers/registration.ts` clicks by that test id and hits Playwright's strict-mode violation. `EventRegistrationButton` now takes a `testId` prop (default unchanged); the hero passes `event-registration-button-hero`. The card keeps the canonical id — it is the one visible on Desktop Chrome, and the helper is the only consumer.

**E2E §1b — section nav without `#registration`** (not a code bug, no change)
Staging on `main-162d84f` serves `href="#registration"` and `id="registration"` today; replaying every assertion of `005-public-event-section-nav.spec.ts` against `/events/924` passes. The failing run (18:05Z) hit the previous pod — `162d84f` became Ready at 18:12Z — and the old `NavList` has exactly the three hrefs the spec received. This is the stale-pod gap the brief describes in §2 and is fixed on the infra side (verify the rollout before E2E).

**Ask 3 — build identity without auth**
`/api/healthz` now returns `gitSha` (baked in via `BUILD_GIT_SHA`) and `imageTag` (runtime `IMAGE_TAG`, `unknown` until set) alongside `status`/`timestamp`. `/api/system/version` is unchanged (still Admin-only).

**Ask 2 — startup smoke test in `web-docker.yml`**
In the `docker` job, before login/push: build the amd64 image with `load: true` (same GHA cache, so the multi-platform build afterwards reuses the layers), `docker run` it and poll `/api/healthz` for up to 30 s, requiring the response to report this build's sha. Fails with `docker logs`. Runs on PR builds too (`push: false`). The release job (`build-for-release`) is not touched.

Also declares `GIT_SHA`/`BUILD_*`/`IMAGE_TAG` in `apps/web/turbo.json`, which clears the `turbo/no-undeclared-env-vars` warnings in both `healthz` and the existing `version` route.

## Verified

- eslint, prettier, `tsc --noEmit` clean; workflow YAML parses.
- Local dev server against the staging API: `/events/503` renders `event-registration-button` ×1 (card) and `event-registration-button-hero` ×1; `/api/healthz` → `{"status":"ok","timestamp":…,"gitSha":"unknown","imageTag":"unknown"}` (sha is `unknown` outside the image build).
- Staging `/events/924` (Playwright replay of the 005 assertions): hrefs `[#more-information, #program, #practical-information, #registration]`, section nav flush under the site navbar, `aria-current` follows the section in view.

## Note for the CD gate

The next `main` build only goes green if the gate tests the promoted tag: the pod currently serving staging still has the duplicate test id. Both sides need to land; `gitSha` in `/api/healthz` is what the gate can compare against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
