### PR TITLE
feat(web): interpret occasions and theme from site settings

### DIFF
--- a/.changeset/web-occasions-config.md
+++ b/.changeset/web-occasions-config.md
@@ -1,0 +1,5 @@
+---
+'@eventuras/web': minor
+---
+
+Site settings can carry an `occasions` block — days the site marks (mourning, Pride, Christmas, New Year, Constitution Day) as a dated override and a yearly schedule. The block is validated entry by entry (invalid entries are logged and dropped), resolved per request in the site's time zone, and the active occasion is exposed as `data-occasion` on `<html>`, with ratio-ui's `data-motion="none"` switch set during mourning. Theming follows ratio-ui's two axes: an occasion or the site can set a named palette (`theme` → `data-theme`, e.g. `bureau`, `ink`) and/or force a colour scheme (`colorScheme` → `data-color-scheme`), rendered server-side with the theme toggle hidden while forced. The light/dark toggle itself now writes `data-color-scheme` instead of the legacy `data-theme="dark"` — the consumer step of ratio-ui's theme migration; stored preferences carry over. No visual changes yet: occasion styling and announcements follow in ratio-ui.

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint
         run: pnpm turbo run lint --filter=@eventuras/web...
 
+      - name: Unit tests
+        run: pnpm turbo run test --filter=@eventuras/web
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -83,6 +83,52 @@ This is a plugin for visual code which makes it easier to see the translations i
     "i18n-ally.keystyle": "nested"
 ```
 
+## Site settings: occasions
+
+The hosted site-settings JSON (`SITE_SETTINGS_URL`) may carry an `occasions` block under
+`site` for days the site marks — mourning, Pride, Christmas, New Year, Constitution Day. The
+app validates it entry by entry (invalid entries are logged and dropped, never fatal), resolves
+what is active per request in the site's time zone, and sets `data-occasion` on `<html>` — plus
+ratio-ui's `data-motion="none"` switch during mourning. Nothing is styled yet: per ratio-ui's
+`docs/occasions.md` the app owns one CSS block per occasion on the `ratio-navbar` / `ratio-hero`
+hooks and feeds the motif/wash slots from config; that, and announcements (`Announcement`),
+follow once ratio-ui 2.20 is published.
+
+```json
+{
+  "site": {
+    "theme": "bureau",
+    "occasions": {
+      "timeZone": "Europe/Oslo",
+      "override": {
+        "id": "mourning",
+        "from": "2026-08-29",
+        "until": "2026-09-14",
+        "theme": "ink",
+        "colorScheme": "dark"
+      },
+      "schedule": [
+        { "id": "constitution-day", "from": "05-16", "until": "05-17" },
+        { "id": "christmas", "from": "12-15", "until": "12-26" },
+        { "id": "new-year", "from": "12-31", "until": "01-01" },
+        { "id": "pride", "from": "2026-06-19", "until": "2026-06-28" }
+      ]
+    }
+  }
+}
+```
+
+- `id`: any lowercase slug (`^[a-z0-9]+(-[a-z0-9]+)*$`, ≤ 40 chars). Which ids get styling is decided in ratio-ui; an unknown id passes through and styles nothing. `mourning` is the one id the app itself reacts to (motion off)
+- `from`/`until`: inclusive; `YYYY-MM-DD` for a one-off, `MM-DD` for a yearly window (may wrap the year end)
+- Resolution: `override` (inside its window) → first matching `schedule` entry → none
+- `theme`: a named ratio-ui palette (`bureau`, `ink`, …) on `data-theme` while the occasion is active; absent = the standard theme
+- `colorScheme`: `light` or `dark`, forced while the occasion is active. Rendered server-side as `data-color-scheme`; the stored preference is ignored and the theme toggle is hidden. The user's own choice returns untouched when the occasion ends
+- `site.theme` / `site.colorScheme` (outside `occasions`): the same, always on — a site that is `bureau`, or dark by design
+
+Theming is two axes, per ratio-ui's contract: `data-theme` is the palette and belongs to the server (site or occasion), `data-color-scheme` is light/dark and is the user's toggle unless forced. Colours, CSS and motifs never come from JSON.
+
+Run the unit tests with `pnpm test`.
+
 ## Testing
 
 ### Cloudflare tunnels

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix && prettier . --write",
     "start": "next start",
+    "test": "vitest run",
     "vercel-build": "pnpm --filter=@eventuras/web^... build && next build"
   },
   "lint-staged": {
@@ -70,7 +71,8 @@
     "postcss": "^8.5.26",
     "prettier": "^3.9.6",
     "tailwindcss": "^4.3.3",
-    "typescript": "6.0.3"
+    "typescript": "6.0.3",
+    "vitest": "^4.1.10"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "4.62.4"

--- a/apps/web/src/app/Providers.tsx
+++ b/apps/web/src/app/Providers.tsx
@@ -13,7 +13,7 @@ import { authStore, useAuthStore } from '@/auth/authStore';
 import { LoginSuccessHandler } from '@/components/auth/LoginSuccessHandler';
 import { SessionWarningOverlay } from '@/components/SessionWarningOverlay';
 import { SentryUserContext } from '@/providers/sentry/SentryUserContext';
-import { ThemeProvider } from '@/providers/theme';
+import { type Theme, ThemeProvider } from '@/providers/theme';
 import { getAuthStatus } from '@/utils/auth/getAuthStatus';
 
 const logger = Logger.create({
@@ -23,6 +23,8 @@ const logger = Logger.create({
 
 type ProvidersProps = {
   children: React.ReactNode;
+  /** Colour scheme forced by the site or an active occasion; hides the user's toggle. */
+  forcedColorScheme?: Theme | null;
 };
 
 /**
@@ -49,7 +51,7 @@ function HeartbeatRunner() {
   return null;
 }
 
-export default function Providers({ children }: Readonly<ProvidersProps>) {
+export default function Providers({ children, forcedColorScheme }: Readonly<ProvidersProps>) {
   const { isAuthenticated } = useAuthStore();
 
   // Initialize auth store and start session monitoring
@@ -96,7 +98,7 @@ export default function Providers({ children }: Readonly<ProvidersProps>) {
   }, []);
 
   return (
-    <ThemeProvider>
+    <ThemeProvider forced={forcedColorScheme}>
       <ToastRenderer />
       <LoginSuccessHandler />
       <SentryUserContext />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,38 +5,62 @@ import { getLocale, getMessages } from 'next-intl/server';
 import { InitSentry } from '@/providers/sentry';
 import { InitTheme } from '@/providers/theme';
 import getSiteSettings from '@/utils/site/getSiteSettings';
+import { resolveOccasion } from '@/utils/site/occasions';
 
 import Providers from './Providers';
 
 import '@eventuras/ratio-ui/ratio-ui.css';
 import '@eventuras/ratio-ui/fonts.css';
 
-const siteSettings = await getSiteSettings();
-export const metadata: Metadata = {
-  title: {
-    template: `%s | ${siteSettings?.name ?? 'Eventuras'}`,
-    default: siteSettings?.name ?? 'Eventuras',
-  },
-  description: siteSettings?.description ?? 'A life with eventuras',
-};
+// getSiteSettings is memoized per request, so this and the layout below share
+// one call and follow the same 10-minute revalidation instead of a one-off
+// read at startup.
+export async function generateMetadata(): Promise<Metadata> {
+  const siteSettings = await getSiteSettings();
+  return {
+    title: {
+      template: `%s | ${siteSettings?.name ?? 'Eventuras'}`,
+      default: siteSettings?.name ?? 'Eventuras',
+    },
+    description: siteSettings?.description ?? 'A life with eventuras',
+  };
+}
 
 /**
  * Root Layout - Minimal wrapper providing html/body structure
- * Actual navbar/footer are in route group layouts
+ * Actual navbar/footer are in route group layouts.
+ * The active occasion (mourning, Pride, …) rides on <html> next to the theme
+ * for the app's [data-occasion] CSS and ratio-ui's chrome hooks; mourning also
+ * flips ratio-ui's data-motion="none" switch (stillness is the device). Theming is
+ * two axes: data-theme is the palette (a named ratio-ui theme from the
+ * occasion or the site; absent = standard) and data-color-scheme is
+ * light/dark — the user's stored choice, unless the occasion or the site
+ * forces one, in which case it is rendered here and the client leaves it alone.
  */
 export default async function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   const locale = await getLocale();
   const messages = await getMessages();
+  const site = await getSiteSettings();
+  const occasion = resolveOccasion(site?.occasions);
+  const theme = occasion?.theme ?? site?.theme ?? null;
+  const forcedColorScheme = occasion?.colorScheme ?? site?.colorScheme ?? null;
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html
+      lang={locale}
+      suppressHydrationWarning
+      data-theme={theme ?? undefined}
+      data-color-scheme={forcedColorScheme ?? undefined}
+      data-occasion={occasion?.id}
+      data-motion={occasion?.id === 'mourning' ? 'none' : undefined}
+    >
       <head>
         <InitSentry />
-        <InitTheme />
+        <InitTheme forced={forcedColorScheme} />
       </head>
       <body>
         <NextIntlClientProvider messages={messages}>
-          <Providers>{children}</Providers>
+          <Providers forcedColorScheme={forcedColorScheme}>{children}</Providers>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/apps/web/src/components/eventuras/UserMenu.tsx
+++ b/apps/web/src/components/eventuras/UserMenu.tsx
@@ -97,7 +97,7 @@ function UserDropdownMenu({
   >;
   onLogout: () => void;
 }>) {
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme, locked } = useTheme();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const handleLogout = () => {
@@ -125,12 +125,14 @@ function UserDropdownMenu({
       </Menu.Link>
       <Menu.Link href="/user/account">{translations.accountLabel}</Menu.Link>
       {isAdmin && <Menu.Link href="/admin">{translations.adminLabel}</Menu.Link>}
-      <Menu.ThemeToggle
-        theme={theme}
-        onThemeChange={setTheme}
-        lightLabel={translations.lightThemeLabel}
-        darkLabel={translations.darkThemeLabel}
-      />
+      {!locked && (
+        <Menu.ThemeToggle
+          theme={theme}
+          onThemeChange={setTheme}
+          lightLabel={translations.lightThemeLabel}
+          darkLabel={translations.darkThemeLabel}
+        />
+      )}
       <Menu.Button id="logout-button" onClick={handleLogout} isDisabled={isLoggingOut}>
         {isLoggingOut ? translations.loggingOutLabel : translations.logoutLabel}
       </Menu.Button>

--- a/apps/web/src/providers/theme/InitTheme.tsx
+++ b/apps/web/src/providers/theme/InitTheme.tsx
@@ -1,6 +1,7 @@
 import Script from 'next/script';
 
 import { defaultTheme, themeLocalStorageKey } from './shared';
+import type { Theme } from './types';
 
 const themeScript = `
 (function () {
@@ -26,15 +27,19 @@ const themeScript = `
       themeToSet = implicitPreference
     }
   }
-  document.documentElement.setAttribute('data-theme', themeToSet)
+  document.documentElement.setAttribute('data-color-scheme', themeToSet)
 })();
 `;
 
 // Uses next/script with beforeInteractive so the script lands in the SSR
 // head and runs before hydration (anti-FOUC). A plain <script> here
 // triggers a React 19 dev warning even though it works at runtime.
-export const InitTheme = () => (
-  <Script id="theme-script" strategy="beforeInteractive">
-    {themeScript}
-  </Script>
-);
+// Writes ratio-ui's light/dark axis (data-color-scheme); data-theme is the
+// palette and belongs to the server. With a forced colour scheme the attribute
+// is server-rendered and the stored preference must not override it: no script.
+export const InitTheme = ({ forced }: { forced?: Theme | null }) =>
+  forced ? null : (
+    <Script id="theme-script" strategy="beforeInteractive">
+      {themeScript}
+    </Script>
+  );

--- a/apps/web/src/providers/theme/ThemeProvider.tsx
+++ b/apps/web/src/providers/theme/ThemeProvider.tsx
@@ -11,29 +11,48 @@ import { themeIsValid } from './types';
 const initialContext: ThemeContextType = {
   setTheme: () => null,
   theme: undefined,
+  locked: false,
 };
 
 const ThemeContext = createContext(initialContext);
 
-export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+export const ThemeProvider = ({
+  children,
+  forced,
+}: {
+  children: React.ReactNode;
+  /** Server-forced colour scheme (light/dark, from the site or an occasion); the stored preference is ignored. Named palettes live on data-theme and never pass through here. */
+  forced?: Theme | null;
+}) => {
   const [theme, setThemeState] = useState<Theme | undefined>(
-    canUseDOM ? (document.documentElement.dataset.theme as Theme) : undefined
+    forced ?? (canUseDOM ? (document.documentElement.dataset.colorScheme as Theme) : undefined)
   );
 
-  const setTheme = useCallback((themeToSet: Theme | null) => {
-    if (themeToSet === null) {
-      globalThis.localStorage.removeItem(themeLocalStorageKey);
-      const implicitPreference = getImplicitPreference();
-      document.documentElement.dataset.theme = implicitPreference || '';
-      if (implicitPreference) setThemeState(implicitPreference);
-    } else {
-      setThemeState(themeToSet);
-      globalThis.localStorage.setItem(themeLocalStorageKey, themeToSet);
-      document.documentElement.dataset.theme = themeToSet;
-    }
-  }, []);
+  const setTheme = useCallback(
+    (themeToSet: Theme | null) => {
+      if (forced) return;
+      if (themeToSet === null) {
+        globalThis.localStorage.removeItem(themeLocalStorageKey);
+        // No reliable matchMedia → fall back rather than leave the attribute empty.
+        const implicitPreference = getImplicitPreference() ?? defaultTheme;
+        document.documentElement.dataset.colorScheme = implicitPreference;
+        setThemeState(implicitPreference);
+      } else {
+        setThemeState(themeToSet);
+        globalThis.localStorage.setItem(themeLocalStorageKey, themeToSet);
+        document.documentElement.dataset.colorScheme = themeToSet;
+      }
+    },
+    [forced]
+  );
 
   useEffect(() => {
+    // A forced scheme is server-rendered; keep DOM and context in step with it.
+    if (forced) {
+      document.documentElement.dataset.colorScheme = forced;
+      setThemeState(forced);
+      return;
+    }
     let themeToSet: Theme = defaultTheme;
     const preference = globalThis.localStorage.getItem(themeLocalStorageKey);
 
@@ -47,11 +66,14 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
       }
     }
 
-    document.documentElement.dataset.theme = themeToSet;
+    document.documentElement.dataset.colorScheme = themeToSet;
     setThemeState(themeToSet);
-  }, []);
+  }, [forced]);
 
-  const contextValue = useMemo(() => ({ setTheme, theme }), [setTheme, theme]);
+  const contextValue = useMemo(
+    () => ({ setTheme, theme, locked: Boolean(forced) }),
+    [setTheme, theme, forced]
+  );
 
   return <ThemeContext.Provider value={contextValue}>{children}</ThemeContext.Provider>;
 };

--- a/apps/web/src/providers/theme/types.ts
+++ b/apps/web/src/providers/theme/types.ts
@@ -1,8 +1,11 @@
+/** The light/dark axis — written to `data-color-scheme`. Named palettes live on `data-theme`. */
 export type Theme = 'dark' | 'light';
 
 export interface ThemeContextType {
   setTheme: (theme: Theme | null) => void;
   theme?: Theme | null;
+  /** The site or an occasion forces the theme; `setTheme` is a no-op and the toggle hides. */
+  locked?: boolean;
 }
 
 export function themeIsValid(string: null | string): string is Theme {

--- a/apps/web/src/utils/site/getSiteSettings.ts
+++ b/apps/web/src/utils/site/getSiteSettings.ts
@@ -1,4 +1,14 @@
+import { cache } from 'react';
+
 import { Logger } from '@eventuras/logger';
+
+import {
+  type ColorScheme,
+  isColorScheme,
+  isSlug,
+  type OccasionsConfig,
+  parseOccasions,
+} from '@/utils/site/occasions';
 
 const logger = Logger.create({
   namespace: 'web:utils:site',
@@ -41,15 +51,23 @@ export interface SiteInfo {
   contactInformation: {
     support: SupportContact;
   };
+  /** Short-lived markings and announcements; see `occasions.ts`. Invalid entries are dropped. */
+  occasions?: OccasionsConfig | null;
+  /** Named ratio-ui palette for the whole site (`data-theme`). Absent = standard. */
+  theme?: string | null;
+  /** Always-on colour scheme for the site; the user's toggle is hidden. Absent = user's choice. */
+  colorScheme?: ColorScheme | null;
 }
 
 /**
  * Fetches site settings from the configured URL.
- * Uses Next.js fetch caching with 10-minute revalidation.
+ * Uses Next.js fetch caching with 10-minute revalidation, and is memoized per
+ * request with React `cache()` so metadata, layouts and the navbar share one
+ * call (and one pair of log lines) per render.
  *
  * @returns Site information or null if not configured or fetch fails
  */
-const getSiteSettings = async (): Promise<SiteInfo | null> => {
+const getSiteSettings = cache(async (): Promise<SiteInfo | null> => {
   const siteSettingsUrl = process.env.SITE_SETTINGS_URL;
 
   if (!siteSettingsUrl) {
@@ -80,11 +98,24 @@ const getSiteSettings = async (): Promise<SiteInfo | null> => {
     }
 
     logger.info('Site settings fetched successfully');
-    return data.site;
+    const occasions = parseOccasions(data.site.occasions, (path, reason) =>
+      logger.warn({ path, reason }, 'Ignoring invalid occasions entry in site settings')
+    );
+    let theme: string | null = null;
+    if (data.site.theme != null) {
+      if (isSlug(data.site.theme)) theme = data.site.theme;
+      else logger.warn({ value: data.site.theme }, 'Ignoring invalid site theme');
+    }
+    let colorScheme: ColorScheme | null = null;
+    if (data.site.colorScheme != null) {
+      if (isColorScheme(data.site.colorScheme)) colorScheme = data.site.colorScheme;
+      else logger.warn({ value: data.site.colorScheme }, 'Ignoring invalid site colorScheme');
+    }
+    return { ...data.site, occasions, theme, colorScheme };
   } catch (error) {
     logger.error({ error, url: siteSettingsUrl }, 'Failed to fetch site settings');
     return null;
   }
-};
+});
 
 export default getSiteSettings;

--- a/apps/web/src/utils/site/occasions.test.ts
+++ b/apps/web/src/utils/site/occasions.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isInWindow,
+  localDate,
+  type OccasionsConfig,
+  parseOccasions,
+  resolveOccasion,
+} from './occasions';
+
+const at = (iso: string) => new Date(iso);
+
+describe('parseOccasions', () => {
+  it('returns null when the block is absent', () => {
+    expect(parseOccasions(undefined)).toBeNull();
+    expect(parseOccasions(null)).toBeNull();
+  });
+
+  it('keeps valid entries and drops invalid ones individually', () => {
+    const rejected: string[] = [];
+    const config = parseOccasions(
+      {
+        override: {
+          id: 'mourning',
+          from: '2026-08-29',
+          until: '2026-09-14',
+          theme: 'ink',
+          colorScheme: 'dark',
+        },
+        schedule: [
+          { id: 'constitution-day', from: '05-16', until: '05-17' },
+          { id: 'halloween', from: '10-31', until: '10-31' },
+          { id: 'Jul 2026', from: '12-15', until: '12-26' },
+          { id: 'pride', from: '2026-06-19' },
+          { id: 'christmas', from: '12-15', until: '2026-12-26' },
+          { id: 'noir', from: '11-01', until: '11-02', colorScheme: 'sepia' },
+          { id: 'retro', from: '11-03', until: '11-04', theme: 'Bureau Theme' },
+        ],
+      },
+      path => rejected.push(path)
+    );
+
+    expect(config?.override).toEqual({
+      id: 'mourning',
+      from: '2026-08-29',
+      until: '2026-09-14',
+      theme: 'ink',
+      colorScheme: 'dark',
+    });
+    // Any slug is a valid id — which ids get styling is ratio-ui's business — but not free text.
+    expect(config?.schedule?.map(s => s.id)).toEqual(['constitution-day', 'halloween']);
+    expect(rejected).toEqual([
+      'occasions.schedule[2]',
+      'occasions.schedule[3]',
+      'occasions.schedule[4]',
+      'occasions.schedule[5]',
+      'occasions.schedule[6]',
+    ]);
+  });
+
+  it('rejects impossible dates but accepts 29 February in a yearly window', () => {
+    const rejected: string[] = [];
+    const config = parseOccasions(
+      {
+        schedule: [
+          { id: 'leap', from: '02-28', until: '02-29' },
+          { id: 'nope', from: '2026-02-31', until: '2026-03-01' },
+          { id: 'nope-2', from: '13-01', until: '13-02' },
+        ],
+      },
+      path => rejected.push(path)
+    );
+    expect(config?.schedule?.map(s => s.id)).toEqual(['leap']);
+    expect(rejected).toEqual(['occasions.schedule[1]', 'occasions.schedule[2]']);
+  });
+
+  it('rejects a one-off window whose until is before from, but lets yearly windows wrap', () => {
+    const rejected: string[] = [];
+    const config = parseOccasions(
+      {
+        schedule: [
+          { id: 'backwards', from: '2026-09-14', until: '2026-08-29' },
+          { id: 'new-year', from: '12-31', until: '01-01' },
+        ],
+      },
+      path => rejected.push(path)
+    );
+    expect(config?.schedule?.map(s => s.id)).toEqual(['new-year']);
+    expect(rejected).toEqual(['occasions.schedule[0]']);
+  });
+
+  it('treats an explicit null the same as an absent field', () => {
+    const rejected: string[] = [];
+    const config = parseOccasions(
+      {
+        timeZone: null,
+        override: null,
+        schedule: [{ id: 'pride', from: '06-19', until: '06-28', theme: null, colorScheme: null }],
+      },
+      path => rejected.push(path)
+    );
+    expect(config).toEqual({ schedule: [{ id: 'pride', from: '06-19', until: '06-28' }] });
+    expect(rejected).toEqual([]);
+  });
+
+  it('drops an invalid time zone but keeps the rest', () => {
+    const rejected: string[] = [];
+    const config = parseOccasions(
+      { timeZone: 'Mars/Olympus', schedule: [{ id: 'pride', from: '06-19', until: '06-28' }] },
+      path => rejected.push(path)
+    );
+    expect(config).toEqual({ schedule: [{ id: 'pride', from: '06-19', until: '06-28' }] });
+    expect(rejected).toEqual(['occasions.timeZone']);
+  });
+
+  it('rejects a block or schedule of the wrong shape without throwing', () => {
+    const rejected: string[] = [];
+    expect(parseOccasions('mourning', path => rejected.push(path))).toBeNull();
+    expect(parseOccasions({ schedule: 'pride' }, path => rejected.push(path))).toEqual({});
+    expect(rejected).toEqual(['occasions', 'occasions.schedule']);
+  });
+});
+
+describe('localDate and isInWindow', () => {
+  it('reads the calendar date in the configured zone', () => {
+    // 23:30 UTC on 16 May is already 17 May in Oslo.
+    expect(localDate(at('2026-05-16T23:30:00Z'), 'Europe/Oslo')).toBe('2026-05-17');
+    expect(localDate(at('2026-05-16T23:30:00Z'), 'UTC')).toBe('2026-05-16');
+  });
+
+  it('treats windows as inclusive and lets yearly windows wrap the year', () => {
+    expect(isInWindow('2026-09-14', '2026-08-29', '2026-09-14')).toBe(true);
+    expect(isInWindow('2026-09-15', '2026-08-29', '2026-09-14')).toBe(false);
+    expect(isInWindow('2027-01-01', '12-31', '01-01')).toBe(true);
+    expect(isInWindow('2026-12-31', '12-31', '01-01')).toBe(true);
+    expect(isInWindow('2026-12-30', '12-31', '01-01')).toBe(false);
+  });
+});
+
+describe('resolveOccasion', () => {
+  const config: OccasionsConfig = {
+    override: {
+      id: 'mourning',
+      from: '2026-08-29',
+      until: '2026-09-14',
+      theme: 'ink',
+      colorScheme: 'dark',
+    },
+    schedule: [
+      { id: 'constitution-day', from: '05-16', until: '05-17' },
+      { id: 'pride', from: '2026-06-19', until: '2026-06-28' },
+      { id: 'new-year', from: '12-31', until: '01-01' },
+    ],
+  };
+
+  it('resolves nothing without config or outside every window', () => {
+    expect(resolveOccasion(null)).toBeNull();
+    expect(resolveOccasion(config, at('2026-03-01T12:00:00Z'))).toBeNull();
+  });
+
+  it('lets the override win over the schedule', () => {
+    expect(resolveOccasion(config, at('2026-09-05T12:00:00Z'))).toEqual({
+      id: 'mourning',
+      theme: 'ink',
+      colorScheme: 'dark',
+    });
+  });
+
+  it('picks the first matching schedule entry, with no theme unless set', () => {
+    expect(resolveOccasion(config, at('2026-06-20T12:00:00Z'))).toEqual({
+      id: 'pride',
+      theme: null,
+      colorScheme: null,
+    });
+  });
+
+  it('applies yearly windows in the site time zone, including across new year', () => {
+    expect(resolveOccasion(config, at('2026-05-16T23:30:00Z'))?.id).toBe('constitution-day');
+    expect(resolveOccasion({ ...config, timeZone: 'UTC' }, at('2026-05-16T23:30:00Z'))?.id).toBe(
+      'constitution-day'
+    );
+    expect(resolveOccasion(config, at('2027-01-01T10:00:00Z'))?.id).toBe('new-year');
+  });
+});

--- a/apps/web/src/utils/site/occasions.ts
+++ b/apps/web/src/utils/site/occasions.ts
@@ -1,0 +1,211 @@
+/**
+ * Occasions: days the site marks without changing what it does — mourning,
+ * Pride, Christmas, a national day — configured in the hosted site-settings
+ * JSON under `site.occasions`. This module only interprets the config:
+ * parsing with per-entry soft failure, and resolving what is active now.
+ * Rendering (data-occasion on <html>, the app's occasion CSS) lives elsewhere.
+ */
+
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SLUG_MAX_LENGTH = 40;
+/** Lowercase slug, safe as a data attribute value. */
+export const isSlug = (value: unknown): value is string =>
+  typeof value === 'string' && value.length <= SLUG_MAX_LENGTH && SLUG.test(value);
+
+export const COLOR_SCHEMES = ['light', 'dark'] as const;
+/** The light/dark axis (`data-color-scheme`), forced while the occasion is active. */
+export type ColorScheme = (typeof COLOR_SCHEMES)[number];
+export const isColorScheme = (value: unknown): value is ColorScheme =>
+  COLOR_SCHEMES.includes(value as ColorScheme);
+
+export interface OccasionConfig {
+  /**
+   * Free-form slug; ratio-ui decides which ids get styling (today: mourning,
+   * pride, christmas, new-year, constitution-day). Unknown ids pass through and
+   * style nothing, so adding one never needs an app release. `mourning` is the
+   * one id the app itself reacts to (it stops all motion).
+   */
+  id: string;
+  /** `YYYY-MM-DD` for a one-off, `MM-DD` for a yearly window. Inclusive; may wrap the year. */
+  from: string;
+  until: string;
+  /** A named ratio-ui palette (`data-theme`: `bureau`, `ink`, …). Absent = the standard theme. */
+  theme?: string;
+  colorScheme?: ColorScheme;
+}
+
+export interface OccasionsConfig {
+  /** IANA zone the dates are read in. @default Europe/Oslo */
+  timeZone?: string;
+  override?: OccasionConfig;
+  schedule?: OccasionConfig[];
+}
+
+export interface ResolvedOccasion {
+  id: string;
+  theme: string | null;
+  colorScheme: ColorScheme | null;
+}
+
+export const DEFAULT_TIME_ZONE = 'Europe/Oslo';
+const FULL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const YEARLY_DATE = /^\d{2}-\d{2}$/;
+
+type Reject = (path: string, reason: string) => void;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+/** The first failing check's reason, or `undefined` when everything passes. */
+const firstProblem = (checks: [failed: boolean, reason: string][]): string | undefined =>
+  checks.find(([failed]) => failed)?.[1];
+
+/** Optional field: absent (`undefined` or an explicit `null`), or passes `isValid`. */
+const optional = (value: unknown, isValid: (v: unknown) => boolean) =>
+  value == null || isValid(value);
+
+/** A real calendar date; `MM-DD` is checked against a leap year so `02-29` is allowed. */
+function isCalendarDate(value: string): boolean {
+  const parts = value.split('-').map(Number);
+  const [year, month, day] = parts.length === 3 ? parts : [2024, ...parts];
+  const date = new Date(Date.UTC(year!, month! - 1, day));
+  return (
+    date.getUTCFullYear() === year && date.getUTCMonth() === month! - 1 && date.getUTCDate() === day
+  );
+}
+
+const bothMatch = (pattern: RegExp, from: unknown, until: unknown) =>
+  pattern.test(String(from)) && pattern.test(String(until));
+
+function parseOccasion(input: unknown, path: string, reject: Reject): OccasionConfig | undefined {
+  if (!isRecord(input)) {
+    reject(path, 'must be an object');
+    return undefined;
+  }
+  const reason = firstProblem([
+    [!isSlug(input.id), `id must be a lowercase slug of at most ${SLUG_MAX_LENGTH} characters`],
+    [
+      !isNonEmptyString(input.from) || !isNonEmptyString(input.until),
+      'from and until are required',
+    ],
+    [
+      !bothMatch(FULL_DATE, input.from, input.until) &&
+        !bothMatch(YEARLY_DATE, input.from, input.until),
+      'from and until must both be YYYY-MM-DD or both be MM-DD',
+    ],
+    [
+      !isCalendarDate(String(input.from)) || !isCalendarDate(String(input.until)),
+      'from and until must be real calendar dates',
+    ],
+    // Yearly windows may wrap the year end on purpose; one-offs must be ordered.
+    [
+      FULL_DATE.test(String(input.from)) && String(input.from) > String(input.until),
+      'until must not be before from',
+    ],
+    [!optional(input.theme, isSlug), 'theme must be a lowercase slug'],
+    [
+      !optional(input.colorScheme, isColorScheme),
+      `colorScheme must be one of ${COLOR_SCHEMES.join(', ')}`,
+    ],
+  ]);
+  if (reason) {
+    reject(path, reason);
+    return undefined;
+  }
+  return {
+    id: input.id as string,
+    from: input.from as string,
+    until: input.until as string,
+    ...(input.theme == null ? {} : { theme: input.theme as string }),
+    ...(input.colorScheme == null ? {} : { colorScheme: input.colorScheme as ColorScheme }),
+  };
+}
+
+function parseTimeZone(value: unknown, reject: Reject): string | undefined {
+  if (value == null) return undefined;
+  if (isNonEmptyString(value) && isValidTimeZone(value)) return value;
+  reject('occasions.timeZone', 'must be a valid IANA time zone');
+  return undefined;
+}
+
+function parseSchedule(value: unknown, reject: Reject): OccasionConfig[] | undefined {
+  if (value == null) return undefined;
+  if (!Array.isArray(value)) {
+    reject('occasions.schedule', 'must be an array');
+    return undefined;
+  }
+  return value
+    .map((entry, index) => parseOccasion(entry, `occasions.schedule[${index}]`, reject))
+    .filter((entry): entry is OccasionConfig => entry !== undefined);
+}
+
+/**
+ * Validates `site.occasions`. Invalid entries are reported through `reject`
+ * and dropped one by one, so a typo in one entry never takes the others — or
+ * the site — down. Returns `null` when the block is absent or not an object.
+ */
+export function parseOccasions(input: unknown, reject: Reject = () => {}): OccasionsConfig | null {
+  if (input === undefined || input === null) return null;
+  if (!isRecord(input)) {
+    reject('occasions', 'must be an object');
+    return null;
+  }
+  const timeZone = parseTimeZone(input.timeZone, reject);
+  const override =
+    input.override == null
+      ? undefined
+      : parseOccasion(input.override, 'occasions.override', reject);
+  const schedule = parseSchedule(input.schedule, reject);
+  return {
+    ...(timeZone === undefined ? {} : { timeZone }),
+    ...(override === undefined ? {} : { override }),
+    ...(schedule === undefined ? {} : { schedule }),
+  };
+}
+
+function isValidTimeZone(timeZone: string): boolean {
+  try {
+    Intl.DateTimeFormat('en-CA', { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Calendar date (`YYYY-MM-DD`) of `now` in the given zone. */
+export function localDate(now: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(now);
+}
+
+/** Inclusive window check; yearly (`MM-DD`) windows may wrap the year end. */
+export function isInWindow(today: string, from: string, until: string): boolean {
+  if (FULL_DATE.test(from)) return from <= today && today <= until;
+  const day = today.slice(5);
+  return from <= until ? from <= day && day <= until : day >= from || day <= until;
+}
+
+/**
+ * The occasion active at `now`: the override if inside its window, else the
+ * first matching schedule entry, else `null`.
+ */
+export function resolveOccasion(
+  config: OccasionsConfig | null | undefined,
+  now: Date = new Date()
+): ResolvedOccasion | null {
+  if (!config) return null;
+  const today = localDate(now, config.timeZone ?? DEFAULT_TIME_ZONE);
+  const active = [config.override, ...(config.schedule ?? [])].find(
+    entry => entry && isInWindow(today, entry.from, entry.until)
+  );
+  return active
+    ? { id: active.id, theme: active.theme ?? null, colorScheme: active.colorScheme ?? null }
+    : null;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       typescript:
         specifier: 6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       '@rollup/rollup-linux-x64-gnu':
         specifier: 4.62.4
@@ -3614,12 +3617,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
-
-  es-module-lexer@2.3.1:
-    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
-
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
@@ -5507,10 +5504,6 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
-    engines: {node: '>=14.0.0'}
-
   tinyrainbow@3.1.1:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
@@ -6031,7 +6024,7 @@ snapshots:
   '@apm-js-collab/code-transformer-bundler-plugins@0.7.4':
     dependencies:
       '@apm-js-collab/code-transformer': 0.18.1
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       magic-string: 0.30.21
       module-details-from-path: 1.0.4
 
@@ -7577,7 +7570,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       chokidar: 5.0.0
       dedent: 1.7.2(babel-plugin-macros@3.1.0)
-      es-module-lexer: 2.3.1
+      es-module-lexer: 2.3.2
       exit-hook: 5.1.0
       isbot: 5.2.1
       jsesc: 3.1.0
@@ -8279,6 +8272,7 @@ snapshots:
   '@types/node@25.9.3':
     dependencies:
       undici-types: 7.24.6
+    optional: true
 
   '@types/nodemailer@8.0.1':
     dependencies:
@@ -8317,7 +8311,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.3
 
   '@typescript-eslint/eslint-plugin@8.64.0(@typescript-eslint/parser@8.64.0(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.8.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -8528,7 +8522,15 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@25.9.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
@@ -8540,7 +8542,7 @@ snapshots:
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@vitest/runner@4.1.10':
     dependencies:
@@ -8565,7 +8567,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1)(vite@8.2.1(@types/node@25.9.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -8877,7 +8879,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.3
     optional: true
 
   bundle-name@4.1.0:
@@ -9194,10 +9196,6 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
-
-  es-module-lexer@2.3.0: {}
-
-  es-module-lexer@2.3.1: {}
 
   es-module-lexer@2.3.2: {}
 
@@ -9666,7 +9664,7 @@ snapshots:
 
   happy-dom@20.10.6:
     dependencies:
-      '@types/node': 25.9.3
+      '@types/node': 24.13.3
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -11529,8 +11527,6 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
 
-  tinyrainbow@3.1.0: {}
-
   tinyrainbow@3.1.1: {}
 
   tldts-core@7.4.10: {}
@@ -11622,7 +11618,8 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.24.6: {}
+  undici-types@7.24.6:
+    optional: true
 
   undici@6.27.0: {}
 
@@ -11833,6 +11830,37 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.2
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+      '@vitest/ui': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.10.6
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/ui@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1)(vite@8.2.1(@types/node@25.9.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
@@ -11842,7 +11870,7 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.2
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.3
@@ -11850,9 +11878,9 @@ snapshots:
       picomatch: 4.0.5
       std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
       vite: 8.2.1(@types/node@25.9.3)(esbuild@0.28.2)(jiti@2.7.0)(sass@1.77.4)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## What

First, deliberately small step of the occasions work (mourning, Pride, Christmas, New Year, Constitution Day): **interpret** the config, expose the result, style nothing yet.

- **`site.occasions`** in the hosted site-settings JSON: a dated `override` and a yearly `schedule` (`MM-DD` windows may wrap the year). Parsed with hand-written validation (no zod in `apps/web`), **entry by entry** — an invalid entry is logged with its path and dropped, so a typo in one line never takes the others or the site down. Resolved per request in the site's time zone (`Europe/Oslo` by default).
- **Exposed on `<html>`** next to the theme: `data-occasion`, plus ratio-ui's `data-motion="none"` switch during mourning. Per ratio-ui's `docs/occasions.md` the app owns one CSS block per occasion on the `ratio-navbar` / `ratio-hero` hooks — that CSS follows once ratio-ui 2.20 is published.
- **Ids are free slugs.** Which ids get styling is ratio-ui's business; adding one never needs an app release. `mourning` is the one id the app itself reacts to.
- **Theming on two axes**, per ratio-ui's `bureau-theme-spec.md`: an occasion or the site can set a named palette (`theme` → `data-theme`, e.g. `bureau`, `ink`) and/or force a colour scheme (`colorScheme` → `data-color-scheme`). A forced scheme is rendered server-side, the `InitTheme` script is omitted, the provider locks, and the toggle hides; the user's stored choice is untouched and returns when the occasion ends.
- **Consumer migration:** the light/dark toggle now writes `data-color-scheme` instead of the legacy `data-theme="dark"` — the step the spec asks eventuras to take before ratio-ui drops the legacy arm. The installed 2.19.0 already has the expand step (both the token block and the `dark:` variant respond to `data-color-scheme`); the storage key is unchanged so preferences carry over.
- **Tests:** vitest added to `apps/web` (same version as the libs), unit tests for parsing and resolution (windows, year wrap, time zone, invalid entries), and a unit-test step in web CI.

Announcements (the band, its tones and severity) are deliberately **not** in this PR — nothing renders them yet; the schema is parked for the `Announcement` PR. Config and rules are documented in `apps/web/README.md` ("Site settings: occasions").

## Verified

- `pnpm test` 10/10, eslint (only the two pre-existing warnings in the theme provider), `tsc --noEmit` clean, `turbo run test --filter=@eventuras/web` runs the suite.
- Locally against a served settings JSON:
  - forced (`theme: bureau`, `colorScheme: dark`): SSR `<html data-theme="bureau" data-color-scheme="dark" data-occasion="mourning" data-motion="none">`, no theme script, and with a stored `light` preference in the browser the server still wins (`color-scheme: dark`).
  - unforced: SSR `<html lang="nb-NO">`, script present, `data-color-scheme="light"` from the stored preference.
  - an invalid schedule entry is logged (`occasions.schedule[1]: id must be a lowercase slug…`) and the rest applies.

## Notes

- Adding vitest re-resolved a few transitive dev packages in the lockfile (tinyrainbow, tinyexec, es-module-lexer patch bumps); the install passed the supply-chain policy.
- Next's `fetch` data cache persists on disk, so a changed settings JSON takes up to 10 minutes to show — also in dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
